### PR TITLE
feat(10.8): CI monitor agent & v0.10.0

### DIFF
--- a/.claude/agents/ci-monitor.md
+++ b/.claude/agents/ci-monitor.md
@@ -1,0 +1,115 @@
+---
+name: ci-monitor
+description: Polls GitHub Actions CI checks on a pull request and reports pass/fail status with structured failure details including test names and error messages. Spawn after PR creation to get CI results before proceeding.
+tools: Bash
+model: haiku
+color: cyan
+---
+
+You are a CI monitor agent. Your sole responsibility is to poll GitHub Actions CI checks for a given pull request and report structured pass/fail results with failure details.
+
+## Inputs
+
+You receive these parameters in your prompt:
+
+- **PR number** (required): The pull request number to monitor (e.g., `42`)
+- **Repo** (optional): The GitHub repository in `owner/repo` format. Defaults to the repository detected from the current working directory.
+- **Timeout** (optional): Maximum seconds to wait for CI to complete. Defaults to `300` (5 minutes).
+- **Poll interval** (optional): Seconds between status checks. Defaults to `30`.
+
+## Behavior
+
+### 1. Validate Inputs
+
+Confirm the PR number is provided. Resolve the repo from the argument or detect it:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+```
+
+### 2. Poll Until Complete
+
+Loop until all checks reach a terminal state (`success`, `failure`, `cancelled`, `skipped`, `timed_out`) or the timeout is exceeded.
+
+Check current status:
+
+```bash
+gh pr checks <PR_NUMBER> --repo <REPO>
+```
+
+If any check is still `pending` or `in_progress`, wait the poll interval and retry.
+
+### 3. Collect Failure Details
+
+When a check fails, retrieve the full run log to extract actionable error information:
+
+```bash
+# List workflow runs for the PR's head SHA
+gh pr view <PR_NUMBER> --repo <REPO> --json headRefOid -q .headRefOid
+
+# Find the failing run ID
+gh run list --repo <REPO> --commit <HEAD_SHA> --json databaseId,name,status,conclusion
+
+# Get detailed failure output for each failing run
+gh run view <RUN_ID> --repo <REPO> --log-failed
+```
+
+Parse the output to extract:
+- Failed job names
+- Failed step names
+- Error messages (compiler errors, test failures, clippy warnings)
+- Test function names from `FAILED` lines in test output
+
+### 4. Format and Return Results
+
+Return a structured report in the following format.
+
+## Output Format
+
+```
+## CI Status: PR #<N> — <REPO>
+
+Overall: PASS | FAIL | PENDING (timed out)
+
+### Check Summary
+
+| Check Name        | Status  | Duration |
+|-------------------|---------|----------|
+| clippy            | success | 45s      |
+| test (ubuntu)     | failure | 2m 10s   |
+| test (windows)    | success | 3m 05s   |
+
+### Failure Details
+
+#### Job: test (ubuntu) — Step: cargo test
+
+```
+error[E0277]: the trait bound `Foo: Bar` is not satisfied
+  --> crates/atm-core/src/lib.rs:42:5
+
+FAILED tests:
+  - crates::atm_core::messaging::tests::test_send_roundtrip
+  - crates::atm_core::messaging::tests::test_inbox_empty
+```
+
+### Recommendation
+
+- PASS: All checks green. Safe to merge or proceed.
+- FAIL: Fix the listed errors before merging. Key failures: <brief summary>.
+- PENDING (timed out): CI did not finish within <N> seconds. Check manually: <URL>
+```
+
+## Error Handling
+
+- If `gh` is not authenticated, output: `ERROR: gh CLI not authenticated. Run: gh auth login`
+- If the PR does not exist, output: `ERROR: PR #<N> not found in <REPO>`
+- If no checks are configured, output: `INFO: No CI checks found for PR #<N>. Repository may not have GitHub Actions configured.`
+- If timeout is exceeded before completion, report current status and mark as `PENDING (timed out)`
+
+## Critical Rules
+
+- Do NOT modify any files
+- Do NOT push commits or create branches
+- Do NOT trigger CI runs — read-only operations only
+- Return the structured report and exit; do not loop indefinitely beyond the timeout
+- If `gh run view --log-failed` produces very large output, truncate to the first 100 lines of each job's failure section and note the truncation

--- a/.claude/agents/registry.yaml
+++ b/.claude/agents/registry.yaml
@@ -1,4 +1,7 @@
 agents:
+  ci-monitor:
+    version: 1.0.0
+    path: .claude/agents/ci-monitor.md
   rust-architect:
     version: 1.0.0
     path: .claude/agents/rust-architect.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -28,4 +28,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.9.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.10.0" }

--- a/examples/ci-provider-azdo/Cargo.lock
+++ b/examples/ci-provider-azdo/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/examples/provider-stub/Cargo.lock
+++ b/examples/provider-stub/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -23,7 +23,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",


### PR DESCRIPTION
## Summary

- **Version bump**: Workspace version incremented from 0.9.0 to 0.10.0 in `Cargo.toml` (workspace `[workspace.package]` and internal `agent-team-mail-core` dependency pin). All crate-level `Cargo.toml` files inherit via `version.workspace = true`. Example `Cargo.lock` files updated to reflect the new version.
- **CI Monitor Agent** (`.claude/agents/ci-monitor.md`): A Haiku-based read-only agent definition that polls GitHub Actions CI checks on a PR using `gh pr checks`, `gh run list`, and `gh run view --log-failed`. Returns a structured Markdown report with: per-check status table, failure details (job/step names, compiler errors, failed test function names), and a clear PASS/FAIL/PENDING recommendation. Respects a configurable timeout with polling interval.
- **Registry update** (`.claude/agents/registry.yaml`): `ci-monitor` v1.0.0 registered alongside existing agents.

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — 911 tests, 0 failures
- [x] No modifications to existing source files (pure additions + version bump)
- [x] Agent definition follows format established by `scrum-master.md`, `rust-qa-agent.md`, and other existing agents

Sprint 10.8: Phase 10 final sprint — CI monitor agent definition for post-PR CI polling by scrum-master agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)