### PR TITLE
chore: add repo-local .atm.toml config

### DIFF
--- a/.atm.toml
+++ b/.atm.toml
@@ -1,0 +1,3 @@
+[core]
+default_team = "atm-dev"
+identity = "arch-ctm"


### PR DESCRIPTION
## Summary
- Adds `.atm.toml` to repo root with default team (`atm-dev`) and identity (`arch-ctm`)
- Agents working in this repo will automatically use these defaults

## Test plan
- [ ] Verify `atm config` shows correct defaults when run from repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)