### PR TITLE
feat(10.7): Identity aliases and Phase 10 integration tests

### DIFF
--- a/crates/atm-core/src/config/aliases.rs
+++ b/crates/atm-core/src/config/aliases.rs
@@ -1,0 +1,104 @@
+//! Identity alias resolution
+//!
+//! Aliases allow role-based names to map to actual inbox identities.
+//! For example, `arch-atm` can resolve to `team-lead`.
+//!
+//! Aliases are configured in `.atm.toml` under the `[aliases]` section:
+//!
+//! ```toml
+//! [aliases]
+//! arch-atm = "team-lead"
+//! dev = "worker-1"
+//! ```
+
+use std::collections::HashMap;
+
+/// Resolve an identity through the alias table.
+///
+/// If `name` matches a key in `aliases`, returns the corresponding value.
+/// Otherwise returns the original name unchanged (pass-through).
+///
+/// Alias resolution is case-sensitive and non-recursive: if the resolved
+/// value is itself an alias key it is NOT resolved further.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::HashMap;
+/// use agent_team_mail_core::config::aliases::resolve_alias;
+///
+/// let mut aliases = HashMap::new();
+/// aliases.insert("arch-atm".to_string(), "team-lead".to_string());
+///
+/// assert_eq!(resolve_alias("arch-atm", &aliases), "team-lead");
+/// assert_eq!(resolve_alias("unknown", &aliases), "unknown");
+/// ```
+pub fn resolve_alias(name: &str, aliases: &HashMap<String, String>) -> String {
+    aliases.get(name).cloned().unwrap_or_else(|| name.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn make_aliases() -> HashMap<String, String> {
+        let mut m = HashMap::new();
+        m.insert("arch-atm".to_string(), "team-lead".to_string());
+        m.insert("dev".to_string(), "worker-1".to_string());
+        m
+    }
+
+    #[test]
+    fn test_resolve_alias_known_name() {
+        let aliases = make_aliases();
+        assert_eq!(resolve_alias("arch-atm", &aliases), "team-lead");
+    }
+
+    #[test]
+    fn test_resolve_alias_second_entry() {
+        let aliases = make_aliases();
+        assert_eq!(resolve_alias("dev", &aliases), "worker-1");
+    }
+
+    #[test]
+    fn test_resolve_alias_passthrough_unknown() {
+        let aliases = make_aliases();
+        assert_eq!(resolve_alias("team-lead", &aliases), "team-lead");
+    }
+
+    #[test]
+    fn test_resolve_alias_empty_map() {
+        let aliases = HashMap::new();
+        assert_eq!(resolve_alias("any-name", &aliases), "any-name");
+    }
+
+    #[test]
+    fn test_resolve_alias_case_sensitive() {
+        let aliases = make_aliases();
+        // "Arch-Atm" is NOT the same as "arch-atm"
+        assert_eq!(resolve_alias("Arch-Atm", &aliases), "Arch-Atm");
+        assert_eq!(resolve_alias("ARCH-ATM", &aliases), "ARCH-ATM");
+    }
+
+    #[test]
+    fn test_resolve_alias_non_recursive() {
+        // Alias chains are NOT followed: if the resolved value is itself an alias
+        // key it is returned as-is without further resolution.
+        let mut aliases = HashMap::new();
+        aliases.insert("a".to_string(), "b".to_string());
+        aliases.insert("b".to_string(), "c".to_string());
+
+        // "a" resolves to "b", but "b" is NOT resolved further to "c"
+        assert_eq!(resolve_alias("a", &aliases), "b");
+    }
+
+    #[test]
+    fn test_resolve_alias_empty_string_key() {
+        let mut aliases = HashMap::new();
+        aliases.insert(String::new(), "nobody".to_string());
+
+        // Empty string lookup should resolve if the empty string is a key
+        assert_eq!(resolve_alias("", &aliases), "nobody");
+    }
+}

--- a/crates/atm-core/src/config/mod.rs
+++ b/crates/atm-core/src/config/mod.rs
@@ -7,10 +7,12 @@
 //! 4. Global config (~/.config/atm/config.toml)
 //! 5. Defaults
 
+pub mod aliases;
 mod bridge;
 mod discovery;
 mod types;
 
+pub use aliases::resolve_alias;
 pub use bridge::{BridgeConfig, BridgeRole, HostnameRegistry, RemoteConfig};
 pub use discovery::{resolve_config, resolve_settings, ConfigError, ConfigOverrides};
 pub use types::{CleanupStrategy, Config, CoreConfig, DisplayConfig, MessagingConfig, OutputFormat, RetentionConfig, TimestampFormat};

--- a/crates/atm-core/src/config/types.rs
+++ b/crates/atm-core/src/config/types.rs
@@ -18,6 +18,12 @@ pub struct Config {
     /// Retention configuration
     #[serde(default)]
     pub retention: RetentionConfig,
+    /// Identity aliases: map role-based names to actual inbox identities.
+    ///
+    /// For example, `arch-atm = "team-lead"` causes `atm send arch-atm …`
+    /// to deliver to the `team-lead` inbox instead.
+    #[serde(default)]
+    pub aliases: HashMap<String, String>,
     /// Plugin-specific configuration sections: [plugins.<name>]
     #[serde(default)]
     pub plugins: HashMap<String, toml::Table>,

--- a/crates/atm-daemon/tests/integration_orchestration.rs
+++ b/crates/atm-daemon/tests/integration_orchestration.rs
@@ -1,0 +1,468 @@
+//! Sprint 10.7 — Integration Orchestration Tests
+//!
+//! End-to-end tests validating the Phase 10 stack:
+//! - Agent state tracker lifecycle
+//! - Unix socket server query
+//! - Pub/sub subscription round-trip via socket
+//! - Alias config parsing and resolution
+
+use agent_team_mail_core::config::aliases::resolve_alias;
+use agent_team_mail_core::config::Config;
+use agent_team_mail_daemon::daemon::socket::{
+    new_launch_sender, new_pubsub_store, new_state_store, start_socket_server,
+};
+use agent_team_mail_daemon::plugins::worker_adapter::{AgentState, AgentStateTracker, PubSub};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tempfile::TempDir;
+
+// ── Test 1: AgentStateTracker lifecycle ───────────────────────────────────────
+
+#[test]
+fn test_state_tracker_lifecycle() {
+    let mut tracker = AgentStateTracker::new();
+
+    // Initially no agents tracked
+    assert!(tracker.get_state("arch-ctm").is_none());
+
+    // Register and verify default state
+    tracker.register_agent("arch-ctm");
+    // State after registration is implementation-defined; we just verify it's tracked
+    assert!(tracker.get_state("arch-ctm").is_some());
+
+    // Transition through valid states
+    tracker.set_state("arch-ctm", AgentState::Launching);
+    assert_eq!(tracker.get_state("arch-ctm"), Some(AgentState::Launching));
+
+    tracker.set_state("arch-ctm", AgentState::Busy);
+    assert_eq!(tracker.get_state("arch-ctm"), Some(AgentState::Busy));
+
+    tracker.set_state("arch-ctm", AgentState::Idle);
+    assert_eq!(tracker.get_state("arch-ctm"), Some(AgentState::Idle));
+
+    tracker.set_state("arch-ctm", AgentState::Killed);
+    assert_eq!(tracker.get_state("arch-ctm"), Some(AgentState::Killed));
+}
+
+#[test]
+fn test_state_tracker_multiple_agents() {
+    let mut tracker = AgentStateTracker::new();
+
+    tracker.register_agent("agent-a");
+    tracker.register_agent("agent-b");
+    tracker.register_agent("agent-c");
+
+    tracker.set_state("agent-a", AgentState::Idle);
+    tracker.set_state("agent-b", AgentState::Busy);
+    tracker.set_state("agent-c", AgentState::Launching);
+
+    let states = tracker.all_states();
+    assert_eq!(states.len(), 3);
+
+    assert_eq!(tracker.get_state("agent-a"), Some(AgentState::Idle));
+    assert_eq!(tracker.get_state("agent-b"), Some(AgentState::Busy));
+    assert_eq!(tracker.get_state("agent-c"), Some(AgentState::Launching));
+}
+
+#[test]
+fn test_state_tracker_transition_time() {
+    let mut tracker = AgentStateTracker::new();
+    tracker.register_agent("arch-ctm");
+    tracker.set_state("arch-ctm", AgentState::Idle);
+
+    // After a state transition, time_since_transition should be available
+    let elapsed = tracker.time_since_transition("arch-ctm");
+    assert!(elapsed.is_some(), "Elapsed time should be available after state set");
+
+    let duration = elapsed.unwrap();
+    // Should be very recent (< 1 second)
+    assert!(duration.as_secs() < 1, "Transition should have just happened");
+}
+
+// ── Test 2: Socket server query for agent state ────────────────────────────────
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_socket_query_agent_state() {
+    use agent_team_mail_core::daemon_client::{SocketRequest, PROTOCOL_VERSION};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio_util::sync::CancellationToken;
+
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let cancel = CancellationToken::new();
+
+    // Register agent in the shared state store
+    let state_store = new_state_store();
+    {
+        let mut tracker = state_store.lock().unwrap();
+        tracker.register_agent("arch-ctm");
+        tracker.set_state("arch-ctm", AgentState::Idle);
+    }
+
+    // Start socket server
+    let _handle = start_socket_server(
+        home_dir.clone(),
+        state_store,
+        new_pubsub_store(),
+        new_launch_sender(),
+        cancel.clone(),
+    )
+    .await
+    .unwrap()
+    .expect("Expected socket server handle on unix");
+
+    // Connect and query
+    let socket_path = home_dir.join(".claude/daemon/atm-daemon.sock");
+    let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+
+    let request = SocketRequest {
+        version: PROTOCOL_VERSION,
+        request_id: "orch-test-1".to_string(),
+        command: "agent-state".to_string(),
+        payload: serde_json::json!({"agent": "arch-ctm", "team": "atm-dev"}),
+    };
+    let req_line = format!("{}\n", serde_json::to_string(&request).unwrap());
+
+    let mut reader = BufReader::new(stream);
+    reader.get_mut().write_all(req_line.as_bytes()).await.unwrap();
+
+    let mut resp_line = String::new();
+    reader.read_line(&mut resp_line).await.unwrap();
+
+    let resp: agent_team_mail_core::daemon_client::SocketResponse =
+        serde_json::from_str(resp_line.trim()).unwrap();
+
+    assert!(resp.is_ok(), "Expected ok response, got: {:?}", resp.error);
+    let payload = resp.payload.unwrap();
+    assert_eq!(payload["state"].as_str().unwrap(), "idle");
+
+    cancel.cancel();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_socket_query_agent_not_found() {
+    use agent_team_mail_core::daemon_client::{SocketRequest, PROTOCOL_VERSION};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio_util::sync::CancellationToken;
+
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let cancel = CancellationToken::new();
+
+    let _handle = start_socket_server(
+        home_dir.clone(),
+        new_state_store(),
+        new_pubsub_store(),
+        new_launch_sender(),
+        cancel.clone(),
+    )
+    .await
+    .unwrap()
+    .expect("Socket server handle");
+
+    let socket_path = home_dir.join(".claude/daemon/atm-daemon.sock");
+    let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+
+    let request = SocketRequest {
+        version: PROTOCOL_VERSION,
+        request_id: "orch-test-not-found".to_string(),
+        command: "agent-state".to_string(),
+        payload: serde_json::json!({"agent": "ghost-agent", "team": "atm-dev"}),
+    };
+    let req_line = format!("{}\n", serde_json::to_string(&request).unwrap());
+
+    let mut reader = BufReader::new(stream);
+    reader.get_mut().write_all(req_line.as_bytes()).await.unwrap();
+
+    let mut resp_line = String::new();
+    reader.read_line(&mut resp_line).await.unwrap();
+
+    let resp: agent_team_mail_core::daemon_client::SocketResponse =
+        serde_json::from_str(resp_line.trim()).unwrap();
+
+    assert!(!resp.is_ok(), "Expected error for untracked agent");
+    assert_eq!(resp.error.unwrap().code, "AGENT_NOT_FOUND");
+
+    cancel.cancel();
+}
+
+// ── Test 3: PubSub subscription round-trip via socket ─────────────────────────
+
+#[cfg(unix)]
+#[tokio::test]
+async fn test_pubsub_subscription_roundtrip() {
+    use agent_team_mail_core::daemon_client::{SocketRequest, PROTOCOL_VERSION};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio_util::sync::CancellationToken;
+
+    let temp_dir = TempDir::new().unwrap();
+    let home_dir = temp_dir.path().to_path_buf();
+    let cancel = CancellationToken::new();
+
+    let pubsub_store = new_pubsub_store();
+
+    let _handle = start_socket_server(
+        home_dir.clone(),
+        new_state_store(),
+        pubsub_store.clone(),
+        new_launch_sender(),
+        cancel.clone(),
+    )
+    .await
+    .unwrap()
+    .expect("Socket server handle");
+
+    let socket_path = home_dir.join(".claude/daemon/atm-daemon.sock");
+
+    // Send subscribe request
+    let sub_request = SocketRequest {
+        version: PROTOCOL_VERSION,
+        request_id: "sub-orch-1".to_string(),
+        command: "subscribe".to_string(),
+        payload: serde_json::json!({
+            "subscriber": "team-lead",
+            "agent": "arch-ctm",
+            "events": ["idle"],
+            "team": "atm-dev"
+        }),
+    };
+    let req_line = format!("{}\n", serde_json::to_string(&sub_request).unwrap());
+
+    let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+    let mut reader = BufReader::new(stream);
+    reader.get_mut().write_all(req_line.as_bytes()).await.unwrap();
+
+    let mut resp_line = String::new();
+    reader.read_line(&mut resp_line).await.unwrap();
+
+    let resp: agent_team_mail_core::daemon_client::SocketResponse =
+        serde_json::from_str(resp_line.trim()).unwrap();
+
+    assert!(resp.is_ok(), "Subscribe should succeed, got: {:?}", resp.error);
+    let payload = resp.payload.unwrap();
+    assert!(payload["subscribed"].as_bool().unwrap());
+
+    // Verify subscription is registered in the store
+    let subscribers = pubsub_store
+        .lock()
+        .unwrap()
+        .matching_subscribers("arch-ctm", "idle");
+    assert!(
+        subscribers.contains(&"team-lead".to_string()),
+        "team-lead should be subscribed"
+    );
+
+    // Now unsubscribe via socket
+    let unsub_request = SocketRequest {
+        version: PROTOCOL_VERSION,
+        request_id: "unsub-orch-1".to_string(),
+        command: "unsubscribe".to_string(),
+        payload: serde_json::json!({
+            "subscriber": "team-lead",
+            "agent": "arch-ctm",
+            "team": "atm-dev"
+        }),
+    };
+    let unsub_line = format!("{}\n", serde_json::to_string(&unsub_request).unwrap());
+
+    let stream2 = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+    let mut reader2 = BufReader::new(stream2);
+    reader2.get_mut().write_all(unsub_line.as_bytes()).await.unwrap();
+
+    let mut resp2_line = String::new();
+    reader2.read_line(&mut resp2_line).await.unwrap();
+
+    let resp2: agent_team_mail_core::daemon_client::SocketResponse =
+        serde_json::from_str(resp2_line.trim()).unwrap();
+
+    assert!(resp2.is_ok(), "Unsubscribe should succeed");
+
+    // Verify subscription is removed
+    let subscribers_after = pubsub_store
+        .lock()
+        .unwrap()
+        .matching_subscribers("arch-ctm", "idle");
+    assert!(
+        !subscribers_after.contains(&"team-lead".to_string()),
+        "team-lead should no longer be subscribed"
+    );
+
+    cancel.cancel();
+}
+
+// ── Test 4: Alias config parsing ──────────────────────────────────────────────
+
+#[test]
+fn test_alias_resolution_config() {
+    // Parse a config with [aliases] section
+    let toml_str = r#"
+[core]
+default_team = "atm-dev"
+identity = "team-lead"
+
+[aliases]
+arch-atm = "team-lead"
+dev = "worker-1"
+codex = "arch-ctm"
+"#;
+
+    let config: Config = toml::from_str(toml_str).expect("Config parses successfully");
+
+    // Verify aliases are loaded
+    assert_eq!(config.aliases.len(), 3);
+    assert_eq!(config.aliases.get("arch-atm").map(String::as_str), Some("team-lead"));
+    assert_eq!(config.aliases.get("dev").map(String::as_str), Some("worker-1"));
+    assert_eq!(config.aliases.get("codex").map(String::as_str), Some("arch-ctm"));
+
+    // Resolve aliases using the helper
+    assert_eq!(resolve_alias("arch-atm", &config.aliases), "team-lead");
+    assert_eq!(resolve_alias("dev", &config.aliases), "worker-1");
+    assert_eq!(resolve_alias("unknown", &config.aliases), "unknown");
+}
+
+#[test]
+fn test_alias_config_roundtrip_serialization() {
+    let toml_str = r#"
+[aliases]
+arch-atm = "team-lead"
+"#;
+
+    let config: Config = toml::from_str(toml_str).unwrap();
+    let reserialized = toml::to_string(&config).unwrap();
+    let config2: Config = toml::from_str(&reserialized).unwrap();
+
+    assert_eq!(config.aliases, config2.aliases);
+}
+
+#[test]
+fn test_alias_config_empty_section() {
+    // Config without [aliases] should default to empty HashMap
+    let toml_str = r#"
+[core]
+default_team = "atm-dev"
+identity = "team-lead"
+"#;
+
+    let config: Config = toml::from_str(toml_str).unwrap();
+    assert!(config.aliases.is_empty());
+
+    // resolve_alias should pass through with empty aliases
+    assert_eq!(resolve_alias("any-agent", &config.aliases), "any-agent");
+}
+
+#[test]
+fn test_alias_default_config() {
+    let config = Config::default();
+    assert!(config.aliases.is_empty());
+}
+
+// ── Test 5: Alias resolution for send command ─────────────────────────────────
+
+#[test]
+fn test_alias_send_resolves() {
+    // Verify that alias resolution works correctly for the send command path.
+    // The actual send command requires a real filesystem setup, so we test
+    // the resolution function directly here.
+
+    let mut aliases = HashMap::new();
+    aliases.insert("arch-atm".to_string(), "team-lead".to_string());
+    aliases.insert("qa".to_string(), "tester-1".to_string());
+
+    // Direct alias lookup
+    assert_eq!(resolve_alias("arch-atm", &aliases), "team-lead");
+    assert_eq!(resolve_alias("qa", &aliases), "tester-1");
+
+    // Unknown names pass through unchanged
+    assert_eq!(resolve_alias("team-lead", &aliases), "team-lead");
+    assert_eq!(resolve_alias("unknown-agent", &aliases), "unknown-agent");
+}
+
+#[test]
+fn test_alias_resolution_with_at_syntax() {
+    // Aliases that include @team should resolve correctly.
+    // The resolved value is then parsed by parse_address.
+    let mut aliases = HashMap::new();
+    aliases.insert("arch-atm".to_string(), "team-lead".to_string());
+
+    // A name with @team suffix is not in aliases — pass through
+    assert_eq!(
+        resolve_alias("arch-atm@atm-dev", &aliases),
+        "arch-atm@atm-dev"
+    );
+
+    // The bare name matches
+    assert_eq!(resolve_alias("arch-atm", &aliases), "team-lead");
+}
+
+// ── Test 6: PubSub unit tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_pubsub_subscribe_and_match() {
+    let mut pubsub = PubSub::new();
+
+    pubsub
+        .subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+        .unwrap();
+
+    let matches = pubsub.matching_subscribers("arch-ctm", "idle");
+    assert_eq!(matches, vec!["team-lead"]);
+}
+
+#[test]
+fn test_pubsub_subscribe_and_unsubscribe() {
+    let mut pubsub = PubSub::new();
+
+    pubsub
+        .subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+        .unwrap();
+    pubsub.unsubscribe("team-lead", "arch-ctm");
+
+    let matches = pubsub.matching_subscribers("arch-ctm", "idle");
+    assert!(matches.is_empty());
+}
+
+#[test]
+fn test_pubsub_multiple_subscribers() {
+    let mut pubsub = PubSub::new();
+
+    pubsub
+        .subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+        .unwrap();
+    pubsub
+        .subscribe("qa-bot", "arch-ctm", vec!["idle".to_string()])
+        .unwrap();
+
+    let mut matches = pubsub.matching_subscribers("arch-ctm", "idle");
+    matches.sort();
+    assert_eq!(matches, vec!["qa-bot", "team-lead"]);
+}
+
+#[test]
+fn test_pubsub_no_match_for_different_event() {
+    let mut pubsub = PubSub::new();
+
+    pubsub
+        .subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+        .unwrap();
+
+    // subscribed to "idle" but querying "busy"
+    let matches = pubsub.matching_subscribers("arch-ctm", "busy");
+    assert!(matches.is_empty());
+}
+
+#[test]
+fn test_pubsub_shared_store() {
+    // Verify that Arc<Mutex<PubSub>> works correctly (as used in production)
+    let store: Arc<Mutex<PubSub>> = Arc::new(Mutex::new(PubSub::new()));
+
+    {
+        let mut ps = store.lock().unwrap();
+        ps.subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+            .unwrap();
+    }
+
+    let matches = store.lock().unwrap().matching_subscribers("arch-ctm", "idle");
+    assert_eq!(matches, vec!["team-lead"]);
+}


### PR DESCRIPTION
## Summary

- Add `[aliases]` section to `.atm.toml` for role-based name → inbox identity mapping
- `resolve_alias()` resolves aliases client-side before inbox operations
- `atm send` applies alias resolution, prints note when alias is used
- End-to-end integration tests validating the full Phase 10 stack
- Merges Sprints 10.4 (pub/sub), 10.5 (tail), and 10.6 (launcher) into unified codebase

## Changes

| File | Description |
|------|-------------|
| `crates/atm-core/src/config/aliases.rs` | **NEW** — `resolve_alias()` function with 7 unit tests |
| `crates/atm-core/src/config/mod.rs` | Re-export `aliases::resolve_alias` |
| `crates/atm-core/src/config/types.rs` | Add `aliases: HashMap<String, String>` to `Config` |
| `crates/atm/src/commands/send.rs` | Apply alias resolution before `parse_address` |
| `crates/atm-daemon/src/daemon/socket.rs` | Fix final test call site for 5-arg `start_socket_server` |
| `crates/atm-daemon/tests/integration_orchestration.rs` | **NEW** — 17 integration + unit tests |

## Merge Conflict Resolution

This PR merges all prior Phase 10 sprint branches (10.4 pub/sub + 10.5 tail + 10.6 launcher) and resolves conflicts where functions needed both `pubsub_store` and `launch_tx` parameters.

## QA Results

- **912 tests passed, 0 failed** (6 ignored — tmux/doc-test, pre-existing)
- **Clippy**: clean (0 warnings with `-D warnings`)
- **Cross-platform**: No `HOME`/`USERPROFILE` env usage in new test files
- **24 new tests** (7 alias unit + 17 integration/orchestration)

## Test plan

- [x] `cargo test --all` — 912 pass, 0 fail
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Alias resolution: `arch-atm` → `team-lead` via `[aliases]` config
- [x] Alias pass-through: unknown names unchanged
- [x] State tracker lifecycle: Launching → Busy → Idle → Killed
- [x] Socket query round-trip with agent state
- [x] PubSub subscription/unsubscription via socket
- [x] Config round-trip serialization with `[aliases]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)