### PR TITLE
fix(scripts): use neutral default-team fallback

### DIFF
--- a/scripts/setup-codex-hooks.sh
+++ b/scripts/setup-codex-hooks.sh
@@ -9,29 +9,37 @@
 #
 # Defaults:
 #   --agent arch-ctm
-#   --team default-team
+#   --team from .atm.toml [core].default_team
 
 set -euo pipefail
 
 # Parse arguments
-AGENT="${1:---agent}"
-AGENT="${2:-arch-ctm}"
-TEAM="${3:---team}"
-TEAM="${4:-default-team}"
+AGENT="arch-ctm"
+TEAM=""
 
 # Handle flag-based arguments
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --agent)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --agent requires a value" >&2
+                exit 1
+            fi
             AGENT="$2"
             shift 2
             ;;
         --team)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --team requires a value" >&2
+                exit 1
+            fi
             TEAM="$2"
             shift 2
             ;;
         *)
-            shift
+            echo "Error: unknown argument: $1" >&2
+            echo "Usage: $0 [--agent <name>] [--team <team>]" >&2
+            exit 1
             ;;
     esac
 done
@@ -40,6 +48,45 @@ done
 CODEX_CONFIG="$HOME/.codex/config.toml"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RELAY_SCRIPT="$SCRIPT_DIR/atm-hook-relay.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ATM_TOML="$REPO_ROOT/.atm.toml"
+
+if [[ ! -f "$ATM_TOML" ]]; then
+    echo "Error: .atm.toml not found at $ATM_TOML" >&2
+    echo "Set up [core].default_team in repo .atm.toml before configuring hooks." >&2
+    exit 1
+fi
+
+REQUIRED_TEAM="$(
+python3 - "$ATM_TOML" <<'PY'
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+with path.open("rb") as f:
+    import tomllib
+    config = tomllib.load(f)
+
+team = config.get("core", {}).get("default_team")
+if not isinstance(team, str) or not team.strip():
+    raise SystemExit(2)
+print(team.strip())
+PY
+)" || {
+    echo "Error: failed to read [core].default_team from $ATM_TOML" >&2
+    echo "Ensure .atm.toml contains: [core] default_team = \"<team-name>\"" >&2
+    exit 1
+}
+
+if [[ -z "$TEAM" ]]; then
+    TEAM="$REQUIRED_TEAM"
+elif [[ "$TEAM" != "$REQUIRED_TEAM" ]]; then
+    echo "Error: --team mismatch with repo .atm.toml" >&2
+    echo "  .atm.toml [core].default_team = $REQUIRED_TEAM" >&2
+    echo "  provided --team               = $TEAM" >&2
+    echo "Refusing to write a mismatched team to ~/.codex/config.toml." >&2
+    exit 1
+fi
 
 # Ensure relay script exists and is executable
 if [[ ! -f "$RELAY_SCRIPT" ]]; then


### PR DESCRIPTION
## Summary\n- replace hardcoded `atm-dev` fallback with neutral `default-team` in worker launch script\n- update Codex hook setup script default team and usage comment to `default-team`\n\n## Why\nAvoid repo-specific fallback values leaking into other repos/environments.