### PR TITLE
Sprint 4.3: Add RosterService for plugin synthetic member management

### DIFF
--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod plugin;
+pub mod roster;

--- a/crates/atm-daemon/src/plugin/context.rs
+++ b/crates/atm-daemon/src/plugin/context.rs
@@ -1,3 +1,4 @@
+use crate::roster::RosterService;
 use super::MailService;
 use atm_core::config::Config;
 use atm_core::context::SystemContext;
@@ -12,14 +13,22 @@ pub struct PluginContext {
     pub mail: Arc<MailService>,
     /// Application configuration
     pub config: Arc<Config>,
+    /// Roster service for managing synthetic team members
+    pub roster: Arc<RosterService>,
 }
 
 impl PluginContext {
-    pub fn new(system: Arc<SystemContext>, mail: Arc<MailService>, config: Arc<Config>) -> Self {
+    pub fn new(
+        system: Arc<SystemContext>,
+        mail: Arc<MailService>,
+        config: Arc<Config>,
+        roster: Arc<RosterService>,
+    ) -> Self {
         Self {
             system,
             mail,
             config,
+            roster,
         }
     }
 }

--- a/crates/atm-daemon/src/roster/mod.rs
+++ b/crates/atm-daemon/src/roster/mod.rs
@@ -1,0 +1,5 @@
+mod service;
+mod tracking;
+
+pub use service::{CleanupMode, RosterError, RosterService};
+pub use tracking::MembershipTracker;

--- a/crates/atm-daemon/src/roster/service.rs
+++ b/crates/atm-daemon/src/roster/service.rs
@@ -1,0 +1,347 @@
+//! Roster service for managing synthetic team members
+
+use crate::roster::tracking::MembershipTracker;
+use atm_core::schema::{AgentMember, TeamConfig};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+/// Cleanup mode for plugin shutdown
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanupMode {
+    /// Set isActive to false but keep member in config
+    Soft,
+    /// Remove member entirely from config
+    Hard,
+}
+
+/// Error type for roster operations
+#[derive(Debug, thiserror::Error)]
+pub enum RosterError {
+    #[error("I/O error: {0}")]
+    Io(String),
+    #[error("JSON error: {0}")]
+    Json(String),
+    #[error("member '{name}' already exists in team '{team}'")]
+    DuplicateMember { team: String, name: String },
+    #[error("member '{name}' not found in team '{team}'")]
+    MemberNotFound { team: String, name: String },
+    #[error("team config not found: {0}")]
+    TeamNotFound(String),
+}
+
+/// Manages synthetic team members registered by plugins
+///
+/// Provides atomic operations for adding, removing, and listing plugin-registered
+/// team members. All config.json modifications are protected by file locks to
+/// ensure consistency across concurrent operations.
+#[derive(Clone)]
+pub struct RosterService {
+    teams_root: PathBuf,
+    tracker: Arc<Mutex<MembershipTracker>>,
+}
+
+impl RosterService {
+    /// Create a new roster service
+    ///
+    /// # Arguments
+    ///
+    /// * `teams_root` - Path to the teams directory (typically `~/.claude/teams`)
+    pub fn new(teams_root: PathBuf) -> Self {
+        Self {
+            teams_root,
+            tracker: Arc::new(Mutex::new(MembershipTracker::new())),
+        }
+    }
+
+    /// Add a member to a team's roster
+    ///
+    /// Atomically reads the team config, adds the member (rejecting duplicates
+    /// by name), writes back atomically, and tracks the membership.
+    ///
+    /// # Arguments
+    ///
+    /// * `team` - Team name
+    /// * `member` - Agent member to add
+    /// * `plugin_name` - Name of the plugin registering this member
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Team config doesn't exist
+    /// - Member with same name already exists
+    /// - I/O or JSON serialization fails
+    pub fn add_member(
+        &self,
+        team: &str,
+        member: AgentMember,
+        plugin_name: &str,
+    ) -> Result<(), RosterError> {
+        let config_path = self.config_path(team);
+        if !config_path.exists() {
+            return Err(RosterError::TeamNotFound(team.to_string()));
+        }
+
+        let member_name = member.name.clone();
+        atomic_config_update(&config_path, |config| {
+            // Check for duplicate
+            if config.members.iter().any(|m| m.name == member_name) {
+                return Err(RosterError::DuplicateMember {
+                    team: team.to_string(),
+                    name: member_name.clone(),
+                });
+            }
+            config.members.push(member);
+            Ok(true)
+        })?;
+
+        // Track the membership
+        self.tracker
+            .lock()
+            .unwrap()
+            .track(plugin_name, team, &member_name);
+
+        Ok(())
+    }
+
+    /// Remove a member from a team's roster
+    ///
+    /// Atomically reads the team config, removes the member by name, writes
+    /// back atomically, and untracks the membership.
+    ///
+    /// # Arguments
+    ///
+    /// * `team` - Team name
+    /// * `agent_name` - Name of the agent to remove
+    /// * `plugin_name` - Name of the plugin that registered this member
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Team config doesn't exist
+    /// - Member not found
+    /// - I/O or JSON serialization fails
+    pub fn remove_member(
+        &self,
+        team: &str,
+        agent_name: &str,
+        plugin_name: &str,
+    ) -> Result<(), RosterError> {
+        let config_path = self.config_path(team);
+        if !config_path.exists() {
+            return Err(RosterError::TeamNotFound(team.to_string()));
+        }
+
+        atomic_config_update(&config_path, |config| {
+            let initial_len = config.members.len();
+            config.members.retain(|m| m.name != agent_name);
+            if config.members.len() == initial_len {
+                return Err(RosterError::MemberNotFound {
+                    team: team.to_string(),
+                    name: agent_name.to_string(),
+                });
+            }
+            Ok(true)
+        })?;
+
+        // Untrack the membership
+        self.tracker
+            .lock()
+            .unwrap()
+            .untrack(plugin_name, team, agent_name);
+
+        Ok(())
+    }
+
+    /// List members in a team's roster
+    ///
+    /// Reads the team config and returns members, optionally filtered by plugin.
+    /// When `plugin_name` is Some, only returns members whose `agent_type`
+    /// starts with `"plugin:{plugin_name}"`.
+    ///
+    /// # Arguments
+    ///
+    /// * `team` - Team name
+    /// * `plugin_name` - Optional plugin name filter
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Team config doesn't exist
+    /// - I/O or JSON parse fails
+    pub fn list_members(
+        &self,
+        team: &str,
+        plugin_name: Option<&str>,
+    ) -> Result<Vec<AgentMember>, RosterError> {
+        let config_path = self.config_path(team);
+        if !config_path.exists() {
+            return Err(RosterError::TeamNotFound(team.to_string()));
+        }
+
+        let content = std::fs::read(&config_path)
+            .map_err(|e| RosterError::Io(format!("read failed: {e}")))?;
+        let config: TeamConfig = serde_json::from_slice(&content)
+            .map_err(|e| RosterError::Json(format!("parse failed: {e}")))?;
+
+        let mut members: Vec<AgentMember> = config
+            .members
+            .into_iter()
+            .filter(|m| m.agent_type.starts_with("plugin:"))
+            .collect();
+
+        if let Some(plugin) = plugin_name {
+            let prefix = format!("plugin:{plugin}");
+            members.retain(|m| m.agent_type == prefix);
+        }
+
+        Ok(members)
+    }
+
+    /// Clean up plugin members on shutdown
+    ///
+    /// Based on the cleanup mode:
+    /// - `Soft`: Sets `is_active = false` for matching members
+    /// - `Hard`: Removes matching members entirely
+    ///
+    /// Returns the count of affected members. Idempotent - calling multiple
+    /// times with the same arguments is safe.
+    ///
+    /// # Arguments
+    ///
+    /// * `team` - Team name
+    /// * `plugin_name` - Plugin name to clean up
+    /// * `mode` - Cleanup mode (Soft or Hard)
+    ///
+    /// # Errors
+    ///
+    /// Returns error if:
+    /// - Team config doesn't exist
+    /// - I/O or JSON serialization fails
+    pub fn cleanup_plugin(
+        &self,
+        team: &str,
+        plugin_name: &str,
+        mode: CleanupMode,
+    ) -> Result<usize, RosterError> {
+        let config_path = self.config_path(team);
+        if !config_path.exists() {
+            return Err(RosterError::TeamNotFound(team.to_string()));
+        }
+
+        let prefix = format!("plugin:{plugin_name}");
+        let mut affected_count = 0;
+
+        atomic_config_update(&config_path, |config| {
+            match mode {
+                CleanupMode::Soft => {
+                    for member in &mut config.members {
+                        if member.agent_type == prefix && member.is_active != Some(false) {
+                            member.is_active = Some(false);
+                            affected_count += 1;
+                        }
+                    }
+                }
+                CleanupMode::Hard => {
+                    let initial_len = config.members.len();
+                    config.members.retain(|m| m.agent_type != prefix);
+                    affected_count = initial_len - config.members.len();
+                }
+            }
+            Ok(affected_count > 0)
+        })?;
+
+        // Clear tracking for this plugin in this team
+        if affected_count > 0 {
+            let mut tracker = self.tracker.lock().unwrap();
+            let members = tracker.get_members(plugin_name);
+            for (member_team, agent_name) in members {
+                if member_team == team {
+                    tracker.untrack(plugin_name, team, &agent_name);
+                }
+            }
+        }
+
+        Ok(affected_count)
+    }
+
+    /// Get the path to a team's config.json
+    fn config_path(&self, team: &str) -> PathBuf {
+        self.teams_root.join(team).join("config.json")
+    }
+}
+
+/// Atomically update a team config file
+///
+/// Acquires an exclusive lock, reads the config, applies the modification
+/// function, and writes back atomically if changes were made.
+///
+/// # Arguments
+///
+/// * `config_path` - Path to config.json
+/// * `modify_fn` - Function that modifies the config and returns Ok(true) if
+///   changes were made, Ok(false) if no changes, or Err on error
+///
+/// # Returns
+///
+/// Returns Ok(()) if successful, or RosterError on failure.
+fn atomic_config_update<F>(config_path: &Path, modify_fn: F) -> Result<(), RosterError>
+where
+    F: FnOnce(&mut TeamConfig) -> Result<bool, RosterError>,
+{
+    let lock_path = config_path.with_extension("lock");
+    let _lock = atm_core::io::lock::acquire_lock(&lock_path, 5)
+        .map_err(|e| RosterError::Io(format!("lock failed: {e}")))?;
+
+    // Read current config
+    let content =
+        std::fs::read(config_path).map_err(|e| RosterError::Io(format!("read failed: {e}")))?;
+    let mut config: TeamConfig = serde_json::from_slice(&content)
+        .map_err(|e| RosterError::Json(format!("parse failed: {e}")))?;
+
+    // Apply modification
+    let changed = modify_fn(&mut config)?;
+    if !changed {
+        return Ok(());
+    }
+
+    // Write back atomically (write to tmp, then rename)
+    let tmp_path = config_path.with_extension("tmp");
+    let new_content = serde_json::to_vec_pretty(&config)
+        .map_err(|e| RosterError::Json(format!("serialize failed: {e}")))?;
+
+    std::fs::write(&tmp_path, &new_content)
+        .map_err(|e| RosterError::Io(format!("write tmp failed: {e}")))?;
+    std::fs::rename(&tmp_path, config_path)
+        .map_err(|e| RosterError::Io(format!("rename failed: {e}")))?;
+
+    Ok(())
+    // Lock released on drop
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cleanup_mode_equality() {
+        assert_eq!(CleanupMode::Soft, CleanupMode::Soft);
+        assert_eq!(CleanupMode::Hard, CleanupMode::Hard);
+        assert_ne!(CleanupMode::Soft, CleanupMode::Hard);
+    }
+
+    #[test]
+    fn test_roster_service_new() {
+        let service = RosterService::new(PathBuf::from("/tmp/teams"));
+        assert_eq!(service.teams_root, PathBuf::from("/tmp/teams"));
+    }
+
+    #[test]
+    fn test_config_path() {
+        let service = RosterService::new(PathBuf::from("/tmp/teams"));
+        let path = service.config_path("test-team");
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/teams").join("test-team").join("config.json")
+        );
+    }
+}

--- a/crates/atm-daemon/src/roster/tracking.rs
+++ b/crates/atm-daemon/src/roster/tracking.rs
@@ -1,0 +1,138 @@
+//! Plugin membership tracking
+
+use std::collections::HashMap;
+
+/// Tracks which agents belong to which plugins
+///
+/// Used by RosterService to maintain a mapping of plugin names to their
+/// registered team members. This allows efficient cleanup when a plugin
+/// shuts down.
+#[derive(Clone, Debug)]
+pub struct MembershipTracker {
+    /// Map of plugin name → Vec<(team_name, agent_name)>
+    memberships: HashMap<String, Vec<(String, String)>>,
+}
+
+impl MembershipTracker {
+    /// Create a new empty tracker
+    pub fn new() -> Self {
+        Self {
+            memberships: HashMap::new(),
+        }
+    }
+
+    /// Track a new member registration
+    ///
+    /// Records that the given plugin has registered an agent in the given team.
+    pub fn track(&mut self, plugin: &str, team: &str, agent: &str) {
+        self.memberships
+            .entry(plugin.to_string())
+            .or_default()
+            .push((team.to_string(), agent.to_string()));
+    }
+
+    /// Untrack a member
+    ///
+    /// Removes the tracking entry for the given plugin/team/agent combination.
+    pub fn untrack(&mut self, plugin: &str, team: &str, agent: &str) {
+        if let Some(members) = self.memberships.get_mut(plugin) {
+            members.retain(|(t, a)| t != team || a != agent);
+            if members.is_empty() {
+                self.memberships.remove(plugin);
+            }
+        }
+    }
+
+    /// Get all members tracked for a plugin
+    ///
+    /// Returns a vector of (team_name, agent_name) tuples for the given plugin.
+    pub fn get_members(&self, plugin: &str) -> Vec<(String, String)> {
+        self.memberships
+            .get(plugin)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    /// Clear all tracking for a plugin
+    ///
+    /// Removes all tracked members for the given plugin.
+    /// Returns the number of members that were removed.
+    pub fn clear_plugin(&mut self, plugin: &str) -> usize {
+        self.memberships
+            .remove(plugin)
+            .map(|v| v.len())
+            .unwrap_or(0)
+    }
+}
+
+impl Default for MembershipTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_track_and_get() {
+        let mut tracker = MembershipTracker::new();
+        tracker.track("issues", "team-a", "issues-bot");
+        tracker.track("issues", "team-b", "issues-watcher");
+
+        let members = tracker.get_members("issues");
+        assert_eq!(members.len(), 2);
+        assert!(members.contains(&("team-a".to_string(), "issues-bot".to_string())));
+        assert!(members.contains(&("team-b".to_string(), "issues-watcher".to_string())));
+    }
+
+    #[test]
+    fn test_untrack() {
+        let mut tracker = MembershipTracker::new();
+        tracker.track("issues", "team-a", "issues-bot");
+        tracker.track("issues", "team-b", "issues-watcher");
+
+        tracker.untrack("issues", "team-a", "issues-bot");
+
+        let members = tracker.get_members("issues");
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0], ("team-b".to_string(), "issues-watcher".to_string()));
+    }
+
+    #[test]
+    fn test_clear_plugin() {
+        let mut tracker = MembershipTracker::new();
+        tracker.track("issues", "team-a", "issues-bot");
+        tracker.track("issues", "team-b", "issues-watcher");
+        tracker.track("ci", "team-a", "ci-monitor");
+
+        let count = tracker.clear_plugin("issues");
+        assert_eq!(count, 2);
+
+        let issues_members = tracker.get_members("issues");
+        assert_eq!(issues_members.len(), 0);
+
+        let ci_members = tracker.get_members("ci");
+        assert_eq!(ci_members.len(), 1);
+    }
+
+    #[test]
+    fn test_get_nonexistent_plugin() {
+        let tracker = MembershipTracker::new();
+        let members = tracker.get_members("nonexistent");
+        assert_eq!(members.len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_plugins() {
+        let mut tracker = MembershipTracker::new();
+        tracker.track("issues", "team-a", "issues-bot");
+        tracker.track("ci", "team-a", "ci-monitor");
+        tracker.track("chat", "team-b", "chatbot");
+
+        assert_eq!(tracker.get_members("issues").len(), 1);
+        assert_eq!(tracker.get_members("ci").len(), 1);
+        assert_eq!(tracker.get_members("chat").len(), 1);
+    }
+}

--- a/crates/atm-daemon/tests/plugin_tests.rs
+++ b/crates/atm-daemon/tests/plugin_tests.rs
@@ -5,6 +5,7 @@ use atm_daemon::plugin::{
     Capability, MailService, Plugin, PluginContext, PluginError, PluginMetadata, PluginRegistry,
     PluginState,
 };
+use atm_daemon::roster::RosterService;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tempfile::TempDir;
@@ -114,9 +115,10 @@ fn create_test_context(teams_root: std::path::PathBuf) -> PluginContext {
         "2.1.39".to_string(),
         "test-team".to_string(),
     ));
-    let mail = Arc::new(MailService::new(teams_root));
+    let mail = Arc::new(MailService::new(teams_root.clone()));
     let config = Arc::new(Config::default());
-    PluginContext::new(system, mail, config)
+    let roster = Arc::new(RosterService::new(teams_root));
+    PluginContext::new(system, mail, config, roster)
 }
 
 fn create_test_message(from: &str, text: &str) -> InboxMessage {

--- a/crates/atm-daemon/tests/roster_tests.rs
+++ b/crates/atm-daemon/tests/roster_tests.rs
@@ -1,0 +1,426 @@
+use atm_core::schema::{AgentMember, TeamConfig};
+use atm_daemon::roster::{CleanupMode, MembershipTracker, RosterError, RosterService};
+use std::collections::HashMap;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use tempfile::TempDir;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/// Create a team config.json in a temp directory
+fn setup_team(temp_dir: &TempDir, team_name: &str) -> std::path::PathBuf {
+    let team_dir = temp_dir.path().join(team_name);
+    std::fs::create_dir_all(&team_dir).unwrap();
+
+    let config = TeamConfig {
+        name: team_name.to_string(),
+        description: Some("Test team".to_string()),
+        created_at: 1770765919076,
+        lead_agent_id: format!("team-lead@{team_name}"),
+        lead_session_id: "test-session-id".to_string(),
+        members: vec![create_lead_member(team_name)],
+        unknown_fields: HashMap::new(),
+    };
+
+    let config_path = team_dir.join("config.json");
+    std::fs::write(&config_path, serde_json::to_vec_pretty(&config).unwrap()).unwrap();
+
+    team_dir
+}
+
+fn create_lead_member(team_name: &str) -> AgentMember {
+    AgentMember {
+        agent_id: format!("team-lead@{team_name}"),
+        name: "team-lead".to_string(),
+        agent_type: "general-purpose".to_string(),
+        model: "claude-opus-4-6".to_string(),
+        prompt: None,
+        color: None,
+        plan_mode_required: None,
+        joined_at: 1770765919076,
+        tmux_pane_id: None,
+        cwd: "/test".to_string(),
+        subscriptions: vec![],
+        backend_type: None,
+        is_active: Some(true),
+        unknown_fields: HashMap::new(),
+    }
+}
+
+fn create_synthetic_member(plugin_name: &str, function_name: &str, team_name: &str) -> AgentMember {
+    AgentMember {
+        agent_id: format!("{plugin_name}-{function_name}@{team_name}"),
+        name: format!("{plugin_name}-{function_name}"),
+        agent_type: format!("plugin:{plugin_name}"),
+        model: "synthetic".to_string(),
+        prompt: None,
+        color: None,
+        plan_mode_required: None,
+        joined_at: chrono::Utc::now().timestamp_millis() as u64,
+        tmux_pane_id: None,
+        cwd: "/test".to_string(),
+        subscriptions: vec![],
+        backend_type: None,
+        is_active: Some(true),
+        unknown_fields: HashMap::new(),
+    }
+}
+
+// ============================================================================
+// MembershipTracker Unit Tests
+// ============================================================================
+
+#[test]
+fn test_membership_tracker_basic() {
+    let mut tracker = MembershipTracker::new();
+
+    tracker.track("issues", "team-a", "issues-bot");
+    tracker.track("issues", "team-b", "issues-watcher");
+
+    let members = tracker.get_members("issues");
+    assert_eq!(members.len(), 2);
+    assert!(members.contains(&("team-a".to_string(), "issues-bot".to_string())));
+    assert!(members.contains(&("team-b".to_string(), "issues-watcher".to_string())));
+
+    let count = tracker.clear_plugin("issues");
+    assert_eq!(count, 2);
+
+    let members_after = tracker.get_members("issues");
+    assert_eq!(members_after.len(), 0);
+}
+
+// ============================================================================
+// RosterService Tests
+// ============================================================================
+
+#[test]
+fn test_add_member_success() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+
+    service.add_member("test-team", member.clone(), "issues").unwrap();
+
+    // Read config and verify member was added
+    let config_path = temp_dir.path().join("test-team").join("config.json");
+    let content = std::fs::read(&config_path).unwrap();
+    let config: TeamConfig = serde_json::from_slice(&content).unwrap();
+
+    assert_eq!(config.members.len(), 2); // Lead + synthetic member
+    assert!(config.members.iter().any(|m| m.name == "issues-bot"));
+}
+
+#[test]
+fn test_add_member_duplicate_rejected() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+
+    // First add should succeed
+    service.add_member("test-team", member.clone(), "issues").unwrap();
+
+    // Second add should fail with DuplicateMember error
+    let result = service.add_member("test-team", member, "issues");
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        RosterError::DuplicateMember { .. }
+    ));
+}
+
+#[test]
+fn test_remove_member_success() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+
+    service.add_member("test-team", member, "issues").unwrap();
+    service.remove_member("test-team", "issues-bot", "issues").unwrap();
+
+    // Verify member was removed
+    let config_path = temp_dir.path().join("test-team").join("config.json");
+    let content = std::fs::read(&config_path).unwrap();
+    let config: TeamConfig = serde_json::from_slice(&content).unwrap();
+
+    assert_eq!(config.members.len(), 1); // Only lead remains
+    assert!(!config.members.iter().any(|m| m.name == "issues-bot"));
+}
+
+#[test]
+fn test_remove_member_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+
+    let result = service.remove_member("test-team", "nonexistent-bot", "issues");
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        RosterError::MemberNotFound { .. }
+    ));
+}
+
+#[test]
+fn test_list_members_all() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member1 = create_synthetic_member("issues", "bot", "test-team");
+    let member2 = create_synthetic_member("ci", "monitor", "test-team");
+
+    service.add_member("test-team", member1, "issues").unwrap();
+    service.add_member("test-team", member2, "ci").unwrap();
+
+    // List all synthetic members (no plugin filter)
+    let members = service.list_members("test-team", None).unwrap();
+    assert_eq!(members.len(), 2);
+    assert!(members.iter().any(|m| m.name == "issues-bot"));
+    assert!(members.iter().any(|m| m.name == "ci-monitor"));
+}
+
+#[test]
+fn test_list_members_filtered_by_plugin() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member1 = create_synthetic_member("issues", "bot", "test-team");
+    let member2 = create_synthetic_member("issues", "watcher", "test-team");
+    let member3 = create_synthetic_member("ci", "monitor", "test-team");
+
+    service.add_member("test-team", member1, "issues").unwrap();
+    service.add_member("test-team", member2, "issues").unwrap();
+    service.add_member("test-team", member3, "ci").unwrap();
+
+    // Filter by "issues" plugin
+    let issues_members = service.list_members("test-team", Some("issues")).unwrap();
+    assert_eq!(issues_members.len(), 2);
+    assert!(issues_members.iter().all(|m| m.agent_type == "plugin:issues"));
+
+    // Filter by "ci" plugin
+    let ci_members = service.list_members("test-team", Some("ci")).unwrap();
+    assert_eq!(ci_members.len(), 1);
+    assert_eq!(ci_members[0].name, "ci-monitor");
+}
+
+#[test]
+fn test_cleanup_plugin_hard() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member1 = create_synthetic_member("issues", "bot", "test-team");
+    let member2 = create_synthetic_member("issues", "watcher", "test-team");
+    let member3 = create_synthetic_member("ci", "monitor", "test-team");
+
+    service.add_member("test-team", member1, "issues").unwrap();
+    service.add_member("test-team", member2, "issues").unwrap();
+    service.add_member("test-team", member3, "ci").unwrap();
+
+    // Hard cleanup of "issues" plugin
+    let count = service
+        .cleanup_plugin("test-team", "issues", CleanupMode::Hard)
+        .unwrap();
+    assert_eq!(count, 2);
+
+    // Verify only "ci" member remains
+    let members = service.list_members("test-team", None).unwrap();
+    assert_eq!(members.len(), 1);
+    assert_eq!(members[0].name, "ci-monitor");
+}
+
+#[test]
+fn test_cleanup_plugin_soft() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+
+    service.add_member("test-team", member, "issues").unwrap();
+
+    // Soft cleanup
+    let count = service
+        .cleanup_plugin("test-team", "issues", CleanupMode::Soft)
+        .unwrap();
+    assert_eq!(count, 1);
+
+    // Verify member still exists but isActive is false
+    let config_path = temp_dir.path().join("test-team").join("config.json");
+    let content = std::fs::read(&config_path).unwrap();
+    let config: TeamConfig = serde_json::from_slice(&content).unwrap();
+
+    let issues_member = config
+        .members
+        .iter()
+        .find(|m| m.name == "issues-bot")
+        .unwrap();
+    assert_eq!(issues_member.is_active, Some(false));
+}
+
+#[test]
+fn test_cleanup_plugin_idempotent() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+
+    service.add_member("test-team", member, "issues").unwrap();
+
+    // First cleanup
+    let count1 = service
+        .cleanup_plugin("test-team", "issues", CleanupMode::Hard)
+        .unwrap();
+    assert_eq!(count1, 1);
+
+    // Second cleanup should return 0 (nothing to clean)
+    let count2 = service
+        .cleanup_plugin("test-team", "issues", CleanupMode::Hard)
+        .unwrap();
+    assert_eq!(count2, 0);
+}
+
+#[test]
+fn test_concurrent_add_remove() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = Arc::new(RosterService::new(temp_dir.path().to_path_buf()));
+    let barrier = Arc::new(Barrier::new(4));
+
+    let mut handles = vec![];
+
+    // Spawn 4 threads that add and remove members concurrently
+    for i in 0..4 {
+        let service_clone = Arc::clone(&service);
+        let barrier_clone = Arc::clone(&barrier);
+
+        let handle = thread::spawn(move || {
+            barrier_clone.wait();
+
+            let member_name = format!("test-{i}");
+            let member = AgentMember {
+                agent_id: format!("{member_name}@test-team"),
+                name: member_name.clone(),
+                agent_type: "plugin:test".to_string(),
+                model: "synthetic".to_string(),
+                prompt: None,
+                color: None,
+                plan_mode_required: None,
+                joined_at: 1770765919076,
+                tmux_pane_id: None,
+                cwd: "/test".to_string(),
+                subscriptions: vec![],
+                backend_type: None,
+                is_active: Some(true),
+                unknown_fields: HashMap::new(),
+            };
+
+            // Add member
+            service_clone
+                .add_member("test-team", member, "test")
+                .unwrap();
+
+            // Small delay
+            thread::sleep(std::time::Duration::from_millis(10));
+
+            // Remove member
+            service_clone
+                .remove_member("test-team", &member_name, "test")
+                .unwrap();
+        });
+
+        handles.push(handle);
+    }
+
+    // Wait for all threads to complete
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    // Verify config is still valid JSON and only lead remains
+    let config_path = temp_dir.path().join("test-team").join("config.json");
+    let content = std::fs::read(&config_path).unwrap();
+    let config: TeamConfig = serde_json::from_slice(&content).unwrap();
+
+    assert_eq!(config.members.len(), 1); // Only lead should remain
+    assert_eq!(config.members[0].name, "team-lead");
+}
+
+#[test]
+fn test_multiple_plugins_isolation() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_team(&temp_dir, "test-team");
+
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+
+    // Add members from two different plugins
+    let issues1 = create_synthetic_member("issues", "bot", "test-team");
+    let issues2 = create_synthetic_member("issues", "watcher", "test-team");
+    let ci1 = create_synthetic_member("ci", "monitor", "test-team");
+    let ci2 = create_synthetic_member("ci", "reporter", "test-team");
+
+    service.add_member("test-team", issues1, "issues").unwrap();
+    service.add_member("test-team", issues2, "issues").unwrap();
+    service.add_member("test-team", ci1, "ci").unwrap();
+    service.add_member("test-team", ci2, "ci").unwrap();
+
+    // Cleanup issues plugin
+    service
+        .cleanup_plugin("test-team", "issues", CleanupMode::Hard)
+        .unwrap();
+
+    // Verify only ci members remain
+    let members = service.list_members("test-team", None).unwrap();
+    assert_eq!(members.len(), 2);
+    assert!(members.iter().all(|m| m.agent_type == "plugin:ci"));
+}
+
+#[test]
+fn test_team_not_found() {
+    let temp_dir = TempDir::new().unwrap();
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+
+    let member = create_synthetic_member("issues", "bot", "nonexistent-team");
+
+    let result = service.add_member("nonexistent-team", member, "issues");
+    assert!(result.is_err());
+    assert!(matches!(
+        result.unwrap_err(),
+        RosterError::TeamNotFound(_)
+    ));
+}
+
+#[test]
+fn test_preserves_unknown_fields() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_team(&temp_dir, "test-team");
+
+    // Add unknown fields to the config
+    let config_path = team_dir.join("config.json");
+    let mut content: serde_json::Value = serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+    content["unknownField"] = serde_json::json!("test-value");
+    content["futureFeature"] = serde_json::json!({"nested": "data"});
+    std::fs::write(&config_path, serde_json::to_vec_pretty(&content).unwrap()).unwrap();
+
+    // Add a member through the service
+    let service = RosterService::new(temp_dir.path().to_path_buf());
+    let member = create_synthetic_member("issues", "bot", "test-team");
+    service.add_member("test-team", member, "issues").unwrap();
+
+    // Verify unknown fields are preserved
+    let content: serde_json::Value = serde_json::from_slice(&std::fs::read(&config_path).unwrap()).unwrap();
+    assert_eq!(content["unknownField"], "test-value");
+    assert_eq!(content["futureFeature"]["nested"], "data");
+}

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -889,6 +889,18 @@ Phase 2 Complete
 - Members cleaned up on plugin shutdown
 - Tests cover add/remove/cleanup
 
+**Status**: ✅ Complete (PR pending)
+**Dev-QA iterations**: 1 (passed first QA review with 1 minor clippy fix)
+**Implementation notes**:
+- New module `crates/atm-daemon/src/roster/` with `RosterService`, `MembershipTracker`, `RosterError`, `CleanupMode`
+- Atomic config.json updates via lock → read → modify → write → rename pattern (reuses `atm_core::io::lock::acquire_lock`)
+- `MembershipTracker` maps plugin_name → Vec<(team, agent_name)> for ownership tracking
+- `CleanupMode::Soft` sets isActive=false, `CleanupMode::Hard` removes members entirely (both idempotent)
+- Synthetic members use `agentType: "plugin:<plugin-name>"` convention
+- `PluginContext` updated with `roster: Arc<RosterService>` field
+- 22 new tests (8 unit + 14 integration): add/remove, cleanup modes, concurrent access (4 threads), plugin isolation, unknown field preservation
+- 33 total atm-daemon tests passing, clippy clean
+
 ### Phase 4 Dependency Graph
 
 ```


### PR DESCRIPTION
## Summary

- Implements `RosterService` that manages synthetic team members in team `config.json` with atomic file updates, plugin ownership tracking, and configurable cleanup modes
- Adds `MembershipTracker` for plugin→member ownership mapping enabling safe cleanup coordination
- Integrates roster into `PluginContext` so plugins can add/remove synthetic members via `ctx.roster`

## Changes

### New Files
- `crates/atm-daemon/src/roster/mod.rs` — Module declaration and public exports
- `crates/atm-daemon/src/roster/service.rs` — `RosterService`, `RosterError`, `CleanupMode`, atomic config update helper
- `crates/atm-daemon/src/roster/tracking.rs` — `MembershipTracker` for plugin→member ownership
- `crates/atm-daemon/tests/roster_tests.rs` — 14 integration tests

### Modified Files
- `crates/atm-daemon/src/lib.rs` — Added `pub mod roster`
- `crates/atm-daemon/src/plugin/context.rs` — Added `roster: Arc<RosterService>` to `PluginContext`
- `crates/atm-daemon/tests/plugin_tests.rs` — Updated `create_test_context` with roster
- `docs/project-plan.md` — Sprint 4.3 status updated

## Key Design Decisions

- **Atomic config.json updates**: Lock → read → modify → write → rename pattern (reuses `atm_core::io::lock::acquire_lock`)
- **Synthetic member convention**: `agentType: "plugin:<plugin-name>"` distinguishes synthetic from real agents
- **Cleanup modes**: `Soft` (set isActive=false) vs `Hard` (remove entirely), both idempotent
- **Thread safety**: `Arc<Mutex<MembershipTracker>>` for safe concurrent access

## Test plan

- [x] Add/remove synthetic members atomically (verified in config.json)
- [x] Duplicate member rejection (DuplicateMember error)
- [x] Member not found errors (MemberNotFound error)
- [x] List members with optional plugin filter
- [x] Hard cleanup removes members, soft sets isActive=false
- [x] Idempotent cleanup (second call returns 0)
- [x] Concurrent add/remove (4 threads, no data corruption)
- [x] Multiple plugin isolation (cleanup one doesn't affect other)
- [x] Unknown field preservation in config.json
- [x] Team not found error handling
- [x] MembershipTracker unit tests
- [x] `cargo clippy --package atm-daemon -- -D warnings` clean
- [x] 33 atm-daemon tests pass (8 unit + 11 plugin + 14 roster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)