### PR TITLE
Phase 5: Merge remaining ARCH-CTM review fixes to develop

### DIFF
--- a/crates/atm-core/src/io/spool.rs
+++ b/crates/atm-core/src/io/spool.rs
@@ -300,6 +300,8 @@ fn process_spooled_message(
 fn get_spool_dir_with_base(subdir: &str, base_dir: Option<&Path>) -> Result<PathBuf, InboxError> {
     let spool_dir = if let Some(base) = base_dir {
         base.join("spool").join(subdir)
+    } else if let Ok(atm_home) = std::env::var("ATM_HOME") {
+        PathBuf::from(atm_home).join("spool").join(subdir)
     } else {
         dirs::config_dir()
             .ok_or_else(|| InboxError::SpoolError {

--- a/crates/atm-daemon/tests/provider_loader_integration.rs
+++ b/crates/atm-daemon/tests/provider_loader_integration.rs
@@ -1,0 +1,59 @@
+//! Integration test for loading external provider libraries
+
+use atm_daemon::plugins::issues::ProviderLoader;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn workspace_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("Failed to find workspace root")
+        .to_path_buf()
+}
+
+fn provider_stub_dir() -> PathBuf {
+    workspace_root().join("examples").join("provider-stub")
+}
+
+fn provider_stub_lib_path() -> PathBuf {
+    let dir = provider_stub_dir().join("target").join("release");
+    let prefix = if cfg!(windows) { "" } else { "lib" };
+    let suffix = std::env::consts::DLL_SUFFIX.trim_start_matches('.');
+    let name = format!("{}atm_provider_stub.{}", prefix, suffix);
+    dir.join(name)
+}
+
+#[test]
+fn test_provider_loader_loads_stub_library() {
+    let stub_dir = provider_stub_dir();
+    assert!(stub_dir.exists(), "provider-stub directory not found");
+
+    // Build the stub provider as a shared library
+    let status = Command::new("cargo")
+        .arg("build")
+        .arg("--release")
+        .current_dir(&stub_dir)
+        .status()
+        .expect("Failed to run cargo build for provider-stub");
+
+    assert!(status.success(), "provider-stub build failed");
+
+    let lib_path = provider_stub_lib_path();
+    assert!(
+        lib_path.exists(),
+        "provider-stub library not found at {:?}",
+        lib_path
+    );
+
+    let mut loader = ProviderLoader::new();
+    let factories = loader.load_libraries(&[lib_path]);
+    assert_eq!(factories.len(), 1);
+
+    let factory = &factories[0];
+    assert_eq!(factory.name, "stub");
+
+    let provider = (factory.create)(None).expect("Failed to create stub provider");
+    assert_eq!(provider.provider_name(), "stub");
+}


### PR DESCRIPTION
## Summary

PR #30 (integrate/phase-5 → develop) was merged before PR #32 (ARCH-CTM fixes → integrate/phase-5), so develop is missing three commits:

- `54f86d6` Fix ARCH-CTM review findings: self-loop, library unload, message dedup
- `b151ff4` ARCH-CTM review: add test coverage and fix spool test isolation
- `4e11922` Fix Windows CI: use ATM_HOME for spool dir in tests

This PR brings develop up to date with the final state of integrate/phase-5.

## Test plan

- [x] All CI green on PR #32 (Ubuntu, macOS, Windows)
- [x] 363 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)