### PR TITLE
Fix release workflow: use macos-latest for x86_64 cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
             os: ubuntu-latest
             archive: tar.gz
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
             archive: tar.gz
           - target: aarch64-apple-darwin
             os: macos-latest


### PR DESCRIPTION
## Summary
- Previous fix incorrectly left `macos-13` in the squash merge
- `macos-13` runners are deprecated and instantly cancelled
- Changes to `macos-latest` (ARM64) which cross-compiles via `rustup target add` (already present)

## Test plan
- [ ] Merge, delete v0.8.0 tag, re-tag, verify all 4 release builds pass