### PR TITLE
Fix release workflow for v0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-latest
+            os: macos-13
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -52,7 +52,7 @@ jobs:
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
+          ARCHIVE="agent-team-mail_${VERSION}_${{ matrix.target }}.tar.gz"
           cd target/${{ matrix.target }}/release
           tar czf "../../../${ARCHIVE}" atm atm-daemon
           cd ../../..
@@ -63,7 +63,7 @@ jobs:
         shell: pwsh
         run: |
           $VERSION = "$env:GITHUB_REF_NAME" -replace '^v', ''
-          $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
+          $ARCHIVE = "agent-team-mail_${VERSION}_${{ matrix.target }}.zip"
           Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe","target/${{ matrix.target }}/release/atm-daemon.exe" -DestinationPath $ARCHIVE
           echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
 


### PR DESCRIPTION
## Summary
- Use `macos-13` (Intel) for `x86_64-apple-darwin` builds since `macos-latest` is now ARM and can't cross-compile
- Rename archive prefix from `atm_` to `agent-team-mail_` to match crate rename

## Context
The v0.8.0 release workflow failed because macOS runners are now ARM-based. This fix uses the Intel runner for x86_64 builds.

## Test plan
- [ ] Release workflow builds all 4 targets successfully after re-tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)