### PR TITLE
fix: arch-ctm Sprint 9.4 findings (atomic write, env isolation, last_run semantics, spawn_blocking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "serial_test",
  "ssh2",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/atm-daemon/Cargo.toml
+++ b/crates/atm-daemon/Cargo.toml
@@ -50,3 +50,4 @@ tokio = { version = "1", features = ["full", "test-util"] }
 chrono = "0.4"
 uuid = { version = "1", features = ["v4"] }
 rand = "0.8"
+serial_test = "3"

--- a/crates/atm-daemon/tests/daemon_tests.rs
+++ b/crates/atm-daemon/tests/daemon_tests.rs
@@ -8,6 +8,7 @@ use agent_team_mail_daemon::plugin::{
     Capability, MailService, Plugin, PluginContext, PluginError, PluginMetadata, PluginRegistry,
 };
 use agent_team_mail_daemon::roster::RosterService;
+use serial_test::serial;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tempfile::TempDir;
@@ -91,6 +92,7 @@ fn create_test_context() -> (PluginContext, TempDir) {
     std::fs::create_dir_all(&teams_root).unwrap();
 
     // Set ATM_HOME for cross-platform testing
+    // SAFETY: Tests are serialized via #[serial], so no parallel mutation
     unsafe {
         std::env::set_var("ATM_HOME", temp_dir.path());
     }
@@ -129,6 +131,7 @@ fn create_test_status_writer(temp_dir: &TempDir) -> Arc<StatusWriter> {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_daemon_starts_and_loads_mock_plugin() {
     let (ctx, temp_dir) = create_test_context();
     let events = Arc::new(Mutex::new(Vec::new()));
@@ -176,6 +179,7 @@ async fn test_daemon_starts_and_loads_mock_plugin() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_signal_triggers_graceful_shutdown() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);
@@ -207,6 +211,7 @@ async fn test_signal_triggers_graceful_shutdown() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_plugin_lifecycle_order() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);
@@ -242,6 +247,7 @@ async fn test_plugin_lifecycle_order() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_spool_drain_runs_on_interval() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);
@@ -267,6 +273,7 @@ async fn test_spool_drain_runs_on_interval() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_graceful_shutdown_with_timeout() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);
@@ -315,6 +322,7 @@ async fn test_graceful_shutdown_with_timeout() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_empty_registry_runs_successfully() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);
@@ -335,6 +343,7 @@ async fn test_empty_registry_runs_successfully() {
 }
 
 #[tokio::test]
+#[serial]
 async fn test_multiple_plugins_run_concurrently() {
     let (ctx, temp_dir) = create_test_context();
     let status_writer = create_test_status_writer(&temp_dir);


### PR DESCRIPTION
## Summary

Fixes four correctness issues identified in arch-ctm Sprint 9.4 review:

### F1 (CRITICAL): StatusWriter Windows rename compatibility
- **Problem**: `std::fs::rename` doesn't replace existing files on Windows
- **Fix**: Add explicit `remove_file` before `rename` for cross-platform safety
- **File**: `crates/atm-daemon/src/daemon/status.rs`

### F2 (MEDIUM): daemon_tests env mutation isolation
- **Problem**: Tests mutating `ATM_HOME` without serialization caused parallel flakes
- **Fix**: Add `serial_test` dependency and mark all tests using `ATM_HOME` with `#[serial]`
- **File**: `crates/atm-daemon/tests/daemon_tests.rs`

### F3 (MEDIUM): PluginStatus.last_run semantics mismatch
- **Problem**: Field documented as "last successful run" but set to current time on every status write
- **Fix**: Rename field to `last_updated` to match actual semantics
- **Files**: `crates/atm-daemon/src/daemon/{status.rs,event_loop.rs}`

### F4 (LOW): Blocking std::fs in async context
- **Problem**: `get_active_teams()` used blocking `std::fs::read_dir` in async status loop
- **Fix**: Wrap in `tokio::task::spawn_blocking` to avoid blocking runtime
- **File**: `crates/atm-daemon/src/daemon/event_loop.rs`

## Test Plan

- ✅ `cargo test --workspace` - all tests pass (652+ tests)
- ✅ `cargo clippy --workspace -- -D warnings` - no warnings
- ✅ Windows rename pattern matches cross-platform guidelines
- ✅ Serial test isolation prevents parallel env mutation
- ✅ Field rename clarifies actual semantics
- ✅ spawn_blocking prevents runtime blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)