### PR TITLE
chore: bump version to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -30,4 +30,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.10.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.11.0" }


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.10.0 to 0.11.0
- Update pinned `agent-team-mail-core` dependency version

## Test plan
- [x] `cargo check` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)