### PR TITLE
feat(atm-agent-mcp): Sprint A.2 — MCP stdio proxy core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/atm-agent-mcp/Cargo.toml
+++ b/crates/atm-agent-mcp/Cargo.toml
@@ -7,10 +7,15 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 description = "MCP proxy for managing Codex agent sessions with ATM team integration"
+default-run = "atm-agent-mcp"
 
 [[bin]]
 name = "atm-agent-mcp"
 path = "src/main.rs"
+
+[[bin]]
+name = "echo-mcp-server"
+path = "tests/fixtures/echo_mcp_server.rs"
 
 [dependencies]
 agent-team-mail-core.workspace = true
@@ -22,7 +27,9 @@ toml.workspace = true
 tokio = { version = "1", features = ["full"] }
 thiserror = "2"
 tracing = "0.1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+tokio = { version = "1", features = ["full", "test-util"] }

--- a/crates/atm-agent-mcp/src/framing.rs
+++ b/crates/atm-agent-mcp/src/framing.rs
@@ -1,0 +1,213 @@
+//! JSON-RPC message framing for MCP stdio transport.
+//!
+//! Supports two framing modes:
+//!
+//! - **Content-Length**: `Content-Length: N\r\n\r\n<N bytes>` (standard MCP stdio transport)
+//! - **Newline-delimited**: one JSON object per `\n`-terminated line (Codex child uses this)
+//!
+//! The proxy reads from upstream (Claude) using [`UpstreamReader`] which auto-detects
+//! framing. Messages are always written to the Codex child in newline-delimited format.
+
+use std::io;
+
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
+
+/// Reads MCP messages from an async reader, auto-detecting Content-Length vs newline framing.
+///
+/// On each call to [`UpstreamReader::next_message`], the reader peeks at incoming bytes:
+/// - If a line starts with `Content-Length:`, it parses the header and reads the body.
+/// - Otherwise it treats the line as a complete JSON message.
+pub struct UpstreamReader<R> {
+    reader: BufReader<R>,
+    buf: String,
+}
+
+impl<R: AsyncRead + Unpin> UpstreamReader<R> {
+    /// Create a new upstream reader wrapping the given async reader.
+    pub fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+            buf: String::new(),
+        }
+    }
+
+    /// Read the next JSON-RPC message, returning `None` on EOF.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error if reading fails or Content-Length parsing encounters
+    /// malformed headers.
+    pub async fn next_message(&mut self) -> io::Result<Option<String>> {
+        loop {
+            self.buf.clear();
+            let n = self.reader.read_line(&mut self.buf).await?;
+            if n == 0 {
+                return Ok(None); // EOF
+            }
+
+            let trimmed = self.buf.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            // Check if this is a Content-Length header
+            if let Some(rest) = trimmed.strip_prefix("Content-Length:") {
+                let len: usize = rest
+                    .trim()
+                    .parse()
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+                // Read until blank line (consume \r\n\r\n separator)
+                loop {
+                    self.buf.clear();
+                    let header_n = self.reader.read_line(&mut self.buf).await?;
+                    if header_n == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "EOF in Content-Length headers",
+                        ));
+                    }
+                    if self.buf.trim().is_empty() {
+                        break;
+                    }
+                    // Skip other headers (e.g. Content-Type)
+                }
+
+                // Read exactly `len` bytes of body
+                let mut body = vec![0u8; len];
+                self.reader.read_exact(&mut body).await?;
+                let msg =
+                    String::from_utf8(body).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                return Ok(Some(msg));
+            }
+
+            // Newline-delimited: the trimmed line IS the JSON message
+            return Ok(Some(trimmed.to_string()));
+        }
+    }
+}
+
+/// Write a JSON message in newline-delimited format to the given writer.
+///
+/// Appends `\n` and flushes. The `json` string must not contain embedded newlines.
+///
+/// # Errors
+///
+/// Returns an I/O error if writing or flushing fails.
+pub async fn write_newline_delimited<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    json: &str,
+) -> io::Result<()> {
+    writer.write_all(json.as_bytes()).await?;
+    writer.write_all(b"\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Encode a JSON message in Content-Length framing format.
+///
+/// Returns a `Vec<u8>` containing `Content-Length: N\r\n\r\n<body>`.
+pub fn encode_content_length(json: &str) -> Vec<u8> {
+    let header = format!("Content-Length: {}\r\n\r\n", json.len());
+    let mut buf = Vec::with_capacity(header.len() + json.len());
+    buf.extend_from_slice(header.as_bytes());
+    buf.extend_from_slice(json.as_bytes());
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_newline_delimited() {
+        let input = b"{\"jsonrpc\":\"2.0\",\"id\":1}\n";
+        let mut reader = UpstreamReader::new(&input[..]);
+        let msg = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(msg, "{\"jsonrpc\":\"2.0\",\"id\":1}");
+    }
+
+    #[tokio::test]
+    async fn test_parse_content_length_frame() {
+        let body = r#"{"jsonrpc":"2.0","id":2}"#;
+        let framed = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+        let mut reader = UpstreamReader::new(framed.as_bytes());
+        let msg = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(msg, body);
+    }
+
+    #[tokio::test]
+    async fn test_parse_content_length_with_extra_header() {
+        let body = r#"{"jsonrpc":"2.0","id":3}"#;
+        let framed = format!(
+            "Content-Length: {}\r\nContent-Type: application/json\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let mut reader = UpstreamReader::new(framed.as_bytes());
+        let msg = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(msg, body);
+    }
+
+    #[tokio::test]
+    async fn test_parse_partial_content_length() {
+        // Body is split in the underlying stream but read_exact handles it
+        let body = r#"{"jsonrpc":"2.0","method":"test"}"#;
+        let framed = format!("Content-Length: {}\r\n\r\n{}", body.len(), body);
+        let mut reader = UpstreamReader::new(framed.as_bytes());
+        let msg = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(msg, body);
+    }
+
+    #[tokio::test]
+    async fn test_parse_multiple_newline_messages() {
+        let input = b"{\"id\":1}\n{\"id\":2}\n{\"id\":3}\n";
+        let mut reader = UpstreamReader::new(&input[..]);
+        assert_eq!(
+            reader.next_message().await.unwrap().unwrap(),
+            "{\"id\":1}"
+        );
+        assert_eq!(
+            reader.next_message().await.unwrap().unwrap(),
+            "{\"id\":2}"
+        );
+        assert_eq!(
+            reader.next_message().await.unwrap().unwrap(),
+            "{\"id\":3}"
+        );
+        assert!(reader.next_message().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_write_newline_delimited() {
+        let mut buf = Vec::new();
+        write_newline_delimited(&mut buf, r#"{"id":1}"#)
+            .await
+            .unwrap();
+        assert_eq!(buf, b"{\"id\":1}\n");
+    }
+
+    #[tokio::test]
+    async fn test_content_length_frame_roundtrip() {
+        let original = r#"{"jsonrpc":"2.0","id":99,"method":"ping"}"#;
+        let encoded = encode_content_length(original);
+        let mut reader = UpstreamReader::new(&encoded[..]);
+        let decoded = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(decoded, original);
+    }
+
+    #[tokio::test]
+    async fn test_eof_returns_none() {
+        let input = b"";
+        let mut reader = UpstreamReader::new(&input[..]);
+        assert!(reader.next_message().await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_blank_lines_skipped() {
+        let input = b"\n\n{\"id\":1}\n\n";
+        let mut reader = UpstreamReader::new(&input[..]);
+        let msg = reader.next_message().await.unwrap().unwrap();
+        assert_eq!(msg, "{\"id\":1}");
+    }
+}

--- a/crates/atm-agent-mcp/src/lib.rs
+++ b/crates/atm-agent-mcp/src/lib.rs
@@ -1,0 +1,12 @@
+//! atm-agent-mcp library crate.
+//!
+//! Provides the MCP proxy core, framing, tool schemas, configuration, and CLI
+//! types for the `atm-agent-mcp` binary. Exposed as a library for integration
+//! testing and potential reuse.
+
+pub mod cli;
+pub mod commands;
+pub mod config;
+pub mod framing;
+pub mod proxy;
+pub mod tools;

--- a/crates/atm-agent-mcp/src/main.rs
+++ b/crates/atm-agent-mcp/src/main.rs
@@ -9,11 +9,8 @@
 
 use clap::Parser;
 
-mod cli;
-mod commands;
-mod config;
-
-use cli::{Cli, Commands};
+use atm_agent_mcp::cli::{Cli, Commands};
+use atm_agent_mcp::commands;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/crates/atm-agent-mcp/src/proxy.rs
+++ b/crates/atm-agent-mcp/src/proxy.rs
@@ -1,0 +1,811 @@
+//! MCP stdio proxy core.
+//!
+//! [`ProxyServer`] sits between Claude (upstream, on stdin/stdout) and a single
+//! `codex mcp-server` child process (downstream). It:
+//!
+//! - Auto-detects Content-Length vs newline-delimited framing on the upstream side
+//! - Writes newline-delimited JSON to the child (Codex convention)
+//! - Intercepts `tools/list` responses to append synthetic ATM tool schemas
+//! - Forwards `codex/event` notifications upstream with an `agent_id` tag
+//! - Lazily spawns the child on first `codex` or `codex-reply` tool call
+//! - Detects child crashes and returns structured JSON-RPC errors
+//! - Applies configurable per-request timeouts
+//! - Sends `notifications/cancelled` to the child when a request times out
+//!
+//! This module implements the Sprint A.2 proxy core. Identity binding, session
+//! registry, and ATM tool execution are deferred to later sprints.
+
+use std::collections::HashMap;
+use std::process::ExitStatus;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::time::{Duration, timeout};
+
+use crate::config::AgentMcpConfig;
+use crate::framing::{UpstreamReader, write_newline_delimited};
+use crate::tools::synthetic_tools;
+
+/// Channel buffer capacity for upstream message delivery.
+///
+/// Sized to handle burst of MCP responses without backpressure.
+const UPSTREAM_CHANNEL_CAPACITY: usize = 256;
+
+/// Grace period in ms after dropping child stdin before force-kill, giving child time to flush output.
+const CHILD_DRAIN_GRACE_MS: u64 = 100;
+
+/// JSON-RPC error code: child process has died.
+pub const ERR_CHILD_DEAD: i64 = -32005;
+
+/// JSON-RPC error code: request timed out.
+pub const ERR_TIMEOUT: i64 = -32006;
+
+/// JSON-RPC error code: method not found.
+pub const ERR_METHOD_NOT_FOUND: i64 = -32601;
+
+/// JSON-RPC error code: internal error.
+pub const ERR_INTERNAL: i64 = -32603;
+
+/// Manages the MCP proxy lifecycle: upstream I/O, child process, and message routing.
+#[derive(Debug)]
+pub struct ProxyServer {
+    config: AgentMcpConfig,
+    child: Option<ChildHandle>,
+    /// Counter of event notifications dropped due to backpressure.
+    pub dropped_events: Arc<AtomicU64>,
+}
+
+/// Handle to the spawned Codex child process.
+struct ChildHandle {
+    /// Shared stdin writer; shared so timeout tasks can send cancellation notifications.
+    stdin: Arc<Mutex<ChildStdin>>,
+    /// Receives responses and notifications from the child stdout reader task.
+    response_rx: mpsc::Receiver<Value>,
+    /// If the child has exited, contains the exit status.
+    exit_status: Arc<Mutex<Option<ExitStatus>>>,
+    /// The child process handle, kept for force-kill on shutdown.
+    process: Arc<Mutex<Option<Child>>>,
+}
+
+impl std::fmt::Debug for ChildHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChildHandle")
+            .field("stdin", &"<ChildStdin>")
+            .field("response_rx", &"<Receiver>")
+            .field("exit_status", &"<Mutex<Option<ExitStatus>>>")
+            .field("process", &"<Mutex<Option<Child>>>")
+            .finish()
+    }
+}
+
+/// Tracks in-flight requests waiting for a response from the child.
+struct PendingRequests {
+    map: HashMap<Value, oneshot::Sender<Value>>,
+    /// Request IDs that correspond to `tools/list` requests and need interception.
+    tools_list_ids: std::collections::HashSet<Value>,
+}
+
+impl PendingRequests {
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            tools_list_ids: std::collections::HashSet::new(),
+        }
+    }
+
+    fn insert(&mut self, id: Value, tx: oneshot::Sender<Value>) {
+        self.map.insert(id, tx);
+    }
+
+    fn mark_tools_list(&mut self, id: Value) {
+        self.tools_list_ids.insert(id);
+    }
+
+    fn is_tools_list(&self, id: &Value) -> bool {
+        self.tools_list_ids.contains(id)
+    }
+
+    fn complete(&mut self, id: &Value) -> Option<oneshot::Sender<Value>> {
+        self.tools_list_ids.remove(id);
+        self.map.remove(id)
+    }
+}
+
+impl ProxyServer {
+    /// Create a new proxy server with the given configuration.
+    pub fn new(config: AgentMcpConfig) -> Self {
+        Self {
+            config,
+            child: None,
+            dropped_events: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Run the proxy loop, reading from `upstream_in` and writing to `upstream_out`.
+    ///
+    /// This is the main entry point. It blocks until upstream EOF or a fatal error.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on unrecoverable I/O failures. Transient errors (child crash,
+    /// timeout) are reported as JSON-RPC error responses to the upstream client.
+    pub async fn run<R, W>(
+        &mut self,
+        upstream_in: R,
+        mut upstream_out: W,
+    ) -> anyhow::Result<()>
+    where
+        R: AsyncRead + Unpin + Send + 'static,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        let mut reader = UpstreamReader::new(upstream_in);
+        let pending = Arc::new(Mutex::new(PendingRequests::new()));
+        let dropped = Arc::clone(&self.dropped_events);
+
+        // Channel for upstream writes (events + responses routed through the channel).
+        // Bounded to prevent unbounded memory growth under backpressure.
+        let (upstream_tx, mut upstream_rx) = mpsc::channel::<Value>(UPSTREAM_CHANNEL_CAPACITY);
+
+        loop {
+            tokio::select! {
+                // Read from upstream stdin
+                result = reader.next_message() => {
+                    let raw = match result? {
+                        Some(r) => r,
+                        None => {
+                            tracing::info!("upstream EOF, shutting down proxy");
+                            break;
+                        }
+                    };
+
+                    let msg: Value = match serde_json::from_str(&raw) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            tracing::warn!("failed to parse upstream JSON: {e}");
+                            continue;
+                        }
+                    };
+
+                    tracing::debug!(direction = "upstream->proxy", %msg);
+
+                    let method = msg.get("method").and_then(|v| v.as_str()).map(String::from);
+                    let id = msg.get("id").cloned();
+
+                    match method.as_deref() {
+                        Some("tools/call") => {
+                            self.handle_tools_call(msg, &pending, &upstream_tx, &dropped)
+                                .await;
+                        }
+                        Some(method_name) => {
+                            let is_tools_list = method_name == "tools/list";
+                            self.forward_to_child(msg, id, is_tools_list, &pending, &upstream_tx)
+                                .await;
+                        }
+                        None => {
+                            // Response from upstream (e.g. elicitation response)
+                            if let Some(ref handle) = self.child {
+                                let mut stdin = handle.stdin.lock().await;
+                                let serialized = serde_json::to_string(&msg).unwrap_or_default();
+                                if let Err(e) =
+                                    write_newline_delimited(&mut *stdin, &serialized).await
+                                {
+                                    tracing::warn!("failed to write response to child: {e}");
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Read from child (server-initiated requests like elicitation)
+                msg = async {
+                    if let Some(ref mut handle) = self.child {
+                        handle.response_rx.recv().await
+                    } else {
+                        std::future::pending::<Option<Value>>().await
+                    }
+                } => {
+                    if let Some(msg) = msg {
+                        route_child_message(msg, &pending, &upstream_tx, &dropped).await;
+                    }
+                }
+
+                // Drain upstream write channel
+                Some(msg) = upstream_rx.recv() => {
+                    let serialized = serde_json::to_string(&msg).unwrap_or_default();
+                    let frame = crate::framing::encode_content_length(&serialized);
+                    if upstream_out.write_all(&frame).await.is_err() {
+                        break;
+                    }
+                    if upstream_out.flush().await.is_err() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Shutdown: signal child and force-kill if it ignores stdin EOF
+        if let Some(handle) = self.child.take() {
+            // Drop stdin to signal EOF to child
+            drop(handle.stdin);
+            // Grace period: give child time to flush output
+            tokio::time::sleep(Duration::from_millis(CHILD_DRAIN_GRACE_MS)).await;
+            // Ensure child terminates even if it ignored stdin EOF
+            if let Some(mut child) = handle.process.lock().await.take() {
+                let _ = child.kill().await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Forward a non-tools/call request or notification to the child.
+    async fn forward_to_child(
+        &mut self,
+        msg: Value,
+        id: Option<Value>,
+        is_tools_list: bool,
+        pending: &Arc<Mutex<PendingRequests>>,
+        upstream_tx: &mpsc::Sender<Value>,
+    ) {
+        if let Some(ref handle) = self.child {
+            let serialized = serde_json::to_string(&msg).unwrap_or_default();
+            let mut stdin = handle.stdin.lock().await;
+            if let Err(e) = write_newline_delimited(&mut *stdin, &serialized).await {
+                tracing::warn!("failed to write to child stdin: {e}");
+            }
+            drop(stdin);
+
+            if let Some(req_id) = id {
+                let (tx, rx) = oneshot::channel();
+                {
+                    let mut guard = pending.lock().await;
+                    guard.insert(req_id.clone(), tx);
+                    if is_tools_list {
+                        guard.mark_tools_list(req_id.clone());
+                    }
+                }
+
+                let upstream_tx_clone = upstream_tx.clone();
+                tokio::spawn(async move {
+                    match rx.await {
+                        Ok(resp) => {
+                            let _ = upstream_tx_clone.send(resp).await;
+                        }
+                        Err(_) => {
+                            tracing::debug!("pending request dropped (child may have died)");
+                        }
+                    }
+                });
+            }
+        } else if let Some(req_id) = id {
+            let err = make_error_response(
+                req_id,
+                ERR_INTERNAL,
+                "Child process not yet spawned",
+                json!({"error_source": "proxy"}),
+            );
+            let _ = upstream_tx.send(err).await;
+        }
+    }
+
+    /// Handle a `tools/call` request from upstream.
+    async fn handle_tools_call(
+        &mut self,
+        msg: Value,
+        pending: &Arc<Mutex<PendingRequests>>,
+        upstream_tx: &mpsc::Sender<Value>,
+        dropped: &Arc<AtomicU64>,
+    ) {
+        let id = msg.get("id").cloned().unwrap_or(Value::Null);
+        let tool_name = msg
+            .pointer("/params/name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        // Check if this is a synthetic ATM tool call
+        if is_synthetic_tool(tool_name) {
+            let resp = self.handle_synthetic_tool(&id, tool_name);
+            let _ = upstream_tx.send(resp).await;
+            return;
+        }
+
+        let is_codex_tool =
+            tool_name == "codex" || tool_name == "codex-reply";
+
+        // Lazy spawn child on first codex/codex-reply
+        if is_codex_tool && self.child.is_none() {
+            tracing::info!("lazy-spawning Codex child process");
+            match self.spawn_child(pending, upstream_tx, dropped).await {
+                Ok(()) => {}
+                Err(e) => {
+                    tracing::error!("failed to spawn child: {e}");
+                    let err = make_error_response(
+                        id,
+                        ERR_CHILD_DEAD,
+                        &format!("Failed to spawn Codex child: {e}"),
+                        json!({"error_source": "proxy"}),
+                    );
+                    let _ = upstream_tx.send(err).await;
+                    return;
+                }
+            }
+        }
+
+        // Check child health
+        if let Some(ref handle) = self.child {
+            let status = handle.exit_status.lock().await;
+            if let Some(exit) = &*status {
+                let code = exit.code().unwrap_or(-1);
+                tracing::warn!("child process is dead (exit code: {code})");
+                let err = make_error_response(
+                    id,
+                    ERR_CHILD_DEAD,
+                    &format!("Codex child process died (exit code: {code})"),
+                    json!({"error_source": "proxy", "exit_code": code}),
+                );
+                let _ = upstream_tx.send(err).await;
+                return;
+            }
+        }
+
+        let Some(ref handle) = self.child else {
+            let err = make_error_response(
+                id.clone(),
+                ERR_INTERNAL,
+                "Child process not available",
+                json!({"error_source": "proxy"}),
+            );
+            let _ = upstream_tx.send(err).await;
+            return;
+        };
+
+        // Forward to child
+        let serialized = serde_json::to_string(&msg).unwrap_or_default();
+        {
+            let mut stdin = handle.stdin.lock().await;
+            if let Err(e) = write_newline_delimited(&mut *stdin, &serialized).await {
+                tracing::error!("failed to write to child: {e}");
+                let err = make_error_response(
+                    id,
+                    ERR_CHILD_DEAD,
+                    &format!("Failed to write to child: {e}"),
+                    json!({"error_source": "proxy"}),
+                );
+                let _ = upstream_tx.send(err).await;
+                return;
+            }
+        }
+
+        // Register pending request with timeout
+        let (tx, rx) = oneshot::channel();
+        pending.lock().await.insert(id.clone(), tx);
+
+        let timeout_secs = self.config.request_timeout_secs;
+        let upstream_tx_clone = upstream_tx.clone();
+        let req_id = id;
+        // Clone the shared stdin so the timeout task can send a cancellation notification
+        let child_stdin = Arc::clone(&handle.stdin);
+
+        tokio::spawn(async move {
+            match timeout(Duration::from_secs(timeout_secs), rx).await {
+                Ok(Ok(resp)) => {
+                    let _ = upstream_tx_clone.send(resp).await;
+                }
+                Ok(Err(_)) => {
+                    // Sender dropped (child died)
+                    tracing::debug!("pending request canceled (child died)");
+                }
+                Err(_elapsed) => {
+                    tracing::warn!("request timed out after {timeout_secs}s");
+                    // Best-effort: send notifications/cancelled to child (FR-14.2).
+                    // Ignore any error — child may already be dead.
+                    let cancel = json!({
+                        "jsonrpc": "2.0",
+                        "method": "notifications/cancelled",
+                        "params": {"requestId": req_id}
+                    });
+                    if let Ok(serialized) = serde_json::to_string(&cancel) {
+                        let mut stdin = child_stdin.lock().await;
+                        let _ = write_newline_delimited(&mut *stdin, &serialized).await;
+                    }
+                    let err = make_error_response(
+                        req_id,
+                        ERR_TIMEOUT,
+                        &format!("Request timed out after {timeout_secs}s"),
+                        json!({"error_source": "proxy"}),
+                    );
+                    let _ = upstream_tx_clone.send(err).await;
+                }
+            }
+        });
+    }
+
+    /// Handle a synthetic tool call (ATM tools, session management).
+    ///
+    /// For Sprint A.2 these return stub "not implemented" errors.
+    fn handle_synthetic_tool(&self, id: &Value, tool_name: &str) -> Value {
+        json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": format!("Tool '{tool_name}' is not yet implemented (Sprint A.4+)")
+                }],
+                "isError": true
+            }
+        })
+    }
+
+    /// Spawn the Codex child process.
+    async fn spawn_child(
+        &mut self,
+        pending: &Arc<Mutex<PendingRequests>>,
+        upstream_tx: &mpsc::Sender<Value>,
+        dropped: &Arc<AtomicU64>,
+    ) -> anyhow::Result<()> {
+        let mut cmd = Command::new(&self.config.codex_bin);
+        cmd.arg("mcp-server");
+
+        // Pass model if configured
+        if let Some(ref model) = self.config.model {
+            cmd.arg("-m").arg(model);
+        }
+
+        cmd.stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null());
+
+        let mut child: Child = cmd.spawn()?;
+
+        let stdin = child.stdin.take().expect("child stdin must be piped");
+        let stdout = child.stdout.take().expect("child stdout must be piped");
+
+        let exit_status: Arc<Mutex<Option<ExitStatus>>> = Arc::new(Mutex::new(None));
+
+        // Wrap stdin in Arc<Mutex> so it can be shared with timeout tasks for cancellation
+        let shared_stdin = Arc::new(Mutex::new(stdin));
+
+        // Wrap the child process so we can force-kill on shutdown
+        let process: Arc<Mutex<Option<Child>>> = Arc::new(Mutex::new(Some(child)));
+
+        // Channel for messages from child stdout reader
+        let (child_tx, child_rx) = mpsc::channel::<Value>(UPSTREAM_CHANNEL_CAPACITY);
+
+        // Spawn child stdout reader task
+        let pending_clone = Arc::clone(pending);
+        let upstream_tx_clone = upstream_tx.clone();
+        let dropped_clone = Arc::clone(dropped);
+        tokio::spawn(async move {
+            let reader = tokio::io::BufReader::new(stdout);
+            let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                let msg: Value = match serde_json::from_str(&line) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!("failed to parse child output: {e}");
+                        continue;
+                    }
+                };
+
+                tracing::debug!(direction = "child->proxy", %msg);
+
+                let method = msg.get("method").and_then(|v| v.as_str());
+
+                if method == Some("codex/event") {
+                    // Add agent_id to event params and forward upstream
+                    let mut event = msg;
+                    forward_event(&mut event, &upstream_tx_clone, &dropped_clone);
+                    continue;
+                }
+
+                // Check if this is a response (has id, has result or error, no method)
+                if method.is_none() {
+                    if let Some(resp_id) = msg.get("id") {
+                        let mut pending_guard = pending_clone.lock().await;
+                        let is_tl = pending_guard.is_tools_list(resp_id);
+                        if let Some(tx) = pending_guard.complete(resp_id) {
+                            let mut resp = msg;
+                            if is_tl {
+                                intercept_tools_list(&mut resp);
+                            }
+                            let _ = tx.send(resp);
+                            continue;
+                        }
+                    }
+                }
+
+                // For server-initiated requests from child (e.g. elicitation/create),
+                // forward to upstream
+                if method.is_some() {
+                    let _ = child_tx.send(msg).await;
+                    continue;
+                }
+
+                // Unmatched response — forward anyway
+                let _ = child_tx.send(msg).await;
+            }
+
+            tracing::info!("child stdout reader exited");
+        });
+
+        // Spawn child wait task to detect crashes
+        let exit_clone = Arc::clone(&exit_status);
+        let pending_crash = Arc::clone(pending);
+        let process_clone = Arc::clone(&process);
+        tokio::spawn(async move {
+            // Take the Child out of the Arc so we can call .wait() on it
+            let child_opt = process_clone.lock().await.take();
+            if let Some(mut child) = child_opt {
+                match child.wait().await {
+                    Ok(s) => {
+                        tracing::info!("child process exited: {s}");
+                        *exit_clone.lock().await = Some(s);
+                    }
+                    Err(e) => {
+                        tracing::error!("error waiting for child: {e}");
+                    }
+                }
+            }
+            // Cancel all pending requests
+            let mut guard = pending_crash.lock().await;
+            // Drop all senders to notify waiters
+            guard.map.clear();
+        });
+
+        self.child = Some(ChildHandle {
+            stdin: shared_stdin,
+            response_rx: child_rx,
+            exit_status,
+            process,
+        });
+
+        Ok(())
+    }
+
+}
+
+/// Forward a `codex/event` notification upstream, injecting `agent_id` into params.
+///
+/// This is a best-effort send: if the upstream channel is full the event is dropped
+/// and the `dropped_events` counter is incremented.
+fn forward_event(
+    event: &mut Value,
+    upstream_tx: &mpsc::Sender<Value>,
+    dropped_events: &Arc<AtomicU64>,
+) {
+    if let Some(params) = event.get_mut("params") {
+        if let Some(obj) = params.as_object_mut() {
+            obj.insert(
+                "agent_id".to_string(),
+                Value::String("proxy:default".to_string()),
+            );
+        }
+    }
+    match upstream_tx.try_send(event.clone()) {
+        Ok(()) => {}
+        Err(_) => {
+            dropped_events.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Route a message received from the child to the appropriate destination.
+///
+/// This is a free function rather than a method to avoid borrow conflicts with
+/// the `ProxyServer`'s mutable child handle.
+async fn route_child_message(
+    msg: Value,
+    pending: &Arc<Mutex<PendingRequests>>,
+    upstream_tx: &mpsc::Sender<Value>,
+    dropped: &Arc<AtomicU64>,
+) {
+    let method = msg.get("method").and_then(|v| v.as_str());
+
+    if method == Some("codex/event") {
+        let mut event = msg;
+        forward_event(&mut event, upstream_tx, dropped);
+        return;
+    }
+
+    // Response — route to pending request
+    if method.is_none() {
+        if let Some(resp_id) = msg.get("id") {
+            let mut guard = pending.lock().await;
+            let is_tl = guard.is_tools_list(resp_id);
+            if let Some(tx) = guard.complete(resp_id) {
+                let mut resp = msg;
+                if is_tl {
+                    intercept_tools_list(&mut resp);
+                }
+                let _ = tx.send(resp);
+                return;
+            }
+        }
+    }
+
+    // Anything else (server-initiated request) — forward upstream
+    let _ = upstream_tx.send(msg).await;
+}
+
+/// Intercept a `tools/list` response to append synthetic ATM tools.
+///
+/// This is called on responses from the child that match a `tools/list` request.
+/// The function mutates the response in-place, appending synthetic tools to
+/// `result.tools`.
+pub fn intercept_tools_list(response: &mut Value) {
+    if let Some(tools_array) = response
+        .pointer_mut("/result/tools")
+        .and_then(|v| v.as_array_mut())
+    {
+        for tool in synthetic_tools() {
+            tools_array.push(tool);
+        }
+    }
+}
+
+/// Check whether a tool name belongs to the synthetic ATM tool set.
+fn is_synthetic_tool(name: &str) -> bool {
+    matches!(
+        name,
+        "atm_send"
+            | "atm_read"
+            | "atm_broadcast"
+            | "atm_pending_count"
+            | "agent_sessions"
+            | "agent_status"
+            | "agent_close"
+    )
+}
+
+/// Construct a JSON-RPC error response.
+pub fn make_error_response(id: Value, code: i64, message: &str, data: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "error": {
+            "code": code,
+            "message": message,
+            "data": data
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_intercept_tools_list_appends_synthetic() {
+        let mut response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "tools": [
+                    {"name": "codex", "inputSchema": {}},
+                    {"name": "codex-reply", "inputSchema": {}}
+                ]
+            }
+        });
+        intercept_tools_list(&mut response);
+        let tools = response["result"]["tools"].as_array().unwrap();
+        // 2 original + 7 synthetic
+        assert_eq!(tools.len(), 9);
+    }
+
+    #[test]
+    fn test_intercept_preserves_original_tools() {
+        let mut response = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "tools": [
+                    {"name": "codex", "inputSchema": {}},
+                    {"name": "codex-reply", "inputSchema": {}}
+                ]
+            }
+        });
+        intercept_tools_list(&mut response);
+        let tools = response["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools
+            .iter()
+            .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+            .collect();
+        assert!(names.contains(&"codex"));
+        assert!(names.contains(&"codex-reply"));
+    }
+
+    #[test]
+    fn test_is_synthetic_tool() {
+        assert!(is_synthetic_tool("atm_send"));
+        assert!(is_synthetic_tool("atm_read"));
+        assert!(is_synthetic_tool("agent_close"));
+        assert!(!is_synthetic_tool("codex"));
+        assert!(!is_synthetic_tool("codex-reply"));
+        assert!(!is_synthetic_tool("unknown"));
+    }
+
+    #[test]
+    fn test_make_error_response_structure() {
+        let resp = make_error_response(
+            json!(42),
+            ERR_TIMEOUT,
+            "timed out",
+            json!({"error_source": "proxy"}),
+        );
+        assert_eq!(resp["jsonrpc"], "2.0");
+        assert_eq!(resp["id"], 42);
+        assert_eq!(resp["error"]["code"], ERR_TIMEOUT);
+        assert_eq!(resp["error"]["message"], "timed out");
+        assert_eq!(resp["error"]["data"]["error_source"], "proxy");
+    }
+
+    #[test]
+    fn test_make_error_child_dead() {
+        let resp = make_error_response(
+            json!(1),
+            ERR_CHILD_DEAD,
+            "Codex child process died (exit code: 1)",
+            json!({"error_source": "proxy", "exit_code": 1}),
+        );
+        assert_eq!(resp["error"]["code"], ERR_CHILD_DEAD);
+        assert_eq!(resp["error"]["data"]["exit_code"], 1);
+    }
+
+    #[test]
+    fn test_forward_event_injects_agent_id() {
+        let (tx, mut rx) = mpsc::channel::<Value>(8);
+        let dropped = Arc::new(AtomicU64::new(0));
+        let mut event = json!({
+            "jsonrpc": "2.0",
+            "method": "codex/event",
+            "params": {"type": "task_started"}
+        });
+        forward_event(&mut event, &tx, &dropped);
+        let received = rx.try_recv().expect("event should be forwarded");
+        assert_eq!(received["params"]["agent_id"], "proxy:default");
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn test_forward_event_drops_on_full_channel() {
+        // Channel capacity of 0 is not valid; use capacity 1 and fill it first
+        let (tx, _rx) = mpsc::channel::<Value>(1);
+        let dropped = Arc::new(AtomicU64::new(0));
+
+        // Fill the channel
+        let filler = json!({"fill": true});
+        let _ = tx.try_send(filler);
+
+        // Now the channel is full — forward_event should drop and increment counter
+        let mut event = json!({
+            "jsonrpc": "2.0",
+            "method": "codex/event",
+            "params": {"type": "task_started"}
+        });
+        forward_event(&mut event, &tx, &dropped);
+        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_proxy_server_debug() {
+        let config = crate::config::AgentMcpConfig::default();
+        let proxy = ProxyServer::new(config);
+        // Verify Debug is implemented (compile-time check; format output is not asserted)
+        let _ = format!("{proxy:?}");
+    }
+
+    #[test]
+    fn test_constants() {
+        assert_eq!(UPSTREAM_CHANNEL_CAPACITY, 256);
+        assert_eq!(CHILD_DRAIN_GRACE_MS, 100);
+    }
+}

--- a/crates/atm-agent-mcp/src/tools.rs
+++ b/crates/atm-agent-mcp/src/tools.rs
@@ -1,0 +1,177 @@
+//! Synthetic MCP tool definitions for ATM integration.
+//!
+//! These tool schemas are appended to `tools/list` responses from the Codex child,
+//! making ATM messaging and session management tools available to Claude alongside
+//! the native `codex` and `codex-reply` tools.
+//!
+//! Tool implementations are stubbed for Sprint A.2 (schemas only). Actual execution
+//! logic will be added in Sprint A.4+.
+
+use serde_json::{Value, json};
+
+/// Number of synthetic tools that the proxy appends to `tools/list` responses.
+pub const SYNTHETIC_TOOL_COUNT: usize = 7;
+
+/// Return all synthetic tool definitions as JSON values.
+///
+/// These are appended to the `result.tools` array in `tools/list` responses
+/// from the child process.
+pub fn synthetic_tools() -> Vec<Value> {
+    vec![
+        atm_send_schema(),
+        atm_read_schema(),
+        atm_broadcast_schema(),
+        atm_pending_count_schema(),
+        agent_sessions_schema(),
+        agent_status_schema(),
+        agent_close_schema(),
+    ]
+}
+
+fn atm_send_schema() -> Value {
+    json!({
+        "name": "atm_send",
+        "description": "Send a message to an ATM team member",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "to": {"type": "string", "description": "Recipient agent name or agent@team"},
+                "message": {"type": "string", "description": "Message text"},
+                "summary": {"type": "string", "description": "Optional message summary"},
+                "identity": {"type": "string", "description": "Explicit sender identity (required outside thread context)"}
+            },
+            "required": ["to", "message"]
+        }
+    })
+}
+
+fn atm_read_schema() -> Value {
+    json!({
+        "name": "atm_read",
+        "description": "Read unread ATM messages from inbox",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "all": {"type": "boolean", "description": "Include already-read messages (default: false)"},
+                "mark_read": {"type": "boolean", "description": "Mark returned messages as read (default: true)"},
+                "limit": {"type": "integer", "description": "Max messages to return"},
+                "since": {"type": "string", "description": "ISO 8601 timestamp filter"},
+                "from": {"type": "string", "description": "Filter by sender name"},
+                "identity": {"type": "string", "description": "Explicit identity (required outside thread context)"}
+            }
+        }
+    })
+}
+
+fn atm_broadcast_schema() -> Value {
+    json!({
+        "name": "atm_broadcast",
+        "description": "Broadcast a message to all ATM team members",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "message": {"type": "string", "description": "Message text"},
+                "summary": {"type": "string", "description": "Optional message summary"},
+                "team": {"type": "string", "description": "Override target team"},
+                "identity": {"type": "string", "description": "Explicit sender identity (required outside thread context)"}
+            },
+            "required": ["message"]
+        }
+    })
+}
+
+fn atm_pending_count_schema() -> Value {
+    json!({
+        "name": "atm_pending_count",
+        "description": "Get count of unread ATM messages without marking them read",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "identity": {"type": "string", "description": "Explicit identity (required outside thread context)"}
+            }
+        }
+    })
+}
+
+fn agent_sessions_schema() -> Value {
+    json!({
+        "name": "agent_sessions",
+        "description": "List active and resumable Codex agent sessions",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "include_closed": {"type": "boolean", "description": "Include closed sessions (default: false)"}
+            }
+        }
+    })
+}
+
+fn agent_status_schema() -> Value {
+    json!({
+        "name": "agent_status",
+        "description": "Get proxy health and active session information",
+        "inputSchema": {
+            "type": "object",
+            "properties": {}
+        }
+    })
+}
+
+fn agent_close_schema() -> Value {
+    json!({
+        "name": "agent_close",
+        "description": "Close an active agent session and release its identity",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "agent_id": {"type": "string", "description": "Agent ID to close"},
+                "identity": {"type": "string", "description": "Identity to close (alternative to agent_id)"}
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_synthetic_tools_count() {
+        assert_eq!(synthetic_tools().len(), SYNTHETIC_TOOL_COUNT);
+    }
+
+    #[test]
+    fn test_all_tools_have_name_and_schema() {
+        for tool in synthetic_tools() {
+            assert!(tool.get("name").is_some(), "tool missing name");
+            assert!(tool.get("description").is_some(), "tool missing description");
+            let schema = tool.get("inputSchema").expect("tool missing inputSchema");
+            assert_eq!(
+                schema.get("type").and_then(|v| v.as_str()),
+                Some("object"),
+                "inputSchema must have type: object"
+            );
+        }
+    }
+
+    #[test]
+    fn test_atm_send_required_fields() {
+        let tool = atm_send_schema();
+        let required = tool["inputSchema"]["required"]
+            .as_array()
+            .expect("atm_send must have required fields");
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"to"));
+        assert!(names.contains(&"message"));
+    }
+
+    #[test]
+    fn test_atm_broadcast_required_fields() {
+        let tool = atm_broadcast_schema();
+        let required = tool["inputSchema"]["required"]
+            .as_array()
+            .expect("atm_broadcast must have required fields");
+        let names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(names.contains(&"message"));
+    }
+}

--- a/crates/atm-agent-mcp/tests/fixtures/echo_mcp_server.rs
+++ b/crates/atm-agent-mcp/tests/fixtures/echo_mcp_server.rs
@@ -1,0 +1,209 @@
+//! Mock MCP server for integration testing.
+//!
+//! Reads newline-delimited JSON from stdin and writes newline-delimited JSON
+//! responses to stdout. Implements enough of the Codex MCP server protocol to
+//! exercise the proxy's framing, pass-through, interception, and event forwarding.
+//!
+//! # Supported methods
+//!
+//! - `initialize` — returns Codex-compatible capabilities
+//! - `tools/list` — returns `codex` and `codex-reply` tool schemas
+//! - `tools/call` — echoes back with `structuredContent` and sends events
+//! - `notifications/initialized` — accepted, no response
+//! - `notifications/cancelled` — accepted, no response
+//!
+//! # Special behaviors
+//!
+//! - When `tools/call` targets `codex` or `codex-reply`, the server emits 2
+//!   `codex/event` notifications before the response.
+//! - When `tools/call` arguments contain `"slow": true`, the server sleeps for
+//!   5 seconds before responding (for timeout testing).
+//! - When `tools/call` targets `crash`, the server exits with code 42.
+
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Write};
+
+fn main() {
+    let stdin = std::io::stdin();
+    let stdout = std::io::stdout();
+    let reader = BufReader::new(stdin.lock());
+    let mut writer = stdout.lock();
+
+    for line in reader.lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let msg: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        handle_message(&msg, &mut writer);
+    }
+}
+
+fn handle_message(msg: &Value, writer: &mut impl Write) {
+    let method = msg.get("method").and_then(|v| v.as_str());
+    let id = msg.get("id").cloned();
+
+    match method {
+        Some("initialize") => {
+            let resp = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {
+                        "tools": { "listChanged": true }
+                    },
+                    "serverInfo": {
+                        "name": "echo-mcp-server",
+                        "title": "Echo MCP Server (test)",
+                        "version": "0.1.0"
+                    }
+                }
+            });
+            write_msg(writer, &resp);
+        }
+
+        Some("tools/list") => {
+            let resp = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "tools": [
+                        {
+                            "name": "codex",
+                            "description": "Start new Codex session",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "prompt": {"type": "string"},
+                                    "cwd": {"type": "string"}
+                                },
+                                "required": ["prompt"]
+                            }
+                        },
+                        {
+                            "name": "codex-reply",
+                            "description": "Continue existing Codex session",
+                            "inputSchema": {
+                                "type": "object",
+                                "properties": {
+                                    "prompt": {"type": "string"},
+                                    "threadId": {"type": "string"}
+                                },
+                                "required": ["prompt"]
+                            }
+                        }
+                    ]
+                }
+            });
+            write_msg(writer, &resp);
+        }
+
+        Some("tools/call") => {
+            let tool_name = msg
+                .pointer("/params/name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let arguments = msg
+                .pointer("/params/arguments")
+                .cloned()
+                .unwrap_or(json!({}));
+
+            // Special: crash on demand
+            if tool_name == "crash" {
+                std::process::exit(42);
+            }
+
+            // Special: slow mode for timeout testing
+            if arguments.get("slow").and_then(|v| v.as_bool()) == Some(true) {
+                std::thread::sleep(std::time::Duration::from_secs(5));
+            }
+
+            let req_id = id.clone().unwrap_or(Value::Null);
+            let thread_id = arguments
+                .get("threadId")
+                .and_then(|v| v.as_str())
+                .unwrap_or("test-thread-001");
+
+            // Emit 2 codex/event notifications before the response
+            if tool_name == "codex" || tool_name == "codex-reply" {
+                for i in 0..2 {
+                    let event = json!({
+                        "jsonrpc": "2.0",
+                        "method": "codex/event",
+                        "params": {
+                            "_meta": {
+                                "requestId": req_id,
+                                "threadId": thread_id
+                            },
+                            "id": format!("evt-{i}"),
+                            "msg": {
+                                "type": if i == 0 { "session_configured" } else { "agent_message" },
+                                "text": format!("event {i} for {tool_name}")
+                            }
+                        }
+                    });
+                    write_msg(writer, &event);
+                }
+            }
+
+            let prompt = arguments
+                .get("prompt")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(no prompt)");
+
+            let resp = json!({
+                "jsonrpc": "2.0",
+                "id": id,
+                "result": {
+                    "content": [{
+                        "type": "text",
+                        "text": format!("Echo from {tool_name}: {prompt}")
+                    }],
+                    "structuredContent": {
+                        "threadId": thread_id,
+                        "content": format!("Echo from {tool_name}: {prompt}")
+                    }
+                }
+            });
+            write_msg(writer, &resp);
+        }
+
+        Some("notifications/initialized") | Some("notifications/cancelled") => {
+            // Notifications have no response
+        }
+
+        Some(unknown) => {
+            // Unknown method — return error
+            if let Some(req_id) = id {
+                let resp = json!({
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {
+                        "code": -32601,
+                        "message": format!("Method not found: {unknown}")
+                    }
+                });
+                write_msg(writer, &resp);
+            }
+        }
+
+        None => {
+            // Response from client (e.g. elicitation response) — no action needed
+        }
+    }
+}
+
+fn write_msg(writer: &mut impl Write, msg: &Value) {
+    let s = serde_json::to_string(msg).expect("serialize JSON");
+    writeln!(writer, "{s}").expect("write to stdout");
+    writer.flush().expect("flush stdout");
+}

--- a/crates/atm-agent-mcp/tests/proxy_integration.rs
+++ b/crates/atm-agent-mcp/tests/proxy_integration.rs
@@ -1,0 +1,814 @@
+//! Integration tests for the MCP proxy.
+//!
+//! These tests spawn the `echo-mcp-server` binary as the child process and
+//! exercise the proxy's message routing, tool interception, event forwarding,
+//! timeout, and crash detection.
+
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream};
+
+/// Find the path to the `echo-mcp-server` test binary.
+fn echo_mcp_server_path() -> PathBuf {
+    let mut path = std::env::current_exe().unwrap();
+    path.pop(); // remove test binary name
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("echo-mcp-server");
+    path
+}
+
+/// Create a proxy config pointed at our echo server.
+fn test_config(timeout_secs: u64) -> atm_agent_mcp::proxy::ProxyServer {
+    use atm_agent_mcp::config::AgentMcpConfig;
+
+    let config = AgentMcpConfig {
+        codex_bin: echo_mcp_server_path().to_string_lossy().to_string(),
+        request_timeout_secs: timeout_secs,
+        ..Default::default()
+    };
+    atm_agent_mcp::proxy::ProxyServer::new(config)
+}
+
+/// Send a JSON-RPC message to the proxy via Content-Length framing.
+async fn send_content_length(writer: &mut DuplexStream, msg: &Value) {
+    let json = serde_json::to_string(msg).unwrap();
+    let header = format!("Content-Length: {}\r\n\r\n", json.len());
+    writer.write_all(header.as_bytes()).await.unwrap();
+    writer.write_all(json.as_bytes()).await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+/// Send a JSON-RPC message in newline-delimited format.
+async fn send_newline(writer: &mut DuplexStream, msg: &Value) {
+    let json = serde_json::to_string(msg).unwrap();
+    writer.write_all(json.as_bytes()).await.unwrap();
+    writer.write_all(b"\n").await.unwrap();
+    writer.flush().await.unwrap();
+}
+
+/// Read a Content-Length framed response from the proxy.
+async fn read_response(reader: &mut BufReader<DuplexStream>) -> Option<Value> {
+    let mut header_line = String::new();
+
+    // Try to read the Content-Length header with a timeout
+    match tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            header_line.clear();
+            let n = reader.read_line(&mut header_line).await.ok()?;
+            if n == 0 {
+                return None;
+            }
+            let trimmed = header_line.trim();
+            if trimmed.starts_with("Content-Length:") {
+                break;
+            }
+            // skip blank lines or other headers
+        }
+        Some(())
+    })
+    .await
+    {
+        Ok(Some(())) => {}
+        Ok(None) | Err(_) => return None,
+    }
+
+    let len: usize = header_line
+        .trim()
+        .strip_prefix("Content-Length:")
+        .unwrap()
+        .trim()
+        .parse()
+        .unwrap();
+
+    // Read until blank line
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).await.ok()?;
+        if line.trim().is_empty() {
+            break;
+        }
+    }
+
+    let mut body = vec![0u8; len];
+    tokio::io::AsyncReadExt::read_exact(reader, &mut body)
+        .await
+        .ok()?;
+    let s = String::from_utf8(body).ok()?;
+    serde_json::from_str(&s).ok()
+}
+
+/// Read all responses available within a timeout.
+async fn read_all_responses(
+    reader: &mut BufReader<DuplexStream>,
+    timeout_duration: Duration,
+) -> Vec<Value> {
+    let mut results = Vec::new();
+    let deadline = tokio::time::Instant::now() + timeout_duration;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, read_response(reader)).await {
+            Ok(Some(v)) => results.push(v),
+            _ => break,
+        }
+    }
+    results
+}
+
+/// Helper: run a proxy with a pair of duplex streams.
+///
+/// Returns (write_end, read_end, join_handle) where:
+/// - write_end: send messages TO the proxy
+/// - read_end: read messages FROM the proxy
+fn spawn_proxy(
+    timeout_secs: u64,
+) -> (
+    DuplexStream,
+    BufReader<DuplexStream>,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+) {
+    let (client_write, proxy_read) = tokio::io::duplex(16384);
+    let (proxy_write, client_read) = tokio::io::duplex(16384);
+
+    let handle = tokio::spawn(async move {
+        let mut proxy = test_config(timeout_secs);
+        proxy.run(proxy_read, proxy_write).await
+    });
+
+    (client_write, BufReader::new(client_read), handle)
+}
+
+// ─── Initialize pass-through ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_initialize_passes_through() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Send initialize request — but first we need to trigger child spawn.
+    // The child is lazy-spawned on codex/codex-reply. For initialize, the child
+    // isn't spawned yet, so we need to send a codex call first, or accept that
+    // initialize returns an error.
+    //
+    // Actually, the proxy forwards all non-tools/call methods to child if spawned.
+    // Since child isn't spawned on initialize, it returns an error.
+    // Let's first spawn the child with a codex call, then test initialize.
+
+    // First, trigger child spawn with a codex tools/call
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "codex",
+            "arguments": {"prompt": "hello"}
+        }
+    });
+    send_newline(&mut writer, &codex_req).await;
+
+    // Read all responses (events + final response)
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    assert!(
+        !responses.is_empty(),
+        "should have received at least one response"
+    );
+
+    // Now send initialize
+    let init_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {}
+        }
+    });
+    send_content_length(&mut writer, &init_req).await;
+
+    let resp = read_response(&mut reader).await.expect("initialize response");
+    assert_eq!(resp["id"], 2);
+    assert!(resp.get("result").is_some(), "initialize should succeed");
+    assert_eq!(
+        resp["result"]["serverInfo"]["name"],
+        "echo-mcp-server"
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Notifications initialized pass-through ─────────────────────────────
+
+#[tokio::test]
+async fn test_notifications_initialized_passes_through() {
+    let (mut writer, _reader, handle) = spawn_proxy(300);
+
+    // Notifications don't get responses, so we just verify no crash
+    let notif = json!({
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+    });
+    send_newline(&mut writer, &notif).await;
+
+    // Small delay to let proxy process
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── tools/list interception ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_tools_list_adds_synthetic_tools() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // First spawn child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    // Now send tools/list
+    let list_req = json!({
+        "jsonrpc": "2.0",
+        "id": 10,
+        "method": "tools/list"
+    });
+    send_newline(&mut writer, &list_req).await;
+
+    let resp = read_response(&mut reader).await.expect("tools/list response");
+    assert_eq!(resp["id"], 10);
+    let tools = resp["result"]["tools"].as_array().expect("tools array");
+
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .collect();
+
+    // Synthetic tools must be present
+    assert!(names.contains(&"atm_send"), "missing atm_send");
+    assert!(names.contains(&"atm_read"), "missing atm_read");
+    assert!(names.contains(&"atm_broadcast"), "missing atm_broadcast");
+    assert!(
+        names.contains(&"atm_pending_count"),
+        "missing atm_pending_count"
+    );
+    assert!(
+        names.contains(&"agent_sessions"),
+        "missing agent_sessions"
+    );
+    assert!(names.contains(&"agent_status"), "missing agent_status");
+    assert!(names.contains(&"agent_close"), "missing agent_close");
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_tools_list_preserves_codex_tools() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Spawn child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    let list_req = json!({
+        "jsonrpc": "2.0",
+        "id": 20,
+        "method": "tools/list"
+    });
+    send_newline(&mut writer, &list_req).await;
+
+    let resp = read_response(&mut reader).await.expect("tools/list response");
+    let tools = resp["result"]["tools"].as_array().expect("tools array");
+    let names: Vec<&str> = tools
+        .iter()
+        .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
+        .collect();
+
+    assert!(names.contains(&"codex"), "original codex tool missing");
+    assert!(
+        names.contains(&"codex-reply"),
+        "original codex-reply tool missing"
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_multiple_synthetic_tools_count() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Spawn child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    let list_req = json!({
+        "jsonrpc": "2.0",
+        "id": 30,
+        "method": "tools/list"
+    });
+    send_newline(&mut writer, &list_req).await;
+
+    let resp = read_response(&mut reader).await.expect("tools/list response");
+    let tools = resp["result"]["tools"].as_array().expect("tools array");
+
+    // 2 from echo server + 7 synthetic = 9
+    assert_eq!(tools.len(), 9, "expected 2 native + 7 synthetic tools");
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Unknown method pass-through ────────────────────────────────────────
+
+#[tokio::test]
+async fn test_unknown_method_passes_through() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Spawn child first
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    // Send unknown method
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 40,
+        "method": "custom/foobar",
+        "params": {}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let resp = read_response(&mut reader).await.expect("should get error response");
+    assert_eq!(resp["id"], 40);
+    // The echo server returns -32601 for unknown methods
+    assert_eq!(resp["error"]["code"], -32601);
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Lazy spawn tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_lazy_spawn_on_first_codex_call() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Before any codex call: send tools/list — should return error (no child)
+    let list_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list"
+    });
+    send_newline(&mut writer, &list_req).await;
+
+    let resp = read_response(&mut reader).await.expect("error response");
+    assert_eq!(resp["id"], 1);
+    // Should be an error since child not spawned
+    assert!(resp.get("error").is_some(), "expected error for no child");
+
+    // Now send codex — this should spawn the child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "hello"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+
+    // Should get events + response now
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    assert!(!responses.is_empty(), "should have received response(s)");
+
+    // Find the response with id=2
+    let main_resp = responses.iter().find(|r| r.get("id") == Some(&json!(2)));
+    assert!(
+        main_resp.is_some(),
+        "should have the codex response with id=2"
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Child crash tests ──────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_child_crash_returns_error() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Spawn child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    // Crash the child
+    let crash_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "crash", "arguments": {}}
+    });
+    send_newline(&mut writer, &crash_req).await;
+
+    // Wait for child to die
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Next request should return dead child error
+    let codex_req2 = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "after crash"}}
+    });
+    send_newline(&mut writer, &codex_req2).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    let error_resp = responses.iter().find(|r| {
+        r.get("id") == Some(&json!(3))
+            && r.pointer("/error/code").and_then(|v| v.as_i64()) == Some(-32005)
+    });
+    assert!(
+        error_resp.is_some(),
+        "expected -32005 CHILD_PROCESS_DEAD error, got: {responses:?}"
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_child_crash_includes_exit_code() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Spawn child
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "init"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    // Crash the child (exit code 42)
+    let crash_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {"name": "crash", "arguments": {}}
+    });
+    send_newline(&mut writer, &crash_req).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Send another request
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "after"}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    let error_resp = responses.iter().find(|r| r.get("id") == Some(&json!(3)));
+    assert!(error_resp.is_some(), "expected error response");
+
+    let err = error_resp.unwrap();
+    let exit_code = err.pointer("/error/data/exit_code").and_then(|v| v.as_i64());
+    assert_eq!(exit_code, Some(42), "expected exit code 42");
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Timeout tests ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_request_timeout_returns_error() {
+    // Use a 1-second timeout
+    let (mut writer, mut reader, handle) = spawn_proxy(1);
+
+    // Send a slow codex call (echo server sleeps 5s)
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "slow", "slow": true}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(10)).await;
+    let timeout_resp = responses.iter().find(|r| {
+        r.get("id") == Some(&json!(1))
+            && r.pointer("/error/code").and_then(|v| v.as_i64()) == Some(-32006)
+    });
+    assert!(
+        timeout_resp.is_some(),
+        "expected -32006 timeout error, got: {responses:?}"
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_timeout_includes_proxy_source() {
+    let (mut writer, mut reader, handle) = spawn_proxy(1);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "slow", "slow": true}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(10)).await;
+    let timeout_resp = responses.iter().find(|r| {
+        r.pointer("/error/code").and_then(|v| v.as_i64()) == Some(-32006)
+    });
+    assert!(timeout_resp.is_some(), "expected timeout error");
+    assert_eq!(
+        timeout_resp.unwrap().pointer("/error/data/error_source"),
+        Some(&json!("proxy"))
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Event forwarding tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_codex_event_forwarded_to_upstream() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Codex call triggers 2 events before the response
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "hello"}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    let events: Vec<&Value> = responses
+        .iter()
+        .filter(|r| r.get("method") == Some(&json!("codex/event")))
+        .collect();
+    assert!(
+        events.len() >= 2,
+        "expected at least 2 codex/event notifications, got {}",
+        events.len()
+    );
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_codex_event_has_agent_id() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "hello"}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    let events: Vec<&Value> = responses
+        .iter()
+        .filter(|r| r.get("method") == Some(&json!("codex/event")))
+        .collect();
+
+    for event in &events {
+        let agent_id = event
+            .pointer("/params/agent_id")
+            .and_then(|v| v.as_str());
+        assert_eq!(
+            agent_id,
+            Some("proxy:default"),
+            "event should have agent_id = proxy:default"
+        );
+    }
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+#[tokio::test]
+async fn test_event_content_unchanged() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "hello"}}
+    });
+    send_newline(&mut writer, &req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    let events: Vec<&Value> = responses
+        .iter()
+        .filter(|r| r.get("method") == Some(&json!("codex/event")))
+        .collect();
+
+    assert!(!events.is_empty(), "expected events");
+    // Check that the msg content is preserved from the echo server
+    let first_event = events[0];
+    let msg_type = first_event
+        .pointer("/params/msg/type")
+        .and_then(|v| v.as_str());
+    assert!(
+        msg_type.is_some(),
+        "event msg.type should be present"
+    );
+    // The echo server sends "session_configured" as the first event type
+    assert_eq!(msg_type, Some("session_configured"));
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Proxy lifecycle tests ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_proxy_shuts_down_on_stdin_eof() {
+    let (writer, _reader, handle) = spawn_proxy(300);
+
+    // Drop the writer immediately — proxy should exit
+    drop(writer);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), handle).await;
+    assert!(result.is_ok(), "proxy should exit on stdin EOF");
+    assert!(result.unwrap().is_ok(), "proxy should exit without panic");
+}
+
+#[tokio::test]
+async fn test_tools_list_schema_valid() {
+    // Verify all synthetic tools have valid JSON Schema inputSchema
+    let tools = atm_agent_mcp::tools::synthetic_tools();
+    for tool in &tools {
+        let name = tool["name"].as_str().unwrap();
+        let schema = tool
+            .get("inputSchema")
+            .unwrap_or_else(|| panic!("{name} missing inputSchema"));
+        assert_eq!(
+            schema["type"].as_str(),
+            Some("object"),
+            "{name} inputSchema type should be 'object'"
+        );
+        assert!(
+            schema.get("properties").is_some(),
+            "{name} inputSchema should have properties"
+        );
+    }
+}
+
+// ─── codex-reply pass-through ───────────────────────────────────────────
+
+#[tokio::test]
+async fn test_codex_reply_passes_through() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // First spawn with codex
+    let codex_req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": "codex", "arguments": {"prompt": "start session"}}
+    });
+    send_newline(&mut writer, &codex_req).await;
+    let _ = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+
+    // Now send codex-reply
+    let reply_req = json!({
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/call",
+        "params": {
+            "name": "codex-reply",
+            "arguments": {"prompt": "continue", "threadId": "test-thread-001"}
+        }
+    });
+    send_newline(&mut writer, &reply_req).await;
+
+    let responses = read_all_responses(&mut reader, Duration::from_secs(5)).await;
+    let main_resp = responses.iter().find(|r| r.get("id") == Some(&json!(2)));
+    assert!(main_resp.is_some(), "should get codex-reply response");
+
+    let resp = main_resp.unwrap();
+    let content = resp
+        .pointer("/result/structuredContent/threadId")
+        .and_then(|v| v.as_str());
+    assert_eq!(content, Some("test-thread-001"));
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Synthetic tool stubs ───────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_synthetic_tool_returns_not_implemented() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // atm_send should work without child spawned (it's synthetic)
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "atm_send",
+            "arguments": {"to": "agent1", "message": "hello"}
+        }
+    });
+    send_newline(&mut writer, &req).await;
+
+    let resp = read_response(&mut reader).await.expect("synthetic tool response");
+    assert_eq!(resp["id"], 1);
+    assert_eq!(resp["result"]["isError"], true);
+    let text = resp["result"]["content"][0]["text"].as_str().unwrap();
+    assert!(text.contains("not yet implemented"));
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Content-Length upstream framing ─────────────────────────────────────
+
+#[tokio::test]
+async fn test_content_length_upstream_framing() {
+    let (mut writer, mut reader, handle) = spawn_proxy(300);
+
+    // Send a synthetic tool call using Content-Length framing
+    let req = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "agent_status",
+            "arguments": {}
+        }
+    });
+    send_content_length(&mut writer, &req).await;
+
+    let resp = read_response(&mut reader).await.expect("response to CL-framed request");
+    assert_eq!(resp["id"], 1);
+    assert_eq!(resp["result"]["isError"], true);
+
+    drop(writer);
+    let _ = handle.await;
+}
+
+// ─── Dropped events counter ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_dropped_events_counter_accessible() {
+    use atm_agent_mcp::config::AgentMcpConfig;
+    use std::sync::atomic::Ordering;
+
+    let config = AgentMcpConfig::default();
+    let proxy = atm_agent_mcp::proxy::ProxyServer::new(config);
+    assert_eq!(proxy.dropped_events.load(Ordering::Relaxed), 0);
+}

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1784,7 +1784,37 @@ Parallel execution plan:
 
 ---
 
-## 12. Future Plugins
+## 12. Phase A: atm-agent-mcp (MCP Stdio Proxy for Codex)
+
+**Goal**: New `atm-agent-mcp` crate — an MCP stdio proxy that sits between Claude and a Codex
+`mcp-server` child process, injecting ATM messaging tools and forwarding `codex/event`
+notifications. Enables Claude to orchestrate Codex agents over the MCP protocol.
+
+**Integration branch**: `integrate/phase-A`
+
+### Phase A Sprint Summary
+
+| Sprint | Name | Status |
+|--------|------|--------|
+| A.1 | Crate scaffold + config | ✅ COMPLETE |
+| A.2 | MCP stdio proxy core | IN PROGRESS |
+| A.3 | Identity binding + session registry | PENDING |
+| A.4 | ATM tool execution (send/read/broadcast) | PENDING |
+| A.5 | Session lifecycle management | PENDING |
+| A.6 | Integration tests + hardening | PENDING |
+| A.7 | CLI polish + docs | PENDING |
+| A.8 | ARCH-CTM review + fixes | PENDING |
+
+### Phase A Design References
+
+- Requirements: `docs/atm-agent-mcp/`
+- Design: `docs/phase-10-codex-orchestration.md`
+- Spike reference: `spike/codex-mcp-pattern-copy`
+- New crate: `crates/atm-agent-mcp`
+
+---
+
+## 13. Future Plugins
 
 Additional plugins planned (each is a self-contained sprint series):
 
@@ -1796,7 +1826,7 @@ Additional plugins planned (each is a self-contained sprint series):
 
 ---
 
-## 13. Sprint Summary
+## 14. Sprint Summary
 
 | Phase | Sprint | Name | Status | PR |
 |-------|--------|------|--------|-----|
@@ -1864,7 +1894,7 @@ Additional plugins planned (each is a self-contained sprint series):
 
 ---
 
-## 12. Scrum Master Agent Prompt
+## 15. Scrum Master Agent Prompt
 
 The following prompt is used when spawning the scrum master agent for a sprint:
 


### PR DESCRIPTION
## Sprint A.2: MCP Stdio Proxy Core

Implements the MCP stdio proxy that sits between Claude (upstream MCP client) and `codex mcp-server` (downstream child process).

## Deliverables

- **Proxy core** (`proxy.rs`): Lazy child spawn on first `codex`/`codex-reply` request, full JSON-RPC pass-through
- **Dual upstream framing** (`framing.rs`): Auto-detects Content-Length framed OR newline-delimited JSON from Claude; always sends newline-delimited to child (Codex convention)
- **`tools/list` interception** (`tools.rs`): Appends 7 synthetic tools to child's response: `atm_send`, `atm_read`, `atm_broadcast`, `atm_pending_count`, `agent_sessions`, `agent_status`, `agent_close`
- **Child health** (FR-11): Crash detection via async wait task; returns `-32005 CHILD_PROCESS_DEAD` with exit code
- **Request timeout** (FR-14): Configurable per-request timeout (default 300s); sends `notifications/cancelled` to child on timeout; returns `-32006 REQUEST_TIMEOUT`
- **Event forwarding** (FR-19): `codex/event` notifications forwarded async to upstream with `agent_id` metadata; fire-and-forget with dropped-event counter
- **`serve` subcommand**: Replaces A.1 stub with real proxy loop
- **Mock child** (`tests/fixtures/echo_mcp_server.rs`): Codex-compatible JSON-RPC server for integration tests

## Test Coverage

- 41 new tests: 21 unit (framing, tools, proxy) + 20 integration (proxy_integration.rs)
- 70 total tests passing in `atm-agent-mcp` crate
- 985 total workspace tests passing

## QA Results

- **rust-qa-agent**: PASS (iteration 2, minor doc findings waived)
- **atm-qa-agent**: PASS (iteration 2 after fixes for FR-14.2 cancellation, shutdown kill, project-plan.md update, code quality)

## Error Code Compliance (NFR-6)

- `-32005 CHILD_PROCESS_DEAD`: child not running
- `-32006 REQUEST_TIMEOUT`: downstream request timed out
- All proxy errors include `error_source: "proxy"` in data

## FRs Covered

FR-1.1, FR-1.2, FR-1.3, FR-11.1–11.3, FR-14.1–14.3, FR-15.1–15.2, FR-19.1–19.5, NFR-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)