### PR TITLE
Fix release workflow: cross-compile x86_64 on ARM64 macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest
@@ -34,6 +34,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Ensure cross-compilation target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Cache cargo
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- `macos-13` runners are deprecated and no longer available
- Use `macos-latest` (ARM64) with explicit `rustup target add x86_64-apple-darwin` for cross-compilation
- Adds redundant `rustup target add` step to ensure std library is installed for cross targets

## Test plan
- [ ] Merge, delete v0.8.0 tag, re-tag, verify all 4 release builds pass