### PR TITLE
Sprint 5.1: Provider abstraction for Issues plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -24,6 +24,8 @@ clap = { version = "4", features = ["derive"] }
 notify = "7"
 dirs = "5"
 hostname = "0.4"
+chrono = "0.4"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/atm-daemon/src/lib.rs
+++ b/crates/atm-daemon/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod daemon;
 pub mod plugin;
+pub mod plugins;
 pub mod roster;

--- a/crates/atm-daemon/src/plugins/issues/azure_devops.rs
+++ b/crates/atm-daemon/src/plugins/issues/azure_devops.rs
@@ -1,0 +1,92 @@
+//! Azure DevOps issue provider stub (not yet implemented)
+
+use super::provider::IssueProvider;
+use super::types::{Issue, IssueComment, IssueFilter};
+use crate::plugin::PluginError;
+
+/// Azure DevOps issue provider (stub)
+#[derive(Debug)]
+pub struct AzureDevOpsProvider {
+    org: String,
+    project: String,
+    repo: String,
+}
+
+impl AzureDevOpsProvider {
+    /// Create a new Azure DevOps provider
+    pub fn new(org: String, project: String, repo: String) -> Self {
+        Self { org, project, repo }
+    }
+}
+
+impl IssueProvider for AzureDevOpsProvider {
+    async fn list_issues(&self, _filter: &IssueFilter) -> Result<Vec<Issue>, PluginError> {
+        Err(PluginError::Provider {
+            message: format!(
+                "Azure DevOps provider not yet implemented (org: {}, project: {}, repo: {})",
+                self.org, self.project, self.repo
+            ),
+            source: None,
+        })
+    }
+
+    async fn get_issue(&self, number: u64) -> Result<Issue, PluginError> {
+        Err(PluginError::Provider {
+            message: format!("Azure DevOps provider not yet implemented (issue {number})"),
+            source: None,
+        })
+    }
+
+    async fn add_comment(&self, issue_number: u64, _body: &str) -> Result<IssueComment, PluginError> {
+        Err(PluginError::Provider {
+            message: format!("Azure DevOps provider not yet implemented (comment on issue {issue_number})"),
+            source: None,
+        })
+    }
+
+    async fn list_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>, PluginError> {
+        Err(PluginError::Provider {
+            message: format!("Azure DevOps provider not yet implemented (comments for issue {issue_number})"),
+            source: None,
+        })
+    }
+
+    fn provider_name(&self) -> &str {
+        "Azure DevOps"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_azure_devops_provider_creation() {
+        let provider = AzureDevOpsProvider::new(
+            "myorg".to_string(),
+            "myproject".to_string(),
+            "myrepo".to_string(),
+        );
+        assert_eq!(provider.provider_name(), "Azure DevOps");
+        assert_eq!(provider.org, "myorg");
+        assert_eq!(provider.project, "myproject");
+        assert_eq!(provider.repo, "myrepo");
+    }
+
+    #[tokio::test]
+    async fn test_azure_devops_not_implemented() {
+        let provider = AzureDevOpsProvider::new(
+            "org".to_string(),
+            "proj".to_string(),
+            "repo".to_string(),
+        );
+
+        let filter = IssueFilter::default();
+        let result = provider.list_issues(&filter).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("not yet implemented"));
+    }
+}

--- a/crates/atm-daemon/src/plugins/issues/github.rs
+++ b/crates/atm-daemon/src/plugins/issues/github.rs
@@ -1,0 +1,331 @@
+//! GitHub issue provider using the `gh` CLI
+
+use super::provider::IssueProvider;
+use super::types::{Issue, IssueComment, IssueFilter, IssueLabel, IssueState};
+use crate::plugin::PluginError;
+use serde::Deserialize;
+use std::process::Command;
+
+/// GitHub issue provider that uses the `gh` CLI
+#[derive(Debug)]
+pub struct GitHubProvider {
+    owner: String,
+    repo: String,
+}
+
+impl GitHubProvider {
+    /// Create a new GitHub provider for the given owner/repo
+    pub fn new(owner: String, repo: String) -> Self {
+        Self { owner, repo }
+    }
+
+    /// Execute a `gh` command and return stdout
+    async fn run_gh(&self, args: &[&str]) -> Result<String, PluginError> {
+        // Run gh command in a blocking task
+        let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+        tokio::task::spawn_blocking(move || {
+            let output = Command::new("gh")
+                .args(&args_owned)
+                .output()
+                .map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::NotFound {
+                        PluginError::Provider {
+                            message: "gh CLI not found. Install from https://cli.github.com/".to_string(),
+                            source: Some(Box::new(e)),
+                        }
+                    } else {
+                        PluginError::Provider {
+                            message: format!("Failed to execute gh: {e}"),
+                            source: Some(Box::new(e)),
+                        }
+                    }
+                })?;
+
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(PluginError::Provider {
+                    message: format!("gh command failed: {stderr}"),
+                    source: None,
+                });
+            }
+
+            let stdout = String::from_utf8(output.stdout).map_err(|e| PluginError::Provider {
+                message: format!("Invalid UTF-8 in gh output: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+
+            Ok(stdout)
+        })
+        .await
+        .map_err(|e| PluginError::Runtime {
+            message: format!("Task join error: {e}"),
+            source: Some(Box::new(e)),
+        })?
+    }
+
+    /// Parse GitHub issue JSON from `gh issue list` or `gh issue view`
+    fn parse_issue(&self, gh_json: &GhIssue) -> Issue {
+        Issue {
+            id: gh_json.number.to_string(),
+            number: gh_json.number,
+            title: gh_json.title.clone(),
+            body: gh_json.body.clone(),
+            state: if gh_json.state.to_uppercase() == "OPEN" {
+                IssueState::Open
+            } else {
+                IssueState::Closed
+            },
+            labels: gh_json
+                .labels
+                .iter()
+                .map(|l| IssueLabel {
+                    name: l.name.clone(),
+                    color: l.color.clone(),
+                })
+                .collect(),
+            assignees: gh_json
+                .assignees
+                .iter()
+                .map(|a| a.login.clone())
+                .collect(),
+            author: gh_json.author.login.clone(),
+            created_at: gh_json.created_at.clone(),
+            updated_at: gh_json.updated_at.clone(),
+            url: gh_json.url.clone(),
+        }
+    }
+}
+
+impl IssueProvider for GitHubProvider {
+    async fn list_issues(&self, filter: &IssueFilter) -> Result<Vec<Issue>, PluginError> {
+        // Build args as owned strings to avoid lifetime issues
+        let repo_arg = format!("{}/{}", self.owner, self.repo);
+        let mut args = vec![
+            "issue".to_string(),
+            "list".to_string(),
+            "--repo".to_string(),
+            repo_arg,
+            "--json".to_string(),
+            "number,title,body,state,labels,assignees,author,createdAt,updatedAt,url".to_string(),
+        ];
+
+        // Add state filter
+        if let Some(state) = filter.state {
+            let state_arg = match state {
+                IssueState::Open => "open",
+                IssueState::Closed => "closed",
+            };
+            args.push("--state".to_string());
+            args.push(state_arg.to_string());
+        } else {
+            args.push("--state".to_string());
+            args.push("all".to_string());
+        }
+
+        // Add label filter (gh uses comma-separated)
+        if !filter.labels.is_empty() {
+            args.push("--label".to_string());
+            args.push(filter.labels.join(","));
+        }
+
+        // Add assignee filter (gh accepts multiple --assignee flags)
+        for assignee in &filter.assignees {
+            args.push("--assignee".to_string());
+            args.push(assignee.clone());
+        }
+
+        // Convert to &str for run_gh
+        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let output = self.run_gh(&args_refs).await?;
+
+        let gh_issues: Vec<GhIssue> =
+            serde_json::from_str(&output).map_err(|e| PluginError::Provider {
+                message: format!("Failed to parse gh JSON: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+
+        let mut issues: Vec<Issue> = gh_issues.iter().map(|gh| self.parse_issue(gh)).collect();
+
+        // Apply since filter (gh doesn't support this natively)
+        if let Some(since) = &filter.since {
+            issues.retain(|issue| issue.updated_at >= *since);
+        }
+
+        Ok(issues)
+    }
+
+    async fn get_issue(&self, number: u64) -> Result<Issue, PluginError> {
+        let number_arg = number.to_string();
+        let repo_arg = format!("{}/{}", self.owner, self.repo);
+        let args = [
+            "issue",
+            "view",
+            &number_arg,
+            "--repo",
+            &repo_arg,
+            "--json",
+            "number,title,body,state,labels,assignees,author,createdAt,updatedAt,url",
+        ];
+
+        let output = self.run_gh(&args).await?;
+
+        let gh_issue: GhIssue =
+            serde_json::from_str(&output).map_err(|e| PluginError::Provider {
+                message: format!("Failed to parse gh JSON: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+
+        Ok(self.parse_issue(&gh_issue))
+    }
+
+    async fn add_comment(&self, issue_number: u64, body: &str) -> Result<IssueComment, PluginError> {
+        let number_arg = issue_number.to_string();
+        let repo_arg = format!("{}/{}", self.owner, self.repo);
+        let args = [
+            "issue",
+            "comment",
+            &number_arg,
+            "--repo",
+            &repo_arg,
+            "--body",
+            body,
+        ];
+
+        self.run_gh(&args).await?;
+
+        // gh issue comment doesn't return JSON, so we construct a minimal comment
+        // In a real implementation, we'd fetch the comment ID via API
+        Ok(IssueComment {
+            id: "unknown".to_string(),
+            body: body.to_string(),
+            author: "current-user".to_string(), // Would need to query gh api user
+            created_at: chrono::Utc::now().to_rfc3339(),
+        })
+    }
+
+    async fn list_comments(&self, issue_number: u64) -> Result<Vec<IssueComment>, PluginError> {
+        let api_path = format!(
+            "repos/{}/{}/issues/{}/comments",
+            self.owner, self.repo, issue_number
+        );
+        let args = [
+            "api",
+            &api_path,
+            "--jq",
+            r#"[.[] | {id: (.id | tostring), body, author: .user.login, created_at: .created_at}]"#,
+        ];
+
+        let output = self.run_gh(&args).await?;
+
+        let comments: Vec<IssueComment> =
+            serde_json::from_str(&output).map_err(|e| PluginError::Provider {
+                message: format!("Failed to parse comment JSON: {e}"),
+                source: Some(Box::new(e)),
+            })?;
+
+        Ok(comments)
+    }
+
+    fn provider_name(&self) -> &str {
+        "GitHub"
+    }
+}
+
+/// GitHub issue JSON schema (from `gh issue list --json`)
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GhIssue {
+    number: u64,
+    title: String,
+    body: Option<String>,
+    state: String,
+    labels: Vec<GhLabel>,
+    assignees: Vec<GhUser>,
+    author: GhUser,
+    created_at: String,
+    updated_at: String,
+    url: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhLabel {
+    name: String,
+    color: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GhUser {
+    login: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_github_provider_creation() {
+        let provider = GitHubProvider::new("owner".to_string(), "repo".to_string());
+        assert_eq!(provider.provider_name(), "GitHub");
+        assert_eq!(provider.owner, "owner");
+        assert_eq!(provider.repo, "repo");
+    }
+
+    #[test]
+    fn test_parse_issue() {
+        let provider = GitHubProvider::new("owner".to_string(), "repo".to_string());
+
+        let gh_issue = GhIssue {
+            number: 42,
+            title: "Test issue".to_string(),
+            body: Some("Body text".to_string()),
+            state: "OPEN".to_string(),
+            labels: vec![GhLabel {
+                name: "bug".to_string(),
+                color: Some("ff0000".to_string()),
+            }],
+            assignees: vec![GhUser {
+                login: "user1".to_string(),
+            }],
+            author: GhUser {
+                login: "author1".to_string(),
+            },
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+        };
+
+        let issue = provider.parse_issue(&gh_issue);
+
+        assert_eq!(issue.number, 42);
+        assert_eq!(issue.title, "Test issue");
+        assert_eq!(issue.state, IssueState::Open);
+        assert_eq!(issue.labels.len(), 1);
+        assert_eq!(issue.labels[0].name, "bug");
+        assert_eq!(issue.assignees.len(), 1);
+        assert_eq!(issue.assignees[0], "user1");
+        assert_eq!(issue.author, "author1");
+    }
+
+    #[test]
+    fn test_parse_issue_closed() {
+        let provider = GitHubProvider::new("owner".to_string(), "repo".to_string());
+
+        let gh_issue = GhIssue {
+            number: 1,
+            title: "Closed issue".to_string(),
+            body: None,
+            state: "CLOSED".to_string(),
+            labels: vec![],
+            assignees: vec![],
+            author: GhUser {
+                login: "author".to_string(),
+            },
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            url: "https://github.com/owner/repo/issues/1".to_string(),
+        };
+
+        let issue = provider.parse_issue(&gh_issue);
+        assert_eq!(issue.state, IssueState::Closed);
+    }
+}

--- a/crates/atm-daemon/src/plugins/issues/mod.rs
+++ b/crates/atm-daemon/src/plugins/issues/mod.rs
@@ -1,0 +1,126 @@
+//! Issues plugin — provider abstraction for issue tracking
+
+mod azure_devops;
+mod github;
+mod provider;
+mod types;
+
+pub use azure_devops::AzureDevOpsProvider;
+pub use github::GitHubProvider;
+pub use provider::{ErasedIssueProvider, IssueProvider};
+pub use types::{Issue, IssueComment, IssueFilter, IssueLabel, IssueState};
+
+use atm_core::context::GitProvider;
+use crate::plugin::PluginError;
+
+/// Create an issue provider for the given git provider
+///
+/// Returns a boxed trait object that implements ErasedIssueProvider.
+///
+/// # Arguments
+///
+/// * `provider` - The git provider (GitHub, Azure DevOps, etc.)
+/// * `_config` - Optional plugin config (reserved for future use)
+///
+/// # Errors
+///
+/// Returns `PluginError::Provider` if the git provider doesn't support issue tracking.
+pub fn create_provider(
+    provider: &GitProvider,
+    _config: Option<&toml::Table>,
+) -> Result<Box<dyn ErasedIssueProvider>, PluginError> {
+    match provider {
+        GitProvider::GitHub { owner, repo } => Ok(Box::new(GitHubProvider::new(
+            owner.clone(),
+            repo.clone(),
+        ))),
+        GitProvider::AzureDevOps { org, project, repo } => Ok(Box::new(AzureDevOpsProvider::new(
+            org.clone(),
+            project.clone(),
+            repo.clone(),
+        ))),
+        GitProvider::GitLab { namespace, repo } => Err(PluginError::Provider {
+            message: format!("GitLab issue provider not yet implemented (namespace: {namespace}, repo: {repo})"),
+            source: None,
+        }),
+        GitProvider::Bitbucket { workspace, repo } => Err(PluginError::Provider {
+            message: format!("Bitbucket issue provider not yet implemented (workspace: {workspace}, repo: {repo})"),
+            source: None,
+        }),
+        GitProvider::Unknown { host } => Err(PluginError::Provider {
+            message: format!("No issue provider for unknown git host: {host}"),
+            source: None,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_provider_github() {
+        let provider = GitProvider::GitHub {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+        };
+        let result = create_provider(&provider, None);
+        assert!(result.is_ok());
+        let provider = result.unwrap();
+        assert_eq!(provider.provider_name(), "GitHub");
+    }
+
+    #[test]
+    fn test_create_provider_azure_devops() {
+        let provider = GitProvider::AzureDevOps {
+            org: "org".to_string(),
+            project: "project".to_string(),
+            repo: "repo".to_string(),
+        };
+        let result = create_provider(&provider, None);
+        assert!(result.is_ok());
+        let provider = result.unwrap();
+        assert_eq!(provider.provider_name(), "Azure DevOps");
+    }
+
+    #[test]
+    fn test_create_provider_gitlab_not_implemented() {
+        let provider = GitProvider::GitLab {
+            namespace: "namespace".to_string(),
+            repo: "repo".to_string(),
+        };
+        let result = create_provider(&provider, None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("GitLab issue provider not yet implemented"));
+    }
+
+    #[test]
+    fn test_create_provider_bitbucket_not_implemented() {
+        let provider = GitProvider::Bitbucket {
+            workspace: "workspace".to_string(),
+            repo: "repo".to_string(),
+        };
+        let result = create_provider(&provider, None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Bitbucket issue provider not yet implemented"));
+    }
+
+    #[test]
+    fn test_create_provider_unknown() {
+        let provider = GitProvider::Unknown {
+            host: "example.com".to_string(),
+        };
+        let result = create_provider(&provider, None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No issue provider for unknown git host"));
+    }
+}

--- a/crates/atm-daemon/src/plugins/issues/provider.rs
+++ b/crates/atm-daemon/src/plugins/issues/provider.rs
@@ -1,0 +1,105 @@
+//! Provider trait for issue operations across git hosting platforms
+
+use super::types::{Issue, IssueComment, IssueFilter};
+use crate::plugin::PluginError;
+use std::future::Future;
+use std::pin::Pin;
+
+/// Async trait for provider-agnostic issue operations.
+///
+/// Each git host (GitHub, Azure DevOps, etc.) implements this trait.
+/// Uses RPITIT (Return Position Impl Trait in Traits) with explicit Send bounds.
+pub trait IssueProvider: Send + Sync + std::fmt::Debug {
+    /// List issues matching filters
+    fn list_issues(
+        &self,
+        filter: &IssueFilter,
+    ) -> impl Future<Output = Result<Vec<Issue>, PluginError>> + Send;
+
+    /// Get a single issue by number
+    fn get_issue(
+        &self,
+        number: u64,
+    ) -> impl Future<Output = Result<Issue, PluginError>> + Send;
+
+    /// Post a comment on an issue
+    fn add_comment(
+        &self,
+        issue_number: u64,
+        body: &str,
+    ) -> impl Future<Output = Result<IssueComment, PluginError>> + Send;
+
+    /// Get comments on an issue
+    fn list_comments(
+        &self,
+        issue_number: u64,
+    ) -> impl Future<Output = Result<Vec<IssueComment>, PluginError>> + Send;
+
+    /// Provider name for logging/display
+    fn provider_name(&self) -> &str;
+}
+
+/// Object-safe version of IssueProvider for type erasure.
+///
+/// This trait is implemented automatically for all types that implement IssueProvider.
+/// Allows storing `Box<dyn ErasedIssueProvider>` in the registry or plugin state.
+pub trait ErasedIssueProvider: Send + Sync + std::fmt::Debug {
+    fn list_issues<'a>(
+        &'a self,
+        filter: &'a IssueFilter,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Issue>, PluginError>> + Send + 'a>>;
+
+    fn get_issue<'a>(
+        &'a self,
+        number: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Issue, PluginError>> + Send + 'a>>;
+
+    fn add_comment<'a>(
+        &'a self,
+        issue_number: u64,
+        body: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<IssueComment, PluginError>> + Send + 'a>>;
+
+    fn list_comments<'a>(
+        &'a self,
+        issue_number: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<IssueComment>, PluginError>> + Send + 'a>>;
+
+    fn provider_name(&self) -> &str;
+}
+
+/// Blanket implementation of ErasedIssueProvider for all IssueProvider types.
+impl<T: IssueProvider> ErasedIssueProvider for T {
+    fn list_issues<'a>(
+        &'a self,
+        filter: &'a IssueFilter,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Issue>, PluginError>> + Send + 'a>> {
+        Box::pin(IssueProvider::list_issues(self, filter))
+    }
+
+    fn get_issue<'a>(
+        &'a self,
+        number: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Issue, PluginError>> + Send + 'a>> {
+        Box::pin(IssueProvider::get_issue(self, number))
+    }
+
+    fn add_comment<'a>(
+        &'a self,
+        issue_number: u64,
+        body: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<IssueComment, PluginError>> + Send + 'a>> {
+        Box::pin(IssueProvider::add_comment(self, issue_number, body))
+    }
+
+    fn list_comments<'a>(
+        &'a self,
+        issue_number: u64,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<IssueComment>, PluginError>> + Send + 'a>> {
+        Box::pin(IssueProvider::list_comments(self, issue_number))
+    }
+
+    fn provider_name(&self) -> &str {
+        IssueProvider::provider_name(self)
+    }
+}

--- a/crates/atm-daemon/src/plugins/issues/types.rs
+++ b/crates/atm-daemon/src/plugins/issues/types.rs
@@ -1,0 +1,149 @@
+//! Shared types for the Issues plugin provider abstraction
+
+use serde::{Deserialize, Serialize};
+
+/// An issue from a git hosting provider
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Issue {
+    /// Provider-specific ID (e.g., "123" for GitHub)
+    pub id: String,
+    /// Issue number
+    pub number: u64,
+    /// Issue title
+    pub title: String,
+    /// Issue body/description
+    pub body: Option<String>,
+    /// Current state
+    pub state: IssueState,
+    /// Labels attached to the issue
+    pub labels: Vec<IssueLabel>,
+    /// Assigned users
+    pub assignees: Vec<String>,
+    /// Issue author
+    pub author: String,
+    /// Creation timestamp (ISO 8601)
+    pub created_at: String,
+    /// Last update timestamp (ISO 8601)
+    pub updated_at: String,
+    /// Web URL to the issue
+    pub url: String,
+}
+
+/// Issue state
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IssueState {
+    /// Issue is open
+    Open,
+    /// Issue is closed
+    Closed,
+}
+
+/// Label attached to an issue
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueLabel {
+    /// Label name
+    pub name: String,
+    /// Label color (hex code, optional)
+    pub color: Option<String>,
+}
+
+/// Comment on an issue
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IssueComment {
+    /// Provider-specific comment ID
+    pub id: String,
+    /// Comment body text
+    pub body: String,
+    /// Comment author
+    pub author: String,
+    /// Creation timestamp (ISO 8601)
+    pub created_at: String,
+}
+
+/// Filter for querying issues
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct IssueFilter {
+    /// Filter by labels (all must match)
+    pub labels: Vec<String>,
+    /// Filter by assignees
+    pub assignees: Vec<String>,
+    /// Filter by state (None = all states)
+    pub state: Option<IssueState>,
+    /// Only issues updated after this timestamp (ISO 8601)
+    pub since: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_issue_serialization() {
+        let issue = Issue {
+            id: "123".to_string(),
+            number: 42,
+            title: "Test issue".to_string(),
+            body: Some("Issue body".to_string()),
+            state: IssueState::Open,
+            labels: vec![IssueLabel {
+                name: "bug".to_string(),
+                color: Some("ff0000".to_string()),
+            }],
+            assignees: vec!["user1".to_string()],
+            author: "author1".to_string(),
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-02T00:00:00Z".to_string(),
+            url: "https://github.com/owner/repo/issues/42".to_string(),
+        };
+
+        let json = serde_json::to_string(&issue).unwrap();
+        let deserialized: Issue = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(issue.id, deserialized.id);
+        assert_eq!(issue.number, deserialized.number);
+        assert_eq!(issue.title, deserialized.title);
+        assert_eq!(issue.state, deserialized.state);
+    }
+
+    #[test]
+    fn test_issue_state_serialization() {
+        let open = IssueState::Open;
+        let closed = IssueState::Closed;
+
+        let open_json = serde_json::to_string(&open).unwrap();
+        let closed_json = serde_json::to_string(&closed).unwrap();
+
+        assert_eq!(open_json, r#""Open""#);
+        assert_eq!(closed_json, r#""Closed""#);
+
+        let open_de: IssueState = serde_json::from_str(&open_json).unwrap();
+        let closed_de: IssueState = serde_json::from_str(&closed_json).unwrap();
+
+        assert_eq!(open_de, IssueState::Open);
+        assert_eq!(closed_de, IssueState::Closed);
+    }
+
+    #[test]
+    fn test_issue_filter_default() {
+        let filter = IssueFilter::default();
+        assert!(filter.labels.is_empty());
+        assert!(filter.assignees.is_empty());
+        assert!(filter.state.is_none());
+        assert!(filter.since.is_none());
+    }
+
+    #[test]
+    fn test_issue_filter_with_filters() {
+        let filter = IssueFilter {
+            labels: vec!["bug".to_string(), "urgent".to_string()],
+            assignees: vec!["user1".to_string()],
+            state: Some(IssueState::Open),
+            since: Some("2026-01-01T00:00:00Z".to_string()),
+        };
+
+        assert_eq!(filter.labels.len(), 2);
+        assert_eq!(filter.assignees.len(), 1);
+        assert_eq!(filter.state, Some(IssueState::Open));
+        assert_eq!(filter.since, Some("2026-01-01T00:00:00Z".to_string()));
+    }
+}

--- a/crates/atm-daemon/src/plugins/mod.rs
+++ b/crates/atm-daemon/src/plugins/mod.rs
@@ -1,0 +1,3 @@
+//! Plugin implementations for atm-daemon
+
+pub mod issues;

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1017,16 +1017,20 @@ MVP Complete (Phase 3)
 **Branch prefix**: `feature/p5-*`
 **Depends on**: Phase 4 complete
 
-### Sprint 5.1: Provider Abstraction
+### Sprint 5.1: Provider Abstraction ✅
 
 **Branch**: `feature/p5-s1-provider-abstraction`
 **Depends on**: Phase 4 complete
+**Status**: COMPLETE (2026-02-12)
 
 **Deliverables**:
-- Provider trait for issue operations (list, get, comment)
-- GitHub provider implementation (using `gh` CLI or API)
-- Azure DevOps provider stub (or implementation if straightforward)
-- Provider selection from `ctx.system.repo.provider`
+- ✅ Provider trait for issue operations (list, get, comment) — `provider.rs` with RPITIT + ErasedIssueProvider
+- ✅ GitHub provider implementation using `gh` CLI subprocess — `github.rs`
+- ✅ Azure DevOps provider stub — `azure_devops.rs`
+- ✅ Provider factory function from GitProvider — `create_provider()` in `mod.rs`
+- ✅ Issue types (Issue, IssueComment, IssueLabel, IssueFilter, IssueState) — `types.rs`
+- ✅ Module structure: `crates/atm-daemon/src/plugins/issues/`
+- ✅ All tests pass (293 total), clippy clean with `-D warnings`
 
 ### Sprint 5.2: Issues Plugin Core
 


### PR DESCRIPTION
## Sprint 5.1: Provider Abstraction

This PR implements the provider abstraction layer for the Issues plugin, enabling support for multiple git hosting platforms (GitHub, Azure DevOps, GitLab, Bitbucket).

### Deliverables

- ✅ **Issue types** (`types.rs`): Issue, IssueComment, IssueLabel, IssueFilter, IssueState
- ✅ **IssueProvider trait** (`provider.rs`): RPITIT pattern with ErasedIssueProvider for type erasure
- ✅ **GitHub provider** (`github.rs`): Implementation using `gh` CLI subprocess
- ✅ **Azure DevOps stub** (`azure_devops.rs`): Placeholder returning "not implemented" errors
- ✅ **Provider factory** (`mod.rs`): `create_provider()` function based on GitProvider enum
- ✅ **Module structure**: New `crates/atm-daemon/src/plugins/` directory

### Technical Details

- Uses same RPITIT + blanket implementation pattern as `Plugin`/`ErasedPlugin`
- GitHub provider spawns `gh` commands in tokio blocking tasks (no HTTP client dependencies)
- Handles `gh` CLI not installed with clear error message
- Added `chrono` and `toml` dependencies to `atm-daemon`

### Testing

- All 293 tests pass (no regressions)
- New tests for Issue type serialization, provider factory, and stub behavior
- Clippy clean with `-D warnings`

### Dependencies

None (first sprint in Phase 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)