### PR TITLE
Fix ATM-QA compliance findings for Phase A design docs

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -848,6 +848,8 @@ interoperability between `atm` teams and agents using the MCP agent mail protoco
 
 **Status**: Planned — research and design TBD.
 
+> **Note**: This plugin (Section 6.6) is an `atm-daemon` plugin for interoperability with the external [mcp_agent_mail](https://github.com/Dicklesworthstone/mcp_agent_mail) project. It is unrelated to `atm-agent-mcp` (the Codex MCP proxy crate defined in `docs/atm-agent-mcp/`). Despite both having "MCP" in their names, they serve different purposes: this plugin bridges a third-party messaging protocol, while `atm-agent-mcp` wraps Codex sessions with ATM identity and communication.
+
 ---
 
 ## 7. Cross-Team Messaging


### PR DESCRIPTION
## Summary

Addresses all 13 Important/Minor findings from ATM-QA agent compliance review of Phase A (atm-agent-mcp) design documentation. The 6 Blocking findings were already resolved by arch-ctm in PR #98.

### Findings Fixed

| ID | Severity | Fix |
|----|----------|-----|
| QA-009 | Important | Registry example `status: "active"` -> `"idle"` (valid FR-17.1 state) |
| QA-010 | Important | Removed `idle_timeout_ms` — MCP proxy always knows state via request/response |
| QA-011 | Important | `atm_read` return fields aligned to InboxMessage schema (`from, text, timestamp, message_id`) |
| QA-012 | Important | Added FR-12.6 with complete env var table (`ATM_AGENT_MCP_*`) |
| QA-013 | Minor | Added disambiguation note in baseline `docs/requirements.md` Section 6.6 |
| QA-014 | Important | Rewrote FR-8.13 to explicit deliver-all policy (no crash detection) |
| QA-016 | Important | Added `identity` parameter to all 4 ATM tool schemas in design doc |
| QA-017 | Minor | Fixed FR-10.1 `last_active_at` -> `last_active` to match registry schema |
| QA-018 | Important | NFR-4 Windows changed from stretch goal to required (Codex CLI supports Windows) |
| QA-019 | Minor | Added test count targets to MVP exit criteria (120+ tests, 80% coverage) |

### Files Changed

- `docs/atm-agent-mcp/requirements.md` — FR-4.3, FR-4.5, FR-8.13, FR-10.1, FR-12.6, NFR-4, MVP exit criteria
- `docs/atm-agent-mcp/codex-mcp-crate-design.md` — idle_timeout removal, registry example, tool schemas, field names
- `docs/requirements.md` — Section 6.6 disambiguation note

## Test plan

- [ ] Review each finding fix against original QA report
- [ ] Verify field names match InboxMessage schema in baseline requirements
- [ ] Verify no stale idle_timeout references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)