### PR TITLE
Fix release workflow: use macos-13 for x86_64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary
- `macos-latest` now runs on ARM64 (M-series) runners which can't natively build x86_64-apple-darwin
- Changed to `macos-13` (Intel) for the x86_64 macOS target
- Fixes the failed v0.8.0 release build

## Test plan
- [ ] Re-tag v0.8.0 after merge and verify all 4 release builds pass