### PR TITLE
chore: sync main → develop (v0.12.0 version bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "atm-agent-mcp"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -30,4 +30,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.11.1" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.12.0" }


### PR DESCRIPTION
## Summary

- Merges `main` into `develop` to bring in the v0.12.0 version bump (PR #123) and CLAUDE.md sync (PR #124) that landed on `main` but were not back-ported to `develop`.
- After merge, `develop` will be at v0.12.0, consistent with the released version.

## Changes
- `Cargo.toml`: 0.11.1 → 0.12.0
- `Cargo.lock`: updated checksums

🤖 Generated with [Claude Code](https://claude.com/claude-code)