### PR TITLE
fix: CLI last_run → last_updated alignment

### DIFF
--- a/crates/atm-daemon/src/daemon/status.rs
+++ b/crates/atm-daemon/src/daemon/status.rs
@@ -1,6 +1,6 @@
 //! Daemon status file writer
 //!
-//! Writes daemon status to `${ATM_HOME}/daemon/status.json` for CLI consumption.
+//! Writes daemon status to `${ATM_HOME}/.claude/daemon/status.json` for CLI consumption.
 //! Status includes daemon PID, uptime, plugin states, and last update timestamp.
 
 use anyhow::{Context, Result};

--- a/crates/atm/src/commands/daemon.rs
+++ b/crates/atm/src/commands/daemon.rs
@@ -109,8 +109,8 @@ fn execute_status(args: StatusArgs) -> Result<()> {
                     print!(" - Error: {}", error);
                 }
 
-                if let Some(ref last_run) = plugin.last_run {
-                    print!(" - Last run: {}", last_run);
+                if let Some(ref last_updated) = plugin.last_updated {
+                    print!(" - Last updated: {}", last_updated);
                 }
 
                 println!();
@@ -182,7 +182,7 @@ struct PluginStatus {
     enabled: bool,
     status: PluginStatusKind,
     last_error: Option<String>,
-    last_run: Option<String>,
+    last_updated: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
Aligns CLI `PluginStatus.last_run` field with `last_updated` in status.json (renamed in PR #77).

Without this fix, the CLI would silently drop the plugin update timestamp.

Found by arch-ctm during Phase 9 final review.

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] Field name matches status.json output

🤖 Generated with [Claude Code](https://claude.com/claude-code)