### PR TITLE
Sprint 9.6: Daemon Retention Tasks

### DIFF
--- a/crates/atm-core/tests/retention_tests.rs
+++ b/crates/atm-core/tests/retention_tests.rs
@@ -61,6 +61,8 @@ fn test_retention_by_max_age() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -95,6 +97,8 @@ fn test_retention_by_max_count() {
         max_count: Some(5),
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -131,6 +135,8 @@ fn test_retention_combined_age_and_count() {
         max_count: Some(3),
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -172,6 +178,8 @@ fn test_archive_strategy() {
         max_count: None,
         strategy: CleanupStrategy::Archive,
         archive_dir: Some(archive_dir.to_str().unwrap().to_string()),
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -228,6 +236,8 @@ fn test_delete_strategy() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: Some(archive_dir.to_str().unwrap().to_string()),
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -263,6 +273,8 @@ fn test_dry_run() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, true).unwrap();
@@ -291,6 +303,8 @@ fn test_empty_inbox() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -316,6 +330,8 @@ fn test_nonexistent_inbox() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -346,6 +362,8 @@ fn test_no_data_loss_within_policy() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -398,6 +416,8 @@ fn test_retention_hours_duration() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();
@@ -432,6 +452,8 @@ fn test_no_retention_policy_keeps_all() {
         max_count: None,
         strategy: CleanupStrategy::Delete,
         archive_dir: None,
+        enabled: false,
+        interval_secs: 300,
     };
 
     let result = apply_retention(&inbox_path, "test-team", "test-agent", &policy, false).unwrap();


### PR DESCRIPTION
## Summary
- Add periodic inbox trimming to daemon event loop as non-blocking background task via `tokio::spawn`
- Add CI report file retention (`clean_report_files()`) for cleaning old `*.json` and `*.md` reports
- Extend `RetentionConfig` with `enabled` and `interval_secs` fields (backward compatible)
- Configurable defaults: 5min interval, 30d max age, 1000 max messages

## Files Changed
- `crates/atm-core/src/config/types.rs` — `enabled`, `interval_secs` fields with serde defaults
- `crates/atm-core/src/retention.rs` — `clean_report_files()`, public `parse_duration()`
- `crates/atm-daemon/src/daemon/event_loop.rs` — `retention_loop()` task with cancellation support
- `crates/atm-core/tests/retention_tests.rs` — Updated for new config fields

## Test plan
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo test --workspace` — 689 passed, 0 failed
- [x] Retention task non-blocking (tokio::spawn)
- [x] Per-origin inbox files handled (agent.hostname.json)
- [x] Backward compatible config parsing
- [x] Cross-platform compliance (ATM_HOME pattern, no HOME/USERPROFILE env)

🤖 Generated with [Claude Code](https://claude.com/claude-code)