### PR TITLE
feat(tui): add atm-tui binary crate — Sprint D.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "predicates",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 3.3.1",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -36,7 +36,7 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 3.3.1",
  "tempfile",
  "thiserror 2.0.18",
  "toml",
@@ -63,7 +63,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 3.3.1",
  "sha2",
  "ssh2",
  "tempfile",
@@ -84,6 +84,12 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -200,13 +206,30 @@ dependencies = [
  "libc",
  "serde",
  "serde_json",
- "serial_test",
+ "serial_test 3.3.1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "atm-tui"
+version = "0.13.0"
+dependencies = [
+ "agent-team-mail-core",
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossterm",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "serial_test 2.0.0",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]
@@ -274,6 +297,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +336,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -349,6 +388,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -370,6 +423,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,6 +456,53 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -426,6 +552,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -510,6 +642,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +682,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -544,8 +707,12 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -599,10 +766,18 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -741,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,6 +955,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inotify"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,6 +984,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357b7205c6cd18dd2c86ed312d1e70add149aea98e7ef72b9fdf0270e555c11d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,6 +1010,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -911,6 +1123,12 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
@@ -935,6 +1153,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "memchr"
@@ -1058,6 +1285,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1190,6 +1423,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,6 +1503,19 @@ checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
@@ -1256,7 +1523,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.11.0",
  "windows-sys 0.61.2",
 ]
 
@@ -1265,6 +1532,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1357,6 +1630,20 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive 2.0.0",
+]
+
+[[package]]
+name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
@@ -1367,7 +1654,18 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "scc",
- "serial_test_derive",
+ "serial_test_derive 3.3.1",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1406,6 +1704,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -1458,10 +1777,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"
@@ -1494,7 +1841,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
- "rustix",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1713,6 +2060,35 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/atm",
     "crates/atm-daemon",
     "crates/atm-agent-mcp",
+    "crates/atm-tui",
 ]
 exclude = [
     "examples/provider-stub",

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "atm-tui"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[[bin]]
+name = "atm-tui"
+path = "src/main.rs"
+
+[dependencies]
+agent-team-mail-core = { path = "../atm-core", version = "=0.13.0" }
+ratatui = "0.29"
+crossterm = { version = "0.28", features = ["event-stream"] }
+clap = { version = "4", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "fs", "io-util"] }
+chrono = { version = "0.4", features = ["serde"] }
+
+[dev-dependencies]
+tempfile = "3"
+serial_test = "2"

--- a/crates/atm-tui/src/agent_terminal.rs
+++ b/crates/atm-tui/src/agent_terminal.rs
@@ -1,0 +1,136 @@
+//! Agent Terminal panel: session log tail and JSONL key expansion.
+//!
+//! This module owns the logic for expanding compact JSONL keys to their full
+//! column names before display in the Agent Terminal panel.
+
+/// Mapping from compact on-disk event keys to full display column names.
+///
+/// Ordered to match §6 of the TUI MVP architecture document.
+pub const COLUMN_MAP: &[(&str, &str)] = &[
+    ("ts", "Timestamp"),
+    ("lv", "Level"),
+    ("src", "Source"),
+    ("act", "Action"),
+    ("team", "Team"),
+    ("sid", "Session ID"),
+    ("aid", "Agent ID"),
+    ("anm", "Agent Name"),
+    ("target", "Target"),
+    ("res", "Result"),
+    ("mid", "Message ID"),
+    ("rid", "Request ID"),
+    ("cnt", "Count"),
+    ("err", "Error"),
+    ("msg", "Message"),
+];
+
+/// Expand compact JSONL keys in a log line to their full column names.
+///
+/// If the line parses as a JSON object, all known compact keys are replaced by
+/// their full names and the object is re-serialised. Unknown keys are left
+/// unchanged. If the line is not valid JSON it is returned as-is.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Illustrative only — atm-tui is a binary crate; doc tests are not supported.
+/// let line = r#"{"ts":"2026-02-20T00:00:00Z","lv":"info"}"#;
+/// let expanded = expand_keys(line);
+/// assert!(expanded.contains("Timestamp"));
+/// ```
+pub fn expand_keys(line: &str) -> String {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return line.to_string();
+    }
+
+    let value: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(_) => return line.to_string(),
+    };
+
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => return line.to_string(),
+    };
+
+    let mut expanded = serde_json::Map::with_capacity(obj.len());
+    for (k, v) in obj {
+        let display_key = COLUMN_MAP
+            .iter()
+            .find(|(compact, _)| *compact == k.as_str())
+            .map(|(_, full)| *full)
+            .unwrap_or(k.as_str());
+        expanded.insert(display_key.to_string(), v.clone());
+    }
+
+    serde_json::to_string(&serde_json::Value::Object(expanded))
+        .unwrap_or_else(|_| line.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_expansion() {
+        let input = r#"{"ts":"2026-01-01T00:00:00Z","lv":"info","src":"atm-tui","act":"tui_start","team":"atm-dev"}"#;
+        let result = expand_keys(input);
+
+        // All known compact keys must be replaced.
+        assert!(result.contains("\"Timestamp\""), "expected Timestamp in: {result}");
+        assert!(result.contains("\"Level\""), "expected Level in: {result}");
+        assert!(result.contains("\"Source\""), "expected Source in: {result}");
+        assert!(result.contains("\"Action\""), "expected Action in: {result}");
+        assert!(result.contains("\"Team\""), "expected Team in: {result}");
+
+        // Original compact keys must not appear as keys.
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let obj = parsed.as_object().unwrap();
+        assert!(!obj.contains_key("ts"), "compact key 'ts' should be gone");
+        assert!(!obj.contains_key("lv"), "compact key 'lv' should be gone");
+        assert!(!obj.contains_key("src"), "compact key 'src' should be gone");
+        assert!(!obj.contains_key("act"), "compact key 'act' should be gone");
+        assert!(!obj.contains_key("team"), "compact key 'team' should be gone");
+    }
+
+    #[test]
+    fn test_non_json_line_returned_as_is() {
+        let input = "this is not json at all";
+        assert_eq!(expand_keys(input), input);
+    }
+
+    #[test]
+    fn test_unknown_keys_preserved() {
+        let input = r#"{"unknown_key":"value","ts":"2026-01-01"}"#;
+        let result = expand_keys(input);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let obj = parsed.as_object().unwrap();
+        assert!(obj.contains_key("unknown_key"));
+        assert!(obj.contains_key("Timestamp"));
+    }
+
+    #[test]
+    fn test_all_column_map_entries_expanded() {
+        // Build a JSON object with every compact key.
+        let mut obj = serde_json::Map::new();
+        for (compact, _) in COLUMN_MAP {
+            obj.insert(compact.to_string(), serde_json::Value::String("v".into()));
+        }
+        let input = serde_json::to_string(&serde_json::Value::Object(obj)).unwrap();
+        let result = expand_keys(&input);
+        let parsed: serde_json::Value = serde_json::from_str(&result).unwrap();
+        let out = parsed.as_object().unwrap();
+
+        for (compact, full) in COLUMN_MAP {
+            assert!(
+                out.contains_key(*full),
+                "full key '{full}' missing from output"
+            );
+            assert!(
+                !out.contains_key(*compact),
+                "compact key '{compact}' should not remain"
+            );
+        }
+    }
+}

--- a/crates/atm-tui/src/app.rs
+++ b/crates/atm-tui/src/app.rs
@@ -1,0 +1,176 @@
+//! Application state machine for the ATM TUI.
+//!
+//! [`App`] is the single source of mutable state for the TUI. All panels read
+//! from it; the refresh loop writes to it. No I/O is performed in this module.
+
+use std::path::PathBuf;
+
+use agent_team_mail_core::daemon_client::AgentSummary;
+
+/// A single row shown in the Dashboard panel.
+#[derive(Debug, Clone)]
+pub struct MemberRow {
+    /// Agent identifier (e.g. `"arch-ctm"`).
+    pub agent: String,
+    /// Current state string (e.g. `"idle"`, `"busy"`).
+    pub state: String,
+    /// Number of messages currently in the agent's inbox file.
+    pub inbox_count: usize,
+}
+
+/// Which panel currently has keyboard focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FocusPanel {
+    /// Left panel — member list.
+    #[default]
+    Dashboard,
+    /// Right panel — agent terminal stream.
+    AgentTerminal,
+}
+
+/// Top-level application state.
+///
+/// Owned by the main event loop. The UI renders this state; the refresh ticker
+/// updates it. Access is single-threaded (no interior mutability required).
+pub struct App {
+    /// Team name being monitored.
+    pub team: String,
+    /// Member rows shown in the dashboard left panel.
+    pub members: Vec<MemberRow>,
+    /// Index into [`members`](Self::members) of the currently selected agent.
+    pub selected_index: usize,
+    /// Raw agent list returned by the daemon `list-agents` command.
+    pub agent_list: Vec<AgentSummary>,
+    /// Log lines collected from the selected agent's session log (bounded to 1000).
+    pub stream_lines: Vec<String>,
+    /// File-read byte position for incremental log tailing.
+    pub stream_pos: u64,
+    /// Path to the selected agent's session log file, if resolved.
+    pub session_log_path: Option<PathBuf>,
+    /// Set to `true` to exit the event loop on the next iteration.
+    pub should_quit: bool,
+    /// Which panel currently holds keyboard focus.
+    pub focus: FocusPanel,
+    /// Name of the agent whose session is currently being streamed.
+    pub streaming_agent: Option<String>,
+}
+
+impl App {
+    /// Create a new [`App`] for the given team.
+    pub fn new(team: String) -> Self {
+        Self {
+            team,
+            members: Vec::new(),
+            selected_index: 0,
+            agent_list: Vec::new(),
+            stream_lines: Vec::new(),
+            stream_pos: 0,
+            session_log_path: None,
+            should_quit: false,
+            focus: FocusPanel::default(),
+            streaming_agent: None,
+        }
+    }
+
+    /// Return the agent name at the currently selected index, if any.
+    pub fn selected_agent(&self) -> Option<&str> {
+        self.members.get(self.selected_index).map(|r| r.agent.as_str())
+    }
+
+    /// Move selection up one row (wraps).
+    pub fn select_previous(&mut self) {
+        if self.members.is_empty() {
+            return;
+        }
+        if self.selected_index == 0 {
+            self.selected_index = self.members.len() - 1;
+        } else {
+            self.selected_index -= 1;
+        }
+    }
+
+    /// Move selection down one row (wraps).
+    pub fn select_next(&mut self) {
+        if self.members.is_empty() {
+            return;
+        }
+        self.selected_index = (self.selected_index + 1) % self.members.len();
+    }
+
+    /// Cycle focus between Dashboard and AgentTerminal panels.
+    pub fn cycle_focus(&mut self) {
+        self.focus = match self.focus {
+            FocusPanel::Dashboard => FocusPanel::AgentTerminal,
+            FocusPanel::AgentTerminal => FocusPanel::Dashboard,
+        };
+    }
+
+    /// Append new log lines to [`stream_lines`](Self::stream_lines), keeping
+    /// the buffer bounded to the last 1000 lines.
+    pub fn append_stream_lines(&mut self, new_lines: Vec<String>) {
+        self.stream_lines.extend(new_lines);
+        const MAX_LINES: usize = 1000;
+        if self.stream_lines.len() > MAX_LINES {
+            let drain_count = self.stream_lines.len() - MAX_LINES;
+            self.stream_lines.drain(..drain_count);
+        }
+    }
+
+    /// Reset stream state when switching to a different agent.
+    pub fn reset_stream(&mut self) {
+        self.stream_lines.clear();
+        self.stream_pos = 0;
+        self.session_log_path = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_select_next_wraps() {
+        let mut app = App::new("atm-dev".to_string());
+        app.members = vec![
+            MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 },
+            MemberRow { agent: "b".into(), state: "idle".into(), inbox_count: 0 },
+        ];
+        app.selected_index = 1;
+        app.select_next();
+        assert_eq!(app.selected_index, 0);
+    }
+
+    #[test]
+    fn test_select_previous_wraps() {
+        let mut app = App::new("atm-dev".to_string());
+        app.members = vec![
+            MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 },
+            MemberRow { agent: "b".into(), state: "idle".into(), inbox_count: 0 },
+        ];
+        app.selected_index = 0;
+        app.select_previous();
+        assert_eq!(app.selected_index, 1);
+    }
+
+    #[test]
+    fn test_append_stream_lines_bounded() {
+        let mut app = App::new("atm-dev".to_string());
+        // Fill past the 1000-line limit.
+        let lines: Vec<String> = (0..1100).map(|i| format!("line {i}")).collect();
+        app.append_stream_lines(lines);
+        assert_eq!(app.stream_lines.len(), 1000);
+        // Should keep the last 1000.
+        assert_eq!(app.stream_lines[0], "line 100");
+        assert_eq!(app.stream_lines[999], "line 1099");
+    }
+
+    #[test]
+    fn test_cycle_focus() {
+        let mut app = App::new("atm-dev".to_string());
+        assert_eq!(app.focus, FocusPanel::Dashboard);
+        app.cycle_focus();
+        assert_eq!(app.focus, FocusPanel::AgentTerminal);
+        app.cycle_focus();
+        assert_eq!(app.focus, FocusPanel::Dashboard);
+    }
+}

--- a/crates/atm-tui/src/dashboard.rs
+++ b/crates/atm-tui/src/dashboard.rs
@@ -1,0 +1,135 @@
+//! Dashboard panel helpers: inbox count reads and session log path resolution.
+//!
+//! This module does not own any rendering code — that lives in [`crate::ui`].
+//! It provides pure functions for computing the data shown in the left panel.
+
+use std::path::{Path, PathBuf};
+
+use agent_team_mail_core::home::get_home_dir;
+
+/// Read the number of messages in an agent's inbox file.
+///
+/// Returns `0` when the inbox does not exist, is empty, or cannot be parsed.
+/// Never panics or propagates errors — silently returns `0` on any failure.
+///
+/// # Arguments
+///
+/// * `home` - ATM home directory (resolved via [`get_home_dir`]).
+/// * `team` - Team name.
+/// * `agent` - Agent name.
+pub fn get_inbox_count(home: &Path, team: &str, agent: &str) -> usize {
+    let inbox_path = home
+        .join(".claude/teams")
+        .join(team)
+        .join("inboxes")
+        .join(format!("{agent}.json"));
+
+    if !inbox_path.exists() {
+        return 0;
+    }
+
+    match std::fs::read_to_string(&inbox_path) {
+        Ok(content) if !content.trim().is_empty() => {
+            serde_json::from_str::<Vec<serde_json::Value>>(&content)
+                .map(|v| v.len())
+                .unwrap_or(0)
+        }
+        _ => 0,
+    }
+}
+
+/// Construct the expected path for an agent's session log file.
+///
+/// Path pattern:
+/// ```text
+/// {ATM_HOME}/.config/atm/agent-sessions/{team}/{agent}/output.log
+/// ```
+///
+/// `ATM_HOME` is resolved via [`get_home_dir`], which honours the `ATM_HOME`
+/// environment variable before falling back to the platform home directory.
+///
+/// # Arguments
+///
+/// * `team`  - Team name.
+/// * `agent` - Agent identifier.
+pub fn session_log_path(team: &str, agent: &str) -> PathBuf {
+    let base = get_home_dir().unwrap_or_default();
+    base.join(".config/atm/agent-sessions")
+        .join(team)
+        .join(agent)
+        .join("output.log")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Helper: set ATM_HOME to the temp dir path (used instead of `serial_test`
+    /// because the tests use different temp dirs and do not conflict).
+    fn with_tmp_home<F: FnOnce(&Path)>(f: F) {
+        let tmp = TempDir::new().expect("tmp dir");
+        // SAFETY: test-only env mutation; tests run in isolation within a
+        // single-threaded test process for this module.
+        unsafe { std::env::set_var("ATM_HOME", tmp.path()) };
+        f(tmp.path());
+        unsafe { std::env::remove_var("ATM_HOME") };
+    }
+
+    // ── test_session_log_path ────────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_session_log_path() {
+        with_tmp_home(|home| {
+            let path = session_log_path("atm-dev", "arch-ctm");
+            let expected = home
+                .join(".config/atm/agent-sessions")
+                .join("atm-dev")
+                .join("arch-ctm")
+                .join("output.log");
+            assert_eq!(path, expected, "session log path mismatch");
+        });
+    }
+
+    // ── test_inbox_count_empty ───────────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_inbox_count_empty() {
+        with_tmp_home(|home| {
+            // Inbox file does not exist yet.
+            let count = get_inbox_count(home, "atm-dev", "arch-ctm");
+            assert_eq!(count, 0, "missing inbox should return 0");
+
+            // Create an empty inbox file.
+            let inbox_dir = home.join(".claude/teams/atm-dev/inboxes");
+            fs::create_dir_all(&inbox_dir).unwrap();
+            let inbox_path = inbox_dir.join("arch-ctm.json");
+            fs::write(&inbox_path, b"").unwrap();
+            let count = get_inbox_count(home, "atm-dev", "arch-ctm");
+            assert_eq!(count, 0, "empty inbox file should return 0");
+        });
+    }
+
+    // ── test_inbox_count_with_messages ──────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_inbox_count_with_messages() {
+        with_tmp_home(|home| {
+            let inbox_dir = home.join(".claude/teams/atm-dev/inboxes");
+            fs::create_dir_all(&inbox_dir).unwrap();
+            let inbox_path = inbox_dir.join("arch-ctm.json");
+
+            // Write a valid JSON array with 3 messages.
+            let payload = r#"[{"message_id":"m1"},{"message_id":"m2"},{"message_id":"m3"}]"#;
+            fs::write(&inbox_path, payload).unwrap();
+
+            let count = get_inbox_count(home, "atm-dev", "arch-ctm");
+            assert_eq!(count, 3, "expected 3 messages in inbox");
+        });
+    }
+}

--- a/crates/atm-tui/src/events.rs
+++ b/crates/atm-tui/src/events.rs
@@ -1,0 +1,125 @@
+//! Keyboard input event handling for the ATM TUI.
+//!
+//! Events are consumed in the main loop. The handler mutates [`App`] state
+//! directly; rendering happens separately. All unrecognised keys are silently
+//! ignored (input is disabled in D.1).
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyModifiers};
+
+use crate::app::App;
+
+/// Process a single terminal input event and update [`App`] state accordingly.
+///
+/// Returns `true` if the application should quit after this event.
+///
+/// # Key bindings
+///
+/// | Key | Action |
+/// |-----|--------|
+/// | `q` | Quit |
+/// | `Ctrl-C` | Quit |
+/// | `↑` | Move selection up |
+/// | `↓` | Move selection down |
+/// | `Tab` | Cycle panel focus |
+/// | _other_ | Ignored (input disabled) |
+pub fn handle_event(event: &Event, app: &mut App) -> bool {
+    if let Event::Key(KeyEvent { code, modifiers, .. }) = event {
+        match (code, modifiers) {
+            (KeyCode::Char('q'), _) => {
+                app.should_quit = true;
+                return true;
+            }
+            (KeyCode::Char('c'), m) if m.contains(KeyModifiers::CONTROL) => {
+                app.should_quit = true;
+                return true;
+            }
+            (KeyCode::Up, _) => {
+                app.select_previous();
+            }
+            (KeyCode::Down, _) => {
+                app.select_next();
+            }
+            (KeyCode::Tab, _) => {
+                app.cycle_focus();
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::{FocusPanel, MemberRow};
+    use crossterm::event::{KeyEventKind, KeyEventState};
+
+    fn key_event(code: KeyCode, modifiers: KeyModifiers) -> Event {
+        Event::Key(KeyEvent {
+            code,
+            modifiers,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        })
+    }
+
+    fn app_with_members() -> App {
+        let mut app = App::new("atm-dev".to_string());
+        app.members = vec![
+            MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 },
+            MemberRow { agent: "b".into(), state: "busy".into(), inbox_count: 1 },
+            MemberRow { agent: "c".into(), state: "idle".into(), inbox_count: 2 },
+        ];
+        app
+    }
+
+    #[test]
+    fn test_q_quits() {
+        let mut app = App::new("atm-dev".to_string());
+        let quit = handle_event(&key_event(KeyCode::Char('q'), KeyModifiers::NONE), &mut app);
+        assert!(quit);
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_ctrl_c_quits() {
+        let mut app = App::new("atm-dev".to_string());
+        let quit = handle_event(&key_event(KeyCode::Char('c'), KeyModifiers::CONTROL), &mut app);
+        assert!(quit);
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_arrow_down_moves_selection() {
+        let mut app = app_with_members();
+        assert_eq!(app.selected_index, 0);
+        handle_event(&key_event(KeyCode::Down, KeyModifiers::NONE), &mut app);
+        assert_eq!(app.selected_index, 1);
+    }
+
+    #[test]
+    fn test_arrow_up_moves_selection() {
+        let mut app = app_with_members();
+        app.selected_index = 2;
+        handle_event(&key_event(KeyCode::Up, KeyModifiers::NONE), &mut app);
+        assert_eq!(app.selected_index, 1);
+    }
+
+    #[test]
+    fn test_tab_cycles_focus() {
+        let mut app = App::new("atm-dev".to_string());
+        assert_eq!(app.focus, FocusPanel::Dashboard);
+        handle_event(&key_event(KeyCode::Tab, KeyModifiers::NONE), &mut app);
+        assert_eq!(app.focus, FocusPanel::AgentTerminal);
+        handle_event(&key_event(KeyCode::Tab, KeyModifiers::NONE), &mut app);
+        assert_eq!(app.focus, FocusPanel::Dashboard);
+    }
+
+    #[test]
+    fn test_other_key_ignored() {
+        let mut app = App::new("atm-dev".to_string());
+        let quit = handle_event(&key_event(KeyCode::Char('x'), KeyModifiers::NONE), &mut app);
+        assert!(!quit);
+        assert!(!app.should_quit);
+    }
+}

--- a/crates/atm-tui/src/main.rs
+++ b/crates/atm-tui/src/main.rs
@@ -1,0 +1,293 @@
+//! ATM TUI — terminal user interface for monitoring agent teams.
+//!
+//! # Usage
+//!
+//! ```text
+//! atm-tui --team atm-dev
+//! ```
+//!
+//! # Key bindings
+//!
+//! | Key | Action |
+//! |-----|--------|
+//! | `q` / `Ctrl-C` | Quit |
+//! | `↑` / `↓` | Select agent |
+//! | `Tab` | Switch panel focus |
+//!
+//! # Architecture
+//!
+//! The main loop drives a 100 ms ticker. On every tick it:
+//! 1. Refreshes the agent list and inbox counts from the daemon / filesystem
+//!    (rate-limited to once every 2 s to avoid socket spam).
+//! 2. Appends new bytes from the selected agent's session log (full 100 ms rate).
+//! 3. Redraws the terminal frame.
+//!
+//! All input events are handled between ticks with a non-blocking poll.
+
+mod agent_terminal;
+mod app;
+mod dashboard;
+mod events;
+mod ui;
+
+use std::io;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use anyhow::{Context, Result};
+use clap::Parser;
+use crossterm::{
+    event::{self, DisableMouseCapture, EnableMouseCapture},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+};
+use ratatui::{Terminal, backend::CrosstermBackend};
+use tokio::time::interval;
+
+use agent_team_mail_core::{
+    daemon_client::{AgentSummary, query_list_agents},
+    event_log::{EventFields, emit_event_best_effort},
+    home::get_home_dir,
+    logging,
+};
+
+use app::{App, MemberRow};
+use dashboard::{get_inbox_count, session_log_path};
+
+/// TUI refresh poll interval (100 ms — see docs/tui-mvp-architecture.md §5).
+const TICK_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+
+/// ATM TUI — live dashboard and agent stream viewer.
+#[derive(Parser, Debug)]
+#[command(version, about)]
+pub struct Cli {
+    /// Team name to monitor (e.g. `atm-dev`).
+    #[arg(short, long)]
+    pub team: String,
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    logging::init();
+
+    let cli = Cli::parse();
+    let team = cli.team.clone();
+
+    emit_event_best_effort(EventFields {
+        level: "info",
+        source: "atm-tui",
+        action: "tui_start",
+        team: Some(team.clone()),
+        ..Default::default()
+    });
+
+    // Set up terminal
+    enable_raw_mode().context("enable raw mode")?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)
+        .context("enter alternate screen")?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend).context("create terminal")?;
+
+    let result = run_app(&mut terminal, team.clone()).await;
+
+    // Restore terminal on exit (even on error)
+    disable_raw_mode().ok();
+    execute!(
+        terminal.backend_mut(),
+        LeaveAlternateScreen,
+        DisableMouseCapture
+    )
+    .ok();
+    terminal.show_cursor().ok();
+
+    if let Err(ref e) = result {
+        eprintln!("atm-tui error: {e:#}");
+    }
+
+    result
+}
+
+// ── Application loop ──────────────────────────────────────────────────────────
+
+/// Run the TUI until the user quits.
+///
+/// # Errors
+///
+/// Returns an error on unrecoverable terminal I/O failures.
+async fn run_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    team: String,
+) -> Result<()> {
+    let mut app = App::new(team.clone());
+
+    // Rate-limit daemon/inbox queries to 2-second intervals.
+    const DAEMON_REFRESH: Duration = Duration::from_secs(2);
+    let mut last_daemon_refresh = Instant::now() - DAEMON_REFRESH; // trigger immediately
+
+    // Resolve ATM home once for inbox reads.
+    let home: PathBuf = get_home_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    // Resolve home for inbox reads (used in the loop closure below)
+    let mut tick = interval(TICK_INTERVAL);
+
+    loop {
+        // ── Draw ──────────────────────────────────────────────────────────────
+        terminal.draw(|f| ui::draw(f, &app))?;
+
+        // ── Daemon / inbox refresh (rate-limited) ─────────────────────────────
+        if last_daemon_refresh.elapsed() >= DAEMON_REFRESH {
+            last_daemon_refresh = Instant::now();
+
+            let agent_list = refresh_agent_list();
+            let members = build_member_rows(&agent_list, &home, &team);
+
+            // Detect if the currently streaming agent has changed identity.
+            if let Some(ref name) = app.streaming_agent.clone()
+                && !members.iter().any(|m| &m.agent == name)
+            {
+                emit_stream_detach_event(&team, name);
+                app.reset_stream();
+                app.streaming_agent = None;
+            }
+
+            app.agent_list = agent_list;
+            app.members = members;
+
+            // Clamp selected_index within bounds after list refresh.
+            if !app.members.is_empty() && app.selected_index >= app.members.len() {
+                app.selected_index = app.members.len() - 1;
+            }
+
+            // Resolve streaming agent from selection.
+            if let Some(agent_name) = app.selected_agent().map(str::to_owned)
+                && app.streaming_agent.as_deref() != Some(&agent_name)
+            {
+                // Switching to a new agent.
+                if let Some(ref prev) = app.streaming_agent.clone() {
+                    emit_stream_detach_event(&team, prev);
+                }
+                app.reset_stream();
+                app.streaming_agent = Some(agent_name.clone());
+                app.session_log_path = Some(session_log_path(&team, &agent_name));
+
+                emit_event_best_effort(EventFields {
+                    level: "info",
+                    source: "atm-tui",
+                    action: "session_connect",
+                    team: Some(team.clone()),
+                    agent_id: Some(agent_name.clone()),
+                    ..Default::default()
+                });
+            }
+        }
+
+        // ── Session log tail (100 ms) ─────────────────────────────────────────
+        if let Some(ref log_path) = app.session_log_path.clone()
+            && let Ok((new_lines, new_pos)) = tail_log_file(log_path, app.stream_pos).await
+            && new_pos > app.stream_pos
+        {
+            // Emit stream_attach on first successful read.
+            if app.stream_pos == 0 && !new_lines.is_empty() {
+                emit_event_best_effort(EventFields {
+                    level: "info",
+                    source: "atm-tui",
+                    action: "stream_attach",
+                    team: Some(team.clone()),
+                    agent_id: app.streaming_agent.clone(),
+                    result: Some("ok".to_string()),
+                    ..Default::default()
+                });
+            }
+            app.stream_pos = new_pos;
+            app.append_stream_lines(new_lines);
+        }
+
+        // ── Input event handling ──────────────────────────────────────────────
+        if event::poll(Duration::from_millis(0))? {
+            let ev = event::read()?;
+            if events::handle_event(&ev, &mut app) || app.should_quit {
+                break;
+            }
+        }
+
+        // ── Tick ──────────────────────────────────────────────────────────────
+        tick.tick().await;
+    }
+
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Query the daemon for the live agent list. Returns an empty vec on failure.
+fn refresh_agent_list() -> Vec<AgentSummary> {
+    match query_list_agents() {
+        Ok(Some(list)) => list,
+        _ => Vec::new(),
+    }
+}
+
+/// Build [`MemberRow`] entries from the agent list with current inbox counts.
+fn build_member_rows(agents: &[AgentSummary], home: &std::path::Path, team: &str) -> Vec<MemberRow> {
+    agents
+        .iter()
+        .map(|a| MemberRow {
+            agent: a.agent.clone(),
+            state: a.state.clone(),
+            inbox_count: get_inbox_count(home, team, &a.agent),
+        })
+        .collect()
+}
+
+/// Read new bytes from a log file since `pos`, returning new lines and the
+/// updated byte position.
+///
+/// Returns `Ok((vec![], pos))` when the file does not exist or has no new data.
+async fn tail_log_file(path: &std::path::Path, pos: u64) -> Result<(Vec<String>, u64)> {
+    use tokio::fs::File;
+    use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+    if !path.exists() {
+        return Ok((Vec::new(), pos));
+    }
+
+    let mut file = File::open(path).await?;
+    let metadata = file.metadata().await?;
+    let file_len = metadata.len();
+
+    if file_len <= pos {
+        return Ok((Vec::new(), pos));
+    }
+
+    file.seek(std::io::SeekFrom::Start(pos)).await?;
+
+    let read_len = (file_len - pos).min(256 * 1024) as usize; // cap at 256 KiB per tick
+    let mut buf = vec![0u8; read_len];
+    let n = file.read(&mut buf).await?;
+    buf.truncate(n);
+
+    let chunk = String::from_utf8_lossy(&buf);
+    let lines: Vec<String> = chunk
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(str::to_string)
+        .collect();
+
+    Ok((lines, pos + n as u64))
+}
+
+fn emit_stream_detach_event(team: &str, agent: &str) {
+    emit_event_best_effort(EventFields {
+        level: "info",
+        source: "atm-tui",
+        action: "stream_detach",
+        team: Some(team.to_string()),
+        agent_id: Some(agent.to_string()),
+        ..Default::default()
+    });
+}

--- a/crates/atm-tui/src/ui.rs
+++ b/crates/atm-tui/src/ui.rs
@@ -1,0 +1,291 @@
+//! Ratatui layout and widget rendering for the ATM TUI.
+//!
+//! The layout is a two-column split with a header bar and a status bar:
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────────┐
+//! │ ATM TUI  │  Team: <team>                                         │ header
+//! ├────────────────────┬─────────────────────────────────────────────┤
+//! │ Dashboard          │ Agent Terminal                              │
+//! │                    │                                             │ body
+//! │ AGENT   STATE INB  │ [LIVE] arch-ctm                            │
+//! │ arch-ctm idle   3  │ {"Timestamp":"...","Level":"info",...}      │
+//! │ ...                │ ...                                         │
+//! │                    ├─────────────────────────────────────────────┤
+//! │                    │ [disabled] control available in next release│ input
+//! ├────────────────────┴─────────────────────────────────────────────┤
+//! │ q: quit  ↑↓: select agent  Tab: switch panel                    │ status
+//! └──────────────────────────────────────────────────────────────────┘
+//! ```
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, BorderType, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::agent_terminal::expand_keys;
+use crate::app::{App, FocusPanel};
+
+/// Render the full TUI frame from current [`App`] state.
+pub fn draw(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    // ── Outer vertical split: header / body / status ─────────────────────────
+    let outer = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1), // header
+            Constraint::Min(0),    // body
+            Constraint::Length(1), // status bar
+        ])
+        .split(area);
+
+    draw_header(frame, outer[0], app);
+    draw_body(frame, outer[1], app);
+    draw_status_bar(frame, outer[2]);
+}
+
+// ── Header ────────────────────────────────────────────────────────────────────
+
+fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
+    let text = Line::from(vec![
+        Span::styled(
+            " ATM TUI  ",
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(format!(" Team: {}", app.team)),
+    ]);
+    frame.render_widget(Paragraph::new(text), area);
+}
+
+// ── Body (left + right) ───────────────────────────────────────────────────────
+
+fn draw_body(frame: &mut Frame, area: Rect, app: &App) {
+    let columns = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
+        .split(area);
+
+    draw_dashboard(frame, columns[0], app);
+    draw_agent_terminal(frame, columns[1], app);
+}
+
+// ── Dashboard panel ───────────────────────────────────────────────────────────
+
+fn draw_dashboard(frame: &mut Frame, area: Rect, app: &App) {
+    let focused = app.focus == FocusPanel::Dashboard;
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let block = Block::default()
+        .title(" Dashboard ")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(border_style);
+
+    // Column header row
+    let header = ListItem::new(Line::from(vec![
+        Span::styled(
+            format!("{:<20} {:<8} {}", "AGENT", "STATE", "INBOX"),
+            Style::default().add_modifier(Modifier::BOLD | Modifier::UNDERLINED),
+        ),
+    ]));
+
+    let mut items: Vec<ListItem> = vec![header];
+
+    for (idx, member) in app.members.iter().enumerate() {
+        let selected = idx == app.selected_index;
+        let style = if selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+        };
+
+        let state_color = match member.state.as_str() {
+            "busy" => Color::Yellow,
+            "launching" => Color::Blue,
+            "killed" | "stale" | "closed" => Color::Red,
+            _ => Color::Green, // idle, unknown
+        };
+
+        let row = Line::from(vec![
+            Span::styled(
+                format!("{:<20}", truncate_str(&member.agent, 20)),
+                style,
+            ),
+            Span::styled(
+                format!(" {:<8}", truncate_str(&member.state, 8)),
+                Style::default().fg(if selected { Color::Black } else { state_color }),
+            ),
+            Span::styled(
+                format!(" {}", member.inbox_count),
+                style,
+            ),
+        ]);
+
+        items.push(ListItem::new(row));
+    }
+
+    if app.members.is_empty() {
+        items.push(ListItem::new(Line::from(Span::styled(
+            " (no members — daemon may be offline)",
+            Style::default().fg(Color::DarkGray),
+        ))));
+    }
+
+    let mut list_state = ListState::default();
+    // +1 because the header occupies index 0 in the item list
+    list_state.select(Some(app.selected_index + 1));
+
+    frame.render_stateful_widget(
+        List::new(items).block(block),
+        area,
+        &mut list_state,
+    );
+}
+
+// ── Agent Terminal panel ──────────────────────────────────────────────────────
+
+fn draw_agent_terminal(frame: &mut Frame, area: Rect, app: &App) {
+    let focused = app.focus == FocusPanel::AgentTerminal;
+    let border_style = if focused {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    // Split right panel: stream area + disabled input bar
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(0), Constraint::Length(3)])
+        .split(area);
+
+    draw_stream_pane(frame, rows[0], app, border_style, focused);
+    draw_disabled_input(frame, rows[1], border_style);
+}
+
+fn draw_stream_pane(
+    frame: &mut Frame,
+    area: Rect,
+    app: &App,
+    border_style: Style,
+    focused: bool,
+) {
+    let agent_label = app
+        .streaming_agent
+        .as_deref()
+        .unwrap_or("(none selected)");
+
+    let source_badge = if app.session_log_path.as_ref().is_some_and(|p| p.exists()) {
+        Span::styled("[LIVE] ", Style::default().fg(Color::Green).add_modifier(Modifier::BOLD))
+    } else {
+        Span::styled("[WAITING] ", Style::default().fg(Color::DarkGray))
+    };
+
+    let title_line = Line::from(vec![
+        source_badge,
+        Span::raw(agent_label),
+    ]);
+
+    let block = Block::default()
+        .title(title_line)
+        .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+        .border_type(if focused { BorderType::Rounded } else { BorderType::Plain })
+        .border_style(border_style);
+
+    // Show the last N lines that fit in the viewport
+    let inner_height = area.height.saturating_sub(2) as usize; // subtract top border + potential title
+    let start = app.stream_lines.len().saturating_sub(inner_height.max(1));
+    let visible: Vec<Line> = app.stream_lines[start..]
+        .iter()
+        .map(|line| {
+            let expanded = expand_keys(line);
+            Line::from(Span::raw(expanded))
+        })
+        .collect();
+
+    if visible.is_empty() {
+        let placeholder = if app.streaming_agent.is_none() {
+            "Select an agent with ↑↓ to stream its session log."
+        } else {
+            "Waiting for session log data..."
+        };
+        frame.render_widget(
+            Paragraph::new(placeholder)
+                .block(block)
+                .style(Style::default().fg(Color::DarkGray))
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    } else {
+        frame.render_widget(
+            Paragraph::new(visible)
+                .block(block)
+                .wrap(Wrap { trim: false }),
+            area,
+        );
+    }
+}
+
+fn draw_disabled_input(frame: &mut Frame, area: Rect, border_style: Style) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain)
+        .border_style(border_style);
+
+    let placeholder = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "[disabled] ",
+            Style::default().fg(Color::DarkGray).add_modifier(Modifier::ITALIC),
+        ),
+        Span::styled(
+            "control available in next release",
+            Style::default().fg(Color::DarkGray),
+        ),
+    ]))
+    .block(block);
+
+    frame.render_widget(placeholder, area);
+}
+
+// ── Status bar ────────────────────────────────────────────────────────────────
+
+fn draw_status_bar(frame: &mut Frame, area: Rect) {
+    let text = Line::from(vec![
+        Span::styled(" q", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::raw(": quit  "),
+        Span::styled("↑↓", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::raw(": select agent  "),
+        Span::styled("Tab", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        Span::raw(": switch panel "),
+    ]);
+    frame.render_widget(
+        Paragraph::new(text).style(Style::default().bg(Color::DarkGray)),
+        area,
+    );
+}
+
+// ── Utilities ─────────────────────────────────────────────────────────────────
+
+/// Truncate a string to `max_chars` characters, appending `…` when truncated.
+fn truncate_str(s: &str, max_chars: usize) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() <= max_chars {
+        s.to_string()
+    } else {
+        let end = max_chars.saturating_sub(1);
+        format!("{}…", chars[..end].iter().collect::<String>())
+    }
+}

--- a/examples/ci-provider-azdo/Cargo.lock
+++ b/examples/ci-provider-azdo/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -186,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +314,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +443,16 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -1045,6 +1085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1426,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/examples/provider-stub/Cargo.lock
+++ b/examples/provider-stub/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "notify",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -186,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +314,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -413,6 +443,16 @@ name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -1045,6 +1085,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,6 +1369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1426,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"


### PR DESCRIPTION
## Sprint D.1 — TUI Crate + Live Stream View (Read-Only)

Introduces the new `crates/atm-tui` binary crate: a ratatui-based TUI for ATM agent team monitoring.

## Deliverables

- **Dashboard panel (left)**: Team member list with agent state + inbox counts (sourced from `~/.claude/teams/{team}/inboxes/` files; 2s refresh rate-limited)
- **Agent Terminal panel (right)**: Live JSONL session log tail at 100ms poll from `${ATM_HOME}/.config/atm/agent-sessions/{team}/{agent}/output.log`; bounded 1000-line buffer
- **Session selector**: Arrow key navigation between agents with wrap-around; `Tab` cycles panel focus
- **Disabled input field**: Visible at bottom of Agent Terminal with placeholder `"control available in next release"` — no active input in D.1
- **JSONL column expansion**: Compact on-disk keys (`ts`, `lv`, `src`, `act`, etc.) expanded to full column names per `docs/tui-mvp-architecture.md §6`
- **C.1 structured event logging**: `tui_start`, `session_connect`, `stream_attach`, `stream_detach` via `emit_event_best_effort` (source: `"atm-tui"`)
- **Graceful exit**: `q` / `Ctrl-C` both exit cleanly
- **CLI flag**: `atm-tui --team <name>`

## Files Added

```
crates/atm-tui/
├── Cargo.toml
└── src/
    ├── main.rs           # CLI entry, 100ms refresh loop, event emissions
    ├── app.rs            # App state machine, MemberRow, FocusPanel, bounded stream buffer
    ├── ui.rs             # Ratatui two-column layout, disabled input field, status bar
    ├── agent_terminal.rs # COLUMN_MAP + expand_keys() for compact→full JSONL key expansion
    ├── dashboard.rs      # get_inbox_count() (direct file read), session_log_path()
    └── events.rs         # Keyboard: q/Ctrl-C quit, ↑↓ selection, Tab focus, others ignored
```

`Cargo.toml` (workspace): added `"crates/atm-tui"` to `members`.

## QA Results

### rust-qa-agent: ✅ PASS (iteration 1/3)
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo test --workspace`: all pass
- 17 atm-tui unit tests: 17/17 pass
- Sprint-required tests confirmed: `test_column_expansion`, `test_session_log_path`, `test_inbox_count_empty`, `test_inbox_count_with_messages`
- One pre-existing flaky test in atm-daemon (Sprint C.3, `test_control_duplicate_does_not_reenqueue`) waived — not introduced by D.1

### atm-qa-agent: ✅ PASS (iteration 1/3)
- All 8 exit criteria verified
- Design compliance: §3.1 mail-only dashboard, §3.2 control input disabled, §6 COLUMN_MAP complete (15 entries), §10 non-goals respected, no control protocol messages sent
- 2 warnings (doc cross-reference §2.1→§6; C.2b dependency sequencing) — informational only

Minor QA findings resolved before PR:
- QA-002: Named `TICK_INTERVAL` constant (was magic literal `100`)
- QA-003: `#[serial]` added to 3 dashboard tests with `ATM_HOME` env mutation
- QA-004: Doc test example in binary crate marked `ignore`

## Test Count

17 tests in `crates/atm-tui` across 4 modules: `agent_terminal`, `app`, `events`, `dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)