### PR TITLE
feat(atm-agent-mcp): Sprint A.1 — crate scaffold + config resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -186,6 +186,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "atm-agent-mcp"
+version = "0.10.0"
+dependencies = [
+ "agent-team-mail-core",
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/atm-core",
     "crates/atm",
     "crates/atm-daemon",
+    "crates/atm-agent-mcp",
 ]
 exclude = [
     "examples/provider-stub",
@@ -22,6 +23,7 @@ rust-version = "1.85"
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
+toml = { version = "0.8", features = ["parse"] }
 
 # Error handling
 thiserror = "2.0"

--- a/crates/atm-agent-mcp/Cargo.toml
+++ b/crates/atm-agent-mcp/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "atm-agent-mcp"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "MCP proxy for managing Codex agent sessions with ATM team integration"
+
+[[bin]]
+name = "atm-agent-mcp"
+path = "src/main.rs"
+
+[dependencies]
+agent-team-mail-core.workspace = true
+clap = { version = "4", features = ["derive"] }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml.workspace = true
+tokio = { version = "1", features = ["full"] }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = "3"
+serial_test = "3"

--- a/crates/atm-agent-mcp/src/cli.rs
+++ b/crates/atm-agent-mcp/src/cli.rs
@@ -1,0 +1,111 @@
+//! CLI argument types for atm-agent-mcp.
+//!
+//! Defines the top-level [`Cli`] struct and all subcommand [`Args`] using
+//! clap's derive macros. Each subcommand maps to a module in [`commands`].
+
+use clap::{Args, Parser, Subcommand};
+use std::path::PathBuf;
+
+/// MCP proxy for managing Codex agent sessions with ATM team integration
+#[derive(Parser, Debug)]
+#[command(name = "atm-agent-mcp", version, about)]
+pub struct Cli {
+    /// Path to .atm.toml config file (default: auto-detected)
+    #[arg(long, global = true)]
+    pub config: Option<PathBuf>,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+/// Top-level subcommands
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Start MCP proxy server
+    Serve(ServeArgs),
+    /// Show resolved configuration
+    Config(ConfigArgs),
+    /// List and manage agent sessions
+    Sessions(SessionsArgs),
+    /// Display saved session summary
+    Summary(SummaryArgs),
+}
+
+/// Arguments for the `serve` subcommand
+#[derive(Args, Debug)]
+pub struct ServeArgs {
+    /// Identity override (overrides config/env)
+    #[arg(long)]
+    pub identity: Option<String>,
+
+    /// Role preset to use
+    #[arg(long)]
+    pub role: Option<String>,
+
+    /// Model override
+    #[arg(long)]
+    pub model: Option<String>,
+
+    /// Sandbox mode
+    #[arg(long)]
+    pub sandbox: Option<String>,
+
+    /// Approval policy
+    #[arg(long, name = "approval-policy")]
+    pub approval_policy: Option<String>,
+
+    /// Resume most recent session, or a specific agent-id
+    #[arg(long)]
+    pub resume: Option<Option<String>>,
+
+    /// Use fast model profile
+    #[arg(long)]
+    pub fast: bool,
+
+    /// Enable subagent mode
+    #[arg(long)]
+    pub subagents: bool,
+
+    /// Read-only mode
+    #[arg(long, conflicts_with = "explore")]
+    pub readonly: bool,
+
+    /// Explore mode (same as readonly, for discoverability)
+    #[arg(long)]
+    pub explore: bool,
+
+    /// Request timeout in seconds
+    #[arg(long)]
+    pub timeout: Option<u64>,
+}
+
+/// Arguments for the `config` subcommand
+#[derive(Args, Debug)]
+pub struct ConfigArgs {
+    /// Output as JSON
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Arguments for the `sessions` subcommand
+#[derive(Args, Debug)]
+pub struct SessionsArgs {
+    /// Filter by repository name
+    #[arg(long)]
+    pub repo: Option<String>,
+
+    /// Filter by identity
+    #[arg(long)]
+    pub identity: Option<String>,
+
+    /// Prune closed/stale sessions
+    #[arg(long)]
+    pub prune: bool,
+}
+
+/// Arguments for the `summary` subcommand
+#[derive(Args, Debug)]
+pub struct SummaryArgs {
+    /// Agent ID to show summary for
+    pub agent_id: String,
+}

--- a/crates/atm-agent-mcp/src/commands/config_cmd.rs
+++ b/crates/atm-agent-mcp/src/commands/config_cmd.rs
@@ -1,0 +1,90 @@
+//! `config` subcommand — show resolved configuration.
+//!
+//! Loads the full resolved configuration and prints it either as JSON
+//! (`--json`) or as a human-readable key=value table.
+
+use crate::cli::ConfigArgs;
+use crate::config::{resolve_config, AgentMcpConfig, ResolvedConfig, RolePreset};
+use std::path::PathBuf;
+
+/// Run the `config` subcommand.
+///
+/// # Errors
+///
+/// Returns an error if config resolution fails (e.g., unreadable TOML file or
+/// home directory cannot be determined).
+pub async fn run(config_path: &Option<PathBuf>, args: ConfigArgs) -> anyhow::Result<()> {
+    let resolved: ResolvedConfig = resolve_config(config_path.as_deref())?;
+    let cfg: &AgentMcpConfig = &resolved.agent_mcp;
+
+    if args.json {
+        let json = serde_json::to_string_pretty(cfg)?;
+        println!("{json}");
+    } else {
+        println!("atm-agent-mcp configuration:");
+        println!("  codex_bin              = {}", cfg.codex_bin);
+        println!(
+            "  identity               = {}",
+            cfg.identity.as_deref().unwrap_or("<unset>")
+        );
+        println!(
+            "  model                  = {}",
+            cfg.model.as_deref().unwrap_or("<unset>")
+        );
+        println!(
+            "  fast_model             = {}",
+            cfg.fast_model.as_deref().unwrap_or("<unset>")
+        );
+        println!(
+            "  reasoning_effort       = {}",
+            cfg.reasoning_effort.as_deref().unwrap_or("<unset>")
+        );
+        println!("  sandbox                = {}", cfg.sandbox);
+        println!("  approval_policy        = {}", cfg.approval_policy);
+        println!("  mail_poll_interval_ms  = {}", cfg.mail_poll_interval_ms);
+        println!("  request_timeout_secs   = {}", cfg.request_timeout_secs);
+        println!("  max_concurrent_threads = {}", cfg.max_concurrent_threads);
+        println!("  persist_threads        = {}", cfg.persist_threads);
+        println!("  auto_mail              = {}", cfg.auto_mail);
+        println!(
+            "  base_prompt_file       = {}",
+            cfg.base_prompt_file.as_deref().unwrap_or("<unset>")
+        );
+        println!(
+            "  extra_instructions_file= {}",
+            cfg.extra_instructions_file.as_deref().unwrap_or("<unset>")
+        );
+
+        if cfg.roles.is_empty() {
+            println!("  roles                  = (none)");
+        } else {
+            println!("  roles:");
+            let mut role_names: Vec<&String> = cfg.roles.keys().collect();
+            role_names.sort();
+            for name in role_names {
+                let preset: &RolePreset = &cfg.roles[name];
+                println!("    [{name}]");
+                if let Some(ref m) = preset.model {
+                    println!("      model            = {m}");
+                }
+                if let Some(ref s) = preset.sandbox {
+                    println!("      sandbox          = {s}");
+                }
+                if let Some(ref a) = preset.approval_policy {
+                    println!("      approval_policy  = {a}");
+                }
+                if let Some(ref r) = preset.reasoning_effort {
+                    println!("      reasoning_effort = {r}");
+                }
+            }
+        }
+
+        // Also show ATM core config context
+        println!();
+        println!("atm core configuration:");
+        println!("  identity    = {}", resolved.core.identity);
+        println!("  team        = {}", resolved.core.default_team);
+    }
+
+    Ok(())
+}

--- a/crates/atm-agent-mcp/src/commands/mod.rs
+++ b/crates/atm-agent-mcp/src/commands/mod.rs
@@ -1,0 +1,8 @@
+//! Command implementations for atm-agent-mcp subcommands.
+//!
+//! Each module corresponds to a top-level subcommand exposed by the CLI.
+
+pub mod config_cmd;
+pub mod serve;
+pub mod sessions;
+pub mod summary;

--- a/crates/atm-agent-mcp/src/commands/serve.rs
+++ b/crates/atm-agent-mcp/src/commands/serve.rs
@@ -1,0 +1,16 @@
+//! `serve` subcommand — MCP proxy server (stub).
+//!
+//! Full implementation is planned for Sprint A.2+. This stub exists so the
+//! CLI structure and binary are buildable before the MCP protocol is wired up.
+
+use crate::cli::ServeArgs;
+
+/// Run the `serve` subcommand.
+///
+/// # Errors
+///
+/// Currently infallible. Returns `Ok(())` after printing a stub message.
+pub async fn run(_args: ServeArgs) -> anyhow::Result<()> {
+    println!("atm-agent-mcp serve: MCP proxy server not yet implemented (Sprint A.2+)");
+    Ok(())
+}

--- a/crates/atm-agent-mcp/src/commands/sessions.rs
+++ b/crates/atm-agent-mcp/src/commands/sessions.rs
@@ -1,0 +1,16 @@
+//! `sessions` subcommand — list and manage agent sessions (stub).
+//!
+//! Full session management is planned for Sprint A.3+. This stub returns an
+//! empty session list in JSON format.
+
+use crate::cli::SessionsArgs;
+
+/// Run the `sessions` subcommand.
+///
+/// # Errors
+///
+/// Currently infallible. Returns `Ok(())` after printing an empty session list.
+pub async fn run(_args: SessionsArgs) -> anyhow::Result<()> {
+    println!("[]");
+    Ok(())
+}

--- a/crates/atm-agent-mcp/src/commands/summary.rs
+++ b/crates/atm-agent-mcp/src/commands/summary.rs
@@ -1,0 +1,16 @@
+//! `summary` subcommand — display saved session summary (stub).
+//!
+//! Full session summary storage is planned for Sprint A.3+. This stub prints
+//! a placeholder message for the requested agent ID.
+
+use crate::cli::SummaryArgs;
+
+/// Run the `summary` subcommand.
+///
+/// # Errors
+///
+/// Currently infallible. Returns `Ok(())` after printing the stub message.
+pub async fn run(args: SummaryArgs) -> anyhow::Result<()> {
+    println!("No summary available for agent {}.", args.agent_id);
+    Ok(())
+}

--- a/crates/atm-agent-mcp/src/config/mod.rs
+++ b/crates/atm-agent-mcp/src/config/mod.rs
@@ -1,0 +1,13 @@
+//! Configuration resolution for atm-agent-mcp.
+//!
+//! The entry point is [`resolve_config`], which loads ATM base config and
+//! extracts the `[plugins.atm-agent-mcp]` section into an [`AgentMcpConfig`].
+//!
+//! See [`resolve`] for the full priority chain and [`types`] for all config types.
+
+mod resolve;
+mod types;
+
+pub use resolve::{resolve_config, ResolvedConfig};
+// Re-exported for use by command modules and future library consumers.
+pub use types::{AgentMcpConfig, RolePreset};

--- a/crates/atm-agent-mcp/src/config/resolve.rs
+++ b/crates/atm-agent-mcp/src/config/resolve.rs
@@ -1,0 +1,535 @@
+//! Config resolution for atm-agent-mcp.
+//!
+//! Resolves [`AgentMcpConfig`] from multiple sources with the following priority
+//! (highest to lowest):
+//!
+//! 1. CLI flags (applied by the caller after [`resolve_config`] returns)
+//! 2. Environment variables (`ATM_AGENT_MCP_*`)
+//! 3. Repo-local `.atm.toml` `[plugins.atm-agent-mcp]` section
+//! 4. Global `~/.config/atm/config.toml` `[plugins.atm-agent-mcp]` section
+//! 5. Compiled-in defaults (via [`AgentMcpConfig::default`])
+
+use super::types::AgentMcpConfig;
+use agent_team_mail_core::config::{resolve_config as core_resolve, ConfigOverrides, CoreConfig};
+use agent_team_mail_core::home::get_home_dir;
+use std::path::Path;
+
+/// Fully resolved configuration combining ATM core settings with plugin config.
+#[derive(Debug, Clone)]
+pub struct ResolvedConfig {
+    /// Plugin-specific MCP configuration
+    pub agent_mcp: AgentMcpConfig,
+    /// ATM core configuration (identity, team, etc.)
+    pub core: CoreConfig,
+}
+
+/// Resolve the complete configuration for atm-agent-mcp.
+///
+/// Loads ATM base config (`.atm.toml` + env + global config), extracts the
+/// `[plugins.atm-agent-mcp]` section into [`AgentMcpConfig`], and applies
+/// `ATM_AGENT_MCP_*` environment variable overrides.
+///
+/// # Arguments
+///
+/// * `config_path` – Optional explicit path to `.atm.toml`. When `None` the
+///   function searches from the current working directory up to the git root,
+///   then falls back to `~/.config/atm/config.toml`.
+///
+/// # Errors
+///
+/// Returns an error if the home directory cannot be determined or if an
+/// explicit `config_path` cannot be read.
+pub fn resolve_config(config_path: Option<&Path>) -> anyhow::Result<ResolvedConfig> {
+    let home_dir = get_home_dir()?;
+    let current_dir = std::env::current_dir()?;
+
+    let mut overrides = ConfigOverrides::default();
+    if let Some(path) = config_path {
+        overrides.config_path = Some(path.to_path_buf());
+    }
+
+    // When an explicit config path is given, use its parent directory as the
+    // search root so repo-local detection still works correctly.
+    let search_dir = if let Some(path) = config_path {
+        path.parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(|| current_dir.clone())
+    } else {
+        current_dir.clone()
+    };
+
+    let core_config = core_resolve(&overrides, &search_dir, &home_dir)?;
+
+    // Extract plugin config, falling back to defaults if the section is absent.
+    let mut agent_mcp = if let Some(table) = core_config.plugin_config("atm-agent-mcp") {
+        toml::Value::Table(table.clone())
+            .try_into::<AgentMcpConfig>()
+            .unwrap_or_default()
+    } else {
+        AgentMcpConfig::default()
+    };
+
+    apply_env_overrides(&mut agent_mcp);
+
+    Ok(ResolvedConfig {
+        agent_mcp,
+        core: core_config.core,
+    })
+}
+
+/// Apply `ATM_AGENT_MCP_*` environment variable overrides to `cfg`.
+///
+/// Empty string values are treated as "not set" and do not override existing
+/// configuration.
+fn apply_env_overrides(cfg: &mut AgentMcpConfig) {
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_IDENTITY") {
+        if !v.is_empty() {
+            cfg.identity = Some(v);
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_MODEL") {
+        if !v.is_empty() {
+            cfg.model = Some(v);
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_SANDBOX") {
+        if !v.is_empty() {
+            cfg.sandbox = v;
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_APPROVAL_POLICY") {
+        if !v.is_empty() {
+            cfg.approval_policy = v;
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_CODEX_BIN") {
+        if !v.is_empty() {
+            cfg.codex_bin = v;
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS") {
+        if let Ok(ms) = v.parse::<u64>() {
+            cfg.mail_poll_interval_ms = ms;
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_FAST_MODEL") {
+        if !v.is_empty() {
+            cfg.fast_model = Some(v);
+        }
+    }
+    if let Ok(v) = std::env::var("ATM_AGENT_MCP_REASONING_EFFORT") {
+        if !v.is_empty() {
+            cfg.reasoning_effort = Some(v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+
+    // ─── Default value tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_config_is_complete() {
+        let cfg = AgentMcpConfig::default();
+        // Verify the struct can be created and key fields exist
+        assert!(!cfg.codex_bin.is_empty());
+        assert!(!cfg.sandbox.is_empty());
+        assert!(!cfg.approval_policy.is_empty());
+    }
+
+    #[test]
+    fn test_default_codex_bin() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.codex_bin, "codex");
+    }
+
+    #[test]
+    fn test_default_sandbox() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.sandbox, "workspace-write");
+    }
+
+    #[test]
+    fn test_default_approval_policy() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.approval_policy, "on-failure");
+    }
+
+    #[test]
+    fn test_default_mail_poll_interval_ms() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.mail_poll_interval_ms, 5000);
+    }
+
+    #[test]
+    fn test_default_request_timeout_secs() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.request_timeout_secs, 300);
+    }
+
+    #[test]
+    fn test_default_max_concurrent_threads() {
+        let cfg = AgentMcpConfig::default();
+        assert_eq!(cfg.max_concurrent_threads, 10);
+    }
+
+    #[test]
+    fn test_default_persist_threads() {
+        let cfg = AgentMcpConfig::default();
+        assert!(cfg.persist_threads);
+    }
+
+    #[test]
+    fn test_default_auto_mail() {
+        let cfg = AgentMcpConfig::default();
+        assert!(cfg.auto_mail);
+    }
+
+    #[test]
+    fn test_default_optional_fields_are_none() {
+        let cfg = AgentMcpConfig::default();
+        assert!(cfg.identity.is_none());
+        assert!(cfg.model.is_none());
+        assert!(cfg.fast_model.is_none());
+        assert!(cfg.reasoning_effort.is_none());
+        assert!(cfg.base_prompt_file.is_none());
+        assert!(cfg.extra_instructions_file.is_none());
+    }
+
+    #[test]
+    fn test_default_roles_is_empty() {
+        let cfg = AgentMcpConfig::default();
+        assert!(cfg.roles.is_empty());
+    }
+
+    // ─── TOML deserialization tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_toml_full_deserialization() {
+        let toml_str = r#"
+codex_bin = "/usr/local/bin/codex"
+identity = "arch-ctm"
+model = "o3"
+fast_model = "o4-mini"
+reasoning_effort = "high"
+sandbox = "network-disabled"
+approval_policy = "never"
+mail_poll_interval_ms = 3000
+request_timeout_secs = 600
+max_concurrent_threads = 5
+persist_threads = false
+auto_mail = false
+base_prompt_file = "/tmp/base.md"
+extra_instructions_file = "/tmp/extra.md"
+"#;
+        let cfg: AgentMcpConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.codex_bin, "/usr/local/bin/codex");
+        assert_eq!(cfg.identity, Some("arch-ctm".to_string()));
+        assert_eq!(cfg.model, Some("o3".to_string()));
+        assert_eq!(cfg.fast_model, Some("o4-mini".to_string()));
+        assert_eq!(cfg.reasoning_effort, Some("high".to_string()));
+        assert_eq!(cfg.sandbox, "network-disabled");
+        assert_eq!(cfg.approval_policy, "never");
+        assert_eq!(cfg.mail_poll_interval_ms, 3000);
+        assert_eq!(cfg.request_timeout_secs, 600);
+        assert_eq!(cfg.max_concurrent_threads, 5);
+        assert!(!cfg.persist_threads);
+        assert!(!cfg.auto_mail);
+        assert_eq!(cfg.base_prompt_file, Some("/tmp/base.md".to_string()));
+        assert_eq!(cfg.extra_instructions_file, Some("/tmp/extra.md".to_string()));
+    }
+
+    #[test]
+    fn test_toml_partial_uses_defaults() {
+        // Only override a few fields; the rest should use defaults
+        let toml_str = r#"
+identity = "dev-agent"
+model = "claude-3-5-sonnet"
+"#;
+        let cfg: AgentMcpConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.identity, Some("dev-agent".to_string()));
+        assert_eq!(cfg.model, Some("claude-3-5-sonnet".to_string()));
+        // Defaults preserved
+        assert_eq!(cfg.codex_bin, "codex");
+        assert_eq!(cfg.sandbox, "workspace-write");
+        assert_eq!(cfg.approval_policy, "on-failure");
+        assert_eq!(cfg.mail_poll_interval_ms, 5000);
+        assert_eq!(cfg.request_timeout_secs, 300);
+        assert_eq!(cfg.max_concurrent_threads, 10);
+        assert!(cfg.persist_threads);
+        assert!(cfg.auto_mail);
+    }
+
+    #[test]
+    fn test_toml_empty_section_uses_all_defaults() {
+        let cfg: AgentMcpConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.codex_bin, "codex");
+        assert_eq!(cfg.sandbox, "workspace-write");
+        assert_eq!(cfg.approval_policy, "on-failure");
+        assert_eq!(cfg.mail_poll_interval_ms, 5000);
+    }
+
+    #[test]
+    fn test_role_presets_deserialization() {
+        let toml_str = r#"
+[roles.architect]
+model = "o3"
+reasoning_effort = "high"
+approval_policy = "never"
+
+[roles.qa]
+model = "claude-3-5-haiku"
+sandbox = "network-disabled"
+"#;
+        let cfg: AgentMcpConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.roles.len(), 2);
+
+        let arch = cfg.roles.get("architect").unwrap();
+        assert_eq!(arch.model, Some("o3".to_string()));
+        assert_eq!(arch.reasoning_effort, Some("high".to_string()));
+        assert_eq!(arch.approval_policy, Some("never".to_string()));
+        assert!(arch.sandbox.is_none());
+
+        let qa = cfg.roles.get("qa").unwrap();
+        assert_eq!(qa.model, Some("claude-3-5-haiku".to_string()));
+        assert_eq!(qa.sandbox, Some("network-disabled".to_string()));
+        assert!(qa.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn test_role_preset_all_none_fields() {
+        let toml_str = "[roles.empty]\n";
+        let cfg: AgentMcpConfig = toml::from_str(toml_str).unwrap();
+        let preset = cfg.roles.get("empty").unwrap();
+        assert!(preset.model.is_none());
+        assert!(preset.sandbox.is_none());
+        assert!(preset.approval_policy.is_none());
+        assert!(preset.reasoning_effort.is_none());
+    }
+
+    #[test]
+    fn test_json_round_trip() {
+        let original = AgentMcpConfig {
+            codex_bin: "my-codex".to_string(),
+            identity: Some("test-id".to_string()),
+            model: Some("gpt-4o".to_string()),
+            fast_model: None,
+            reasoning_effort: None,
+            sandbox: "workspace-write".to_string(),
+            approval_policy: "on-failure".to_string(),
+            mail_poll_interval_ms: 2000,
+            request_timeout_secs: 120,
+            max_concurrent_threads: 4,
+            persist_threads: false,
+            auto_mail: true,
+            base_prompt_file: None,
+            extra_instructions_file: None,
+            roles: std::collections::HashMap::new(),
+        };
+
+        let json = serde_json::to_string_pretty(&original).unwrap();
+        let restored: AgentMcpConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(original.codex_bin, restored.codex_bin);
+        assert_eq!(original.identity, restored.identity);
+        assert_eq!(original.model, restored.model);
+        assert_eq!(original.sandbox, restored.sandbox);
+        assert_eq!(original.approval_policy, restored.approval_policy);
+        assert_eq!(original.mail_poll_interval_ms, restored.mail_poll_interval_ms);
+        assert_eq!(original.request_timeout_secs, restored.request_timeout_secs);
+        assert_eq!(original.max_concurrent_threads, restored.max_concurrent_threads);
+        assert_eq!(original.persist_threads, restored.persist_threads);
+        assert_eq!(original.auto_mail, restored.auto_mail);
+    }
+
+    // ─── Environment variable override tests ────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_env_identity_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_IDENTITY");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_IDENTITY", "env-agent");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.identity, Some("env-agent".to_string()));
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_IDENTITY");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_model_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_MODEL");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_MODEL", "o3-mini");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.model, Some("o3-mini".to_string()));
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_MODEL");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_sandbox_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_SANDBOX");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_SANDBOX", "network-disabled");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.sandbox, "network-disabled");
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_SANDBOX");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_mail_poll_interval_numeric_parse() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS", "1500");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.mail_poll_interval_ms, 1500);
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_codex_bin_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_CODEX_BIN");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_CODEX_BIN", "/opt/bin/codex");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.codex_bin, "/opt/bin/codex");
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_CODEX_BIN");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_empty_env_does_not_override_identity() {
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_IDENTITY", "");
+        }
+        let cfg = AgentMcpConfig {
+            identity: Some("preset-identity".to_string()),
+            ..Default::default()
+        };
+        let mut cfg = cfg;
+        apply_env_overrides(&mut cfg);
+        // Empty string must not override the existing value
+        assert_eq!(cfg.identity, Some("preset-identity".to_string()));
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_IDENTITY");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_empty_env_does_not_override_sandbox() {
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_SANDBOX", "");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        // sandbox starts at default "workspace-write"
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.sandbox, "workspace-write");
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_SANDBOX");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalid_numeric_env_does_not_crash() {
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS", "not-a-number");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        apply_env_overrides(&mut cfg); // must not panic
+        // Value unchanged because parse failed
+        assert_eq!(cfg.mail_poll_interval_ms, 5000);
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_MAIL_POLL_INTERVAL_MS");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_fast_model_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_FAST_MODEL");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_FAST_MODEL", "o4-mini");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.fast_model, Some("o4-mini".to_string()));
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_FAST_MODEL");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_reasoning_effort_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_REASONING_EFFORT");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_REASONING_EFFORT", "medium");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.reasoning_effort, Some("medium".to_string()));
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_REASONING_EFFORT");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_approval_policy_override() {
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_APPROVAL_POLICY");
+        }
+        let mut cfg = AgentMcpConfig::default();
+        unsafe {
+            env::set_var("ATM_AGENT_MCP_APPROVAL_POLICY", "never");
+        }
+        apply_env_overrides(&mut cfg);
+        assert_eq!(cfg.approval_policy, "never");
+        unsafe {
+            env::remove_var("ATM_AGENT_MCP_APPROVAL_POLICY");
+        }
+    }
+}

--- a/crates/atm-agent-mcp/src/config/types.rs
+++ b/crates/atm-agent-mcp/src/config/types.rs
@@ -1,0 +1,159 @@
+//! Configuration types for atm-agent-mcp.
+//!
+//! [`AgentMcpConfig`] is deserialized from the `[plugins.atm-agent-mcp]` section
+//! of `.atm.toml`. [`RolePreset`] holds per-role model/sandbox/approval overrides.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Per-role model/sandbox/approval_policy overrides.
+///
+/// Role presets are defined under `[plugins.atm-agent-mcp.roles.<name>]` in `.atm.toml`
+/// and selected at runtime via `--role <name>`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RolePreset {
+    /// Model to use for this role
+    pub model: Option<String>,
+    /// Sandbox mode for this role
+    pub sandbox: Option<String>,
+    /// Approval policy for this role
+    pub approval_policy: Option<String>,
+    /// Reasoning effort level (e.g., "low", "medium", "high")
+    pub reasoning_effort: Option<String>,
+}
+
+/// Resolved atm-agent-mcp plugin configuration.
+///
+/// Deserialized from `[plugins.atm-agent-mcp]` section of `.atm.toml`.
+/// All fields have sensible defaults so a minimal or absent config section
+/// produces a fully functional configuration.
+///
+/// # Example `.atm.toml` section
+///
+/// ```toml
+/// [plugins.atm-agent-mcp]
+/// codex_bin = "/usr/local/bin/codex"
+/// identity = "arch-ctm"
+/// sandbox = "workspace-write"
+/// approval_policy = "on-failure"
+///
+/// [plugins.atm-agent-mcp.roles.architect]
+/// model = "o3"
+/// reasoning_effort = "high"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentMcpConfig {
+    /// Path to codex binary (default: `"codex"` from `PATH`)
+    #[serde(default = "default_codex_bin")]
+    pub codex_bin: String,
+
+    /// Default agent identity
+    #[serde(default)]
+    pub identity: Option<String>,
+
+    /// Model override (None = let Codex use its default)
+    #[serde(default)]
+    pub model: Option<String>,
+
+    /// Fast model for `--fast` flag
+    #[serde(default)]
+    pub fast_model: Option<String>,
+
+    /// Reasoning effort level
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+
+    /// Sandbox mode (default: `"workspace-write"`)
+    #[serde(default = "default_sandbox")]
+    pub sandbox: String,
+
+    /// Approval policy (default: `"on-failure"`)
+    #[serde(default = "default_approval_policy")]
+    pub approval_policy: String,
+
+    /// Mail poll interval in milliseconds (default: `5000`)
+    #[serde(default = "default_mail_poll_interval_ms")]
+    pub mail_poll_interval_ms: u64,
+
+    /// Request timeout in seconds (default: `300`)
+    #[serde(default = "default_request_timeout_secs")]
+    pub request_timeout_secs: u64,
+
+    /// Maximum concurrent agent threads (default: `10`)
+    #[serde(default = "default_max_concurrent_threads")]
+    pub max_concurrent_threads: usize,
+
+    /// Persist thread IDs to disk across restarts (default: `true`)
+    #[serde(default = "default_persist_threads")]
+    pub persist_threads: bool,
+
+    /// Enable automatic mail injection into Codex context (default: `true`)
+    #[serde(default = "default_auto_mail")]
+    pub auto_mail: bool,
+
+    /// Optional base prompt file path
+    #[serde(default)]
+    pub base_prompt_file: Option<String>,
+
+    /// Optional extra instructions file path
+    #[serde(default)]
+    pub extra_instructions_file: Option<String>,
+
+    /// Named role presets indexed by role name
+    #[serde(default)]
+    pub roles: HashMap<String, RolePreset>,
+}
+
+fn default_codex_bin() -> String {
+    "codex".to_string()
+}
+
+fn default_sandbox() -> String {
+    "workspace-write".to_string()
+}
+
+fn default_approval_policy() -> String {
+    "on-failure".to_string()
+}
+
+fn default_mail_poll_interval_ms() -> u64 {
+    5000
+}
+
+fn default_request_timeout_secs() -> u64 {
+    300
+}
+
+fn default_max_concurrent_threads() -> usize {
+    10
+}
+
+fn default_persist_threads() -> bool {
+    true
+}
+
+fn default_auto_mail() -> bool {
+    true
+}
+
+impl Default for AgentMcpConfig {
+    fn default() -> Self {
+        Self {
+            codex_bin: default_codex_bin(),
+            identity: None,
+            model: None,
+            fast_model: None,
+            reasoning_effort: None,
+            sandbox: default_sandbox(),
+            approval_policy: default_approval_policy(),
+            mail_poll_interval_ms: default_mail_poll_interval_ms(),
+            request_timeout_secs: default_request_timeout_secs(),
+            max_concurrent_threads: default_max_concurrent_threads(),
+            persist_threads: default_persist_threads(),
+            auto_mail: default_auto_mail(),
+            base_prompt_file: None,
+            extra_instructions_file: None,
+            roles: HashMap::new(),
+        }
+    }
+}

--- a/crates/atm-agent-mcp/src/main.rs
+++ b/crates/atm-agent-mcp/src/main.rs
@@ -1,0 +1,28 @@
+//! atm-agent-mcp — MCP proxy for Codex agent sessions with ATM team integration.
+//!
+//! # Subcommands
+//!
+//! - `serve`    — Start the MCP proxy server (Sprint A.2+)
+//! - `config`   — Show resolved configuration
+//! - `sessions` — List and manage agent sessions (Sprint A.3+)
+//! - `summary`  — Display saved session summary (Sprint A.3+)
+
+use clap::Parser;
+
+mod cli;
+mod commands;
+mod config;
+
+use cli::{Cli, Commands};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Serve(args) => commands::serve::run(args).await,
+        Commands::Config(args) => commands::config_cmd::run(&cli.config, args).await,
+        Commands::Sessions(args) => commands::sessions::run(args).await,
+        Commands::Summary(args) => commands::summary::run(args).await,
+    }
+}


### PR DESCRIPTION
## Sprint A.1: Crate Scaffold + Config

Creates the `crates/atm-agent-mcp/` binary crate — a new workspace member providing the MCP proxy CLI skeleton and full config resolution system.

## Deliverables

- **New crate `atm-agent-mcp`** added to workspace (`Cargo.toml` members)
- **CLI skeleton** (`clap` derive) with subcommands: `serve`, `config`, `sessions`, `summary`
- **`AgentMcpConfig`** struct with all 15 required fields (FR-12.1): `codex_bin`, `identity`, `model`, `fast_model`, `reasoning_effort`, `sandbox`, `approval_policy`, `mail_poll_interval_ms`, `request_timeout_secs`, `max_concurrent_threads`, `persist_threads`, `auto_mail`, `base_prompt_file`, `extra_instructions_file`, `roles`
- **`RolePreset`** struct with model/sandbox/approval_policy/reasoning_effort (FR-12.2)
- **Config resolution** (FR-12.3): env vars → .atm.toml → global config → defaults
- **8 env var overrides** per FR-12.6 table (`ATM_AGENT_MCP_*`)
- **High-level flags** on `serve`: `--fast`, `--subagents`, `--readonly`, `--explore` (FR-13.7)
- **`atm-agent-mcp config`** prints resolved config (text + `--json` mode)
- **Stubs** for `serve` (not implemented), `sessions` (empty list), `summary` (no summary)
- **28 unit tests** covering defaults, env overrides, TOML parsing, role presets, JSON round-trip

## Functional Requirements

- FR-12.1 through FR-12.6 (Configuration)
- FR-13.1 through FR-13.7 (CLI Interface — stubs for non-config commands)

## QA Results

Both QA agents passed on iteration 2 of 2:

**rust-qa-agent**: PASS
- `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test -p atm-agent-mcp`: 28/28 pass
- `cargo test --workspace`: 942 tests, 0 failures

**atm-qa-agent**: PASS
- All FR-12 and FR-13 requirements verified against implementation
- No blocking findings
- 3 minor findings addressed (doc comment updated, tracing dep added)

## Out of Scope (deferred to later sprints)

- MCP protocol handling (A.2)
- Identity binding + context injection (A.3)
- ATM communication tools (A.4)
- Session registry (A.5)
- Lifecycle state machine (A.6)
- Auto mail injection (A.7)
- Shutdown/resume/audit (A.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)