### PR TITLE
chore: bump version to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "atm-agent-mcp"
-version = "0.10.0"
+version = "0.11.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -30,4 +30,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.11.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.11.1" }


### PR DESCRIPTION
## Summary
- Bump version to v0.11.1 patch release
- Includes atm-agent-mcp in release workflow (PR #115)

## Changes in this release
- feat(release): include atm-agent-mcp in release workflow and crates.io publish (#115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)