### PR TITLE
feat(bridge): Sprint 8.2 — Per-origin read path + watcher fix

### DIFF
--- a/crates/atm-daemon/src/daemon/watcher.rs
+++ b/crates/atm-daemon/src/daemon/watcher.rs
@@ -15,6 +15,8 @@ pub struct InboxEvent {
     pub agent: String,
     pub path: PathBuf,
     pub kind: InboxEventKind,
+    /// Origin hostname for per-origin inbox files (None for local inbox)
+    pub origin: Option<String>,
 }
 
 /// Type of inbox event
@@ -36,10 +38,12 @@ pub enum InboxEventKind {
 ///
 /// * `teams_root` - Root directory containing team inboxes (e.g., ~/.claude/teams)
 /// * `event_tx` - Channel sender for inbox events
+/// * `hostname_registry` - Optional hostname registry for parsing per-origin inbox files
 /// * `cancel` - Cancellation token to stop watching
 pub async fn watch_inboxes(
     teams_root: PathBuf,
     event_tx: mpsc::Sender<InboxEvent>,
+    hostname_registry: Option<std::sync::Arc<atm_core::config::HostnameRegistry>>,
     cancel: CancellationToken,
 ) -> Result<()> {
     info!("Starting inbox watcher for: {}", teams_root.display());
@@ -73,6 +77,7 @@ pub async fn watch_inboxes(
     // Spawn a blocking task to handle the synchronous mpsc receiver
     let cancel_clone = cancel.clone();
     let teams_root_clone = teams_root.clone();
+    let registry_clone = hostname_registry.clone();
     tokio::task::spawn_blocking(move || {
         loop {
             if cancel_clone.is_cancelled() {
@@ -86,7 +91,7 @@ pub async fn watch_inboxes(
                     debug!("File system event: {:?}", event);
 
                     // Parse the event and send to async channel if it's relevant
-                    if let Some(inbox_events) = parse_event(&teams_root_clone, event) {
+                    if let Some(inbox_events) = parse_event(&teams_root_clone, event, registry_clone.as_deref()) {
                         for inbox_event in inbox_events {
                             // Use blocking_send since we're in a blocking task
                             if let Err(e) = event_tx.blocking_send(inbox_event) {
@@ -117,8 +122,18 @@ pub async fn watch_inboxes(
 /// Returns None if the event is not relevant (non-inbox file, config.json, etc).
 /// Returns Some(vec) with InboxEvent(s) if the event is for an inbox file.
 ///
-/// Path pattern: <teams_root>/<team>/inboxes/<agent>.json
-fn parse_event(teams_root: &PathBuf, event: Event) -> Option<Vec<InboxEvent>> {
+/// Path pattern: <teams_root>/<team>/inboxes/<agent>.json or <agent>.<hostname>.json
+///
+/// # Arguments
+///
+/// * `teams_root` - Root directory for teams
+/// * `event` - File system event
+/// * `hostname_registry` - Optional hostname registry for parsing per-origin files
+fn parse_event(
+    teams_root: &PathBuf,
+    event: Event,
+    hostname_registry: Option<&atm_core::config::HostnameRegistry>,
+) -> Option<Vec<InboxEvent>> {
     let mut events = Vec::new();
 
     // Map event kind to InboxEventKind
@@ -136,7 +151,7 @@ fn parse_event(teams_root: &PathBuf, event: Event) -> Option<Vec<InboxEvent>> {
         }
 
         // Extract team and agent from path
-        // Path pattern: <teams_root>/<team>/inbox/<agent>.json
+        // Path pattern: <teams_root>/<team>/inboxes/<agent>.json or <agent>.<hostname>.json
         let rel_path = match path.strip_prefix(teams_root) {
             Ok(p) => p,
             Err(_) => continue, // Not under teams_root
@@ -144,7 +159,7 @@ fn parse_event(teams_root: &PathBuf, event: Event) -> Option<Vec<InboxEvent>> {
 
         let components: Vec<_> = rel_path.components().collect();
 
-        // Need at least: <team>/inbox/<agent>.json (3 components)
+        // Need at least: <team>/inboxes/<agent>.json (3 components)
         if components.len() < 3 {
             continue;
         }
@@ -160,17 +175,22 @@ fn parse_event(teams_root: &PathBuf, event: Event) -> Option<Vec<InboxEvent>> {
             continue;
         }
 
-        // Extract agent name (filename without .json extension)
-        let agent = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(s) => s.to_string(),
+        // Extract filename without extension
+        let file_stem = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(s) => s,
             None => continue,
         };
+
+        // Parse agent name and origin
+        // Format: <agent>.json (local) or <agent>.<hostname>.json (origin)
+        let (agent, origin) = parse_agent_and_origin(file_stem, hostname_registry);
 
         events.push(InboxEvent {
             team,
             agent,
             path: path.clone(),
             kind: inbox_kind,
+            origin,
         });
     }
 
@@ -180,6 +200,46 @@ fn parse_event(teams_root: &PathBuf, event: Event) -> Option<Vec<InboxEvent>> {
         Some(events)
     }
 }
+
+/// Parse agent name and origin from file stem
+///
+/// Handles both local files (<agent>) and per-origin files (<agent>.<hostname>).
+/// Uses hostname registry to determine if a suffix is a known hostname.
+///
+/// # Arguments
+///
+/// * `file_stem` - Filename without .json extension (e.g., "dev-agent" or "dev-agent.mac-studio")
+/// * `hostname_registry` - Optional hostname registry
+///
+/// # Returns
+///
+/// Tuple of (agent_name, origin) where origin is Some(hostname) for origin files, None for local files
+fn parse_agent_and_origin(
+    file_stem: &str,
+    hostname_registry: Option<&atm_core::config::HostnameRegistry>,
+) -> (String, Option<String>) {
+    // If no hostname registry, treat entire stem as agent name
+    let Some(registry) = hostname_registry else {
+        return (file_stem.to_string(), None);
+    };
+
+    // Try to find a suffix that matches a known hostname
+    // Walk backwards through dots to handle agent names with dots
+    let parts: Vec<&str> = file_stem.split('.').collect();
+
+    for i in (1..parts.len()).rev() {
+        let potential_hostname = parts[i..].join(".");
+        if registry.is_known_hostname(&potential_hostname) {
+            // Found a match - everything before this is the agent name
+            let agent_name = parts[..i].join(".");
+            return (agent_name, Some(potential_hostname));
+        }
+    }
+
+    // No hostname match found - treat entire stem as agent name (local inbox)
+    (file_stem.to_string(), None)
+}
+
 
 #[cfg(test)]
 mod tests {
@@ -196,7 +256,7 @@ mod tests {
             attrs: Default::default(),
         };
 
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_some());
 
         let events = result.unwrap();
@@ -207,6 +267,7 @@ mod tests {
         assert_eq!(inbox_event.agent, "agent-1");
         assert_eq!(inbox_event.path, inbox_path);
         assert_eq!(inbox_event.kind, InboxEventKind::MessageReceived);
+        assert_eq!(inbox_event.origin, None);
     }
 
     #[test]
@@ -220,7 +281,7 @@ mod tests {
             attrs: Default::default(),
         };
 
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_some());
 
         let events = result.unwrap();
@@ -228,6 +289,7 @@ mod tests {
 
         let inbox_event = &events[0];
         assert_eq!(inbox_event.kind, InboxEventKind::MessageReceived);
+        assert_eq!(inbox_event.origin, None);
     }
 
     #[test]
@@ -241,7 +303,7 @@ mod tests {
             attrs: Default::default(),
         };
 
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_some());
 
         let events = result.unwrap();
@@ -249,6 +311,7 @@ mod tests {
 
         let inbox_event = &events[0];
         assert_eq!(inbox_event.kind, InboxEventKind::FileRemoved);
+        assert_eq!(inbox_event.origin, None);
     }
 
     #[test]
@@ -263,7 +326,7 @@ mod tests {
         };
 
         // Should be ignored (not in inbox/ subdirectory)
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_none());
     }
 
@@ -279,7 +342,7 @@ mod tests {
         };
 
         // Should be ignored (not .json)
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_none());
     }
 
@@ -295,12 +358,120 @@ mod tests {
             attrs: Default::default(),
         };
 
-        let result = parse_event(&teams_root, event);
+        let result = parse_event(&teams_root, event, None);
         assert!(result.is_some());
 
         let events = result.unwrap();
         assert_eq!(events.len(), 2);
         assert_eq!(events[0].agent, "agent-a");
         assert_eq!(events[1].agent, "agent-b");
+    }
+
+    #[test]
+    fn test_parse_event_per_origin_file() {
+        use atm_core::config::{HostnameRegistry, RemoteConfig};
+
+        let teams_root = PathBuf::from("/tmp/teams");
+        let origin_path = teams_root.join("my-team/inboxes/agent-1.mac-studio.json");
+
+        // Create hostname registry
+        let mut registry = HostnameRegistry::new();
+        registry
+            .register(RemoteConfig {
+                hostname: "mac-studio".to_string(),
+                address: "user@mac".to_string(),
+                ssh_key_path: None,
+                aliases: Vec::new(),
+            })
+            .unwrap();
+
+        let event = Event {
+            kind: EventKind::Create(notify::event::CreateKind::File),
+            paths: vec![origin_path.clone()],
+            attrs: Default::default(),
+        };
+
+        let result = parse_event(&teams_root, event, Some(&registry));
+        assert!(result.is_some());
+
+        let events = result.unwrap();
+        assert_eq!(events.len(), 1);
+
+        let inbox_event = &events[0];
+        assert_eq!(inbox_event.team, "my-team");
+        assert_eq!(inbox_event.agent, "agent-1");
+        assert_eq!(inbox_event.origin, Some("mac-studio".to_string()));
+    }
+
+    #[test]
+    fn test_parse_event_per_origin_file_with_dotted_agent() {
+        use atm_core::config::{HostnameRegistry, RemoteConfig};
+
+        let teams_root = PathBuf::from("/tmp/teams");
+        let origin_path = teams_root.join("my-team/inboxes/dev.agent.mac-studio.json");
+
+        // Create hostname registry
+        let mut registry = HostnameRegistry::new();
+        registry
+            .register(RemoteConfig {
+                hostname: "mac-studio".to_string(),
+                address: "user@mac".to_string(),
+                ssh_key_path: None,
+                aliases: Vec::new(),
+            })
+            .unwrap();
+
+        let event = Event {
+            kind: EventKind::Create(notify::event::CreateKind::File),
+            paths: vec![origin_path.clone()],
+            attrs: Default::default(),
+        };
+
+        let result = parse_event(&teams_root, event, Some(&registry));
+        assert!(result.is_some());
+
+        let events = result.unwrap();
+        assert_eq!(events.len(), 1);
+
+        let inbox_event = &events[0];
+        assert_eq!(inbox_event.team, "my-team");
+        assert_eq!(inbox_event.agent, "dev.agent");
+        assert_eq!(inbox_event.origin, Some("mac-studio".to_string()));
+    }
+
+    #[test]
+    fn test_parse_event_unknown_hostname_treated_as_local() {
+        use atm_core::config::{HostnameRegistry, RemoteConfig};
+
+        let teams_root = PathBuf::from("/tmp/teams");
+        let unknown_path = teams_root.join("my-team/inboxes/agent-1.unknown-host.json");
+
+        // Create hostname registry without unknown-host
+        let mut registry = HostnameRegistry::new();
+        registry
+            .register(RemoteConfig {
+                hostname: "known-host".to_string(),
+                address: "user@known".to_string(),
+                ssh_key_path: None,
+                aliases: Vec::new(),
+            })
+            .unwrap();
+
+        let event = Event {
+            kind: EventKind::Create(notify::event::CreateKind::File),
+            paths: vec![unknown_path.clone()],
+            attrs: Default::default(),
+        };
+
+        let result = parse_event(&teams_root, event, Some(&registry));
+        assert!(result.is_some());
+
+        let events = result.unwrap();
+        assert_eq!(events.len(), 1);
+
+        let inbox_event = &events[0];
+        // Entire stem treated as agent name since hostname not recognized
+        assert_eq!(inbox_event.agent, "agent-1.unknown-host");
+        assert_eq!(inbox_event.origin, None);
     }
 }


### PR DESCRIPTION
## Summary

Sprint 8.2 implementation: Per-origin merged inbox reader and watcher origin support.

### Deliverables

1. **Merged inbox reader** (`atm-core/io/inbox.rs`)
   - New `inbox_read_merged()` function reads local + all per-origin inbox files
   - Uses hostname registry from bridge config to filter valid origin files
   - Deduplicates by `message_id` (first occurrence wins)
   - Sorts by timestamp with stable tie-breakers
   - Backward-compatible: works with or without bridge configured
   - Handles agent names with dots correctly

2. **Watcher origin support** (`atm-daemon/daemon/watcher.rs`)
   - Added `origin: Option<String>` field to `InboxEvent`
   - `parse_event` extracts origin hostname from filename suffix
   - Normalizes agent field by stripping hostname suffix
   - `parse_agent_and_origin` helper handles dotted agent names
   - Accepts optional hostname registry parameter

3. **Event loop integration** (`atm-daemon/daemon/event_loop.rs`)
   - `extract_hostname_registry` helper builds registry from bridge config
   - Passes registry to watcher for origin file parsing

4. **CLI updates**
   - `read.rs`: Uses `inbox_read_merged`, marks only local inbox as read
   - `inbox.rs`: Uses `inbox_read_merged` for summaries and watch mode

### Tests

- Unit tests for merged reading with/without origin files
- Deduplication across origins
- Messages without `message_id` included (not deduped)
- Agent names with dots
- Unknown hostname filtering
- Watcher tests for per-origin file parsing
- All 218 tests pass
- Clippy clean

### Key Design Decisions

- Local `<agent>.json` files are NEVER modified by the bridge
- Remote origin files (`<agent>.<hostname>.json`) are additive alongside local files
- Filename parsing matches suffix against hostname registry (NOT dot-split)
- Dedup by `message_id` (first occurrence wins, directory order non-deterministic)
- Sort by timestamp, stable tie-breaker: message_id then origin filename
- Backward-compatible: works with or without bridge configured

## Test Plan

- [x] `cargo test --workspace` passes (218 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] All tests use `ATM_HOME` for temp directories

## Related

- Sprint 8.1: #54 (Bridge config + plugin scaffold)
- Design doc: `docs/phase8-bridge-design.md`