### PR TITLE
chore: bump version to 0.9.0 for Phase 9 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -28,4 +28,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.8.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.9.0" }


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.8.0 to 0.9.0 in root `Cargo.toml`
- Update internal `agent-team-mail-core` dependency version to `=0.9.0`
- Cargo.lock updated via `cargo check`

## Context
Version 0.9.0 corresponds to Phase 9 (CI monitor integration). This PR targets `integrate/phase-9` so the version bump is included in PR #75 (Phase 9 merge to develop).

## Conflict check
No conflicts detected with develop's publishing doc commits (a705430, d41cfa5, 4611c83). The publishing docs exist only on develop and will coexist cleanly after the Phase 9 merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)