### PR TITLE
docs(tui): align agent_id model; add D.3 cleanup + demo; plan Phase E

### DIFF
--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2326,6 +2326,7 @@ C.3 is a single sprint (one SM, one dev agent). The three components are natural
 |--------|------|------------|--------|
 | D.1 | TUI crate + live stream view (read-only) | C.2b | ⏳ PLANNED |
 | D.2 | Interactive controls (stdin inject, interrupt) | C.3 | ⏳ PLANNED |
+| D.3 | Identifier cleanup + user demo | D.1, D.2 | ⏳ PLANNED |
 
 **Execution model**: D.1 and D.2 launch in parallel after Phase C integration merges to develop. D.1 needs only C.2b (session log tail + pub/sub). D.2 needs C.3 (control receiver endpoint).
 
@@ -2389,7 +2390,51 @@ C.3 is a single sprint (one SM, one dev agent). The three components are natural
 
 ---
 
-## 16. Future Plugins
+### Sprint D.3 — Identifier Cleanup (`thread_id` MCP-internal only) + User Demo
+
+**Branch**: `feature/pD-s3-identifier-cleanup`
+**Crate(s)**: `crates/atm-tui`, `crates/atm-daemon`, `crates/atm-agent-mcp` (boundary mapping), docs
+**Depends on**: D.1 merged + D.2 merged
+
+#### Scope
+
+1. Enforce `agent_id` as the only public conversation identifier in TUI/control docs and user-facing contracts.
+2. Remove `thread_id` from public TUI/control payload definitions and examples.
+3. Audit for non-MCP `thread_id` usage and either rename to backend-neutral `agent_id` or move behind MCP-internal adapters.
+4. Specifically review `crates/atm-daemon/src/plugins/worker_adapter/hook_watcher.rs` for non-MCP `thread_id` exposure and align naming/boundary docs.
+5. Add regression checks proving non-MCP public APIs do not require `thread_id`.
+6. Run a scripted user demo covering dashboard, agent terminal, control send/ack path, and one degraded scenario.
+
+#### Exit Criteria
+
+- [ ] No `thread_id` in `docs/tui-*.md` payload definitions/examples (except explicit MCP-internal notes).
+- [ ] No non-MCP public API surface requires `thread_id`.
+- [ ] Remaining `thread_id` usage is MCP-internal and documented as adapter-only.
+- [ ] `rg -n "thread_id|threadId" docs/tui-*.md crates/atm/src crates/atm-daemon/src` returns only approved exceptions.
+- [ ] User demo script is committed, runnable from clean checkout, and includes one degraded/failure scenario (`daemon unavailable` or `not_live` target).
+- [ ] Demo artifacts captured (logs/screenshots) and team-lead sign-off recorded.
+
+---
+
+## 16. Phase E (Planned): TUI Hardening and Production Readiness
+
+**Status**: PLANNED
+**Goal**: Harden Phase D TUI deliverables for reliability, observability, performance, and operator confidence under sustained real-world load.
+
+Planned scope:
+
+1. Reliability hardening (restart/reconnect handling, failure injection, queue/backpressure behavior).
+2. Performance tuning (render responsiveness under sustained stream load, control-ack visibility latency).
+3. UX/accessibility polish (focus consistency, keyboard ergonomics, high-noise workflow usability).
+4. Operational validation (repeatable runbooks, SLO-oriented checks, troubleshooting guidance).
+
+Gate intent:
+
+- Phase D provides functional end-to-end behavior.
+- Phase E raises operational quality for broader rollout.
+
+---
+## 17. Future Plugins
 
 Additional plugins planned (each is a self-contained sprint series):
 
@@ -2401,7 +2446,7 @@ Additional plugins planned (each is a self-contained sprint series):
 
 ---
 
-## 17. Sprint Summary
+## 18. Sprint Summary
 
 | Phase | Sprint | Name | Status | PR |
 |-------|--------|------|--------|-----|

--- a/docs/tui-control-protocol.md
+++ b/docs/tui-control-protocol.md
@@ -28,6 +28,7 @@ Phase alignment:
 
 - Phase C target is a lightweight receiver contract/stub (`C.3`): endpoint, validation, ack, dedupe skeleton
 - full interactive TUI control flows are Phase D scope
+- provider-native ids (such as Codex `threadId`) are MCP-internal details and must not appear in public TUI/control payloads
 
 ---
 
@@ -49,12 +50,11 @@ Control payload object fields:
 - `request_id` (string): stable idempotency key for the logical send
 - `team` (string): team namespace
 - `session_id` (string): Claude session id
-- `agent_id` (string): worker session id
+- `agent_id` (string): canonical conversation id exposed outside MCP
 - `sent_at` / `acked_at` (RFC 3339 UTC string)
 
 Optional:
 
-- `thread_id` (string): backend-native thread/conversation handle
 - `meta` (object): transport/UI metadata
 
 Versioning rule:
@@ -84,7 +84,6 @@ Required fields:
 
 Optional fields:
 
-- `thread_id`
 - `content_encoding` (default: `utf-8`)
 - `content_preview`
 - `interrupt` (default: `false`)
@@ -133,7 +132,6 @@ Required fields:
 
 Optional fields:
 
-- `thread_id`
 - `meta.retry_count`
 - `meta.ui_source`
 
@@ -187,7 +185,7 @@ Notes:
 Rules:
 
 - retries of a logical send must reuse the same `request_id`
-- receiver deduplicates by `request_id + session_id + agent_id`
+- receiver deduplicates by `team + request_id + session_id + agent_id`
 - duplicate delivery must not re-execute input injection
 - duplicate request returns ack with:
   - `result = "ok"`
@@ -282,7 +280,6 @@ Minimum audit fields for both request and ack events:
   "request_id": "req_01HZY8QJ8R7G6K2YJ7V2M9A1P3",
   "session_id": "claude-session-uuid",
   "agent_id": "codex:abc123",
-  "thread_id": "thread-xyz789",
   "team": "atm-dev",
   "sender": "arch-ctm",
   "sent_at": "2026-02-20T21:15:00Z",

--- a/docs/tui-mvp-architecture.md
+++ b/docs/tui-mvp-architecture.md
@@ -195,13 +195,17 @@ File-reference path uses shared local storage and sends `content_ref` metadata i
 Definitions:
 
 - `session_id`: Claude session identifier
-- `agent_id`: ATM worker session identifier (e.g. `codex:...`)
-- `thread_id`: backend-specific conversation handle (e.g. Codex internal thread ID)
+- `agent_id`: canonical conversation/session identifier for ATM and TUI surfaces (backend-agnostic)
 
 Correlation:
 
 - all control requests require `request_id`
 - retries must reuse the same `request_id` (idempotent)
+
+Backend mapping rule:
+
+- provider-specific ids (for example Codex `threadId`) are MCP-internal details
+- outside MCP, callers use `agent_id` only
 
 ---
 


### PR DESCRIPTION
## Summary
- make `agent_id` the canonical public conversation identifier in TUI docs
- remove public `thread_id` fields/examples from TUI control protocol docs
- add Phase D Sprint D.3 for identifier cleanup + user demo
- add planned Phase E section for TUI hardening/production readiness

## Files
- docs/tui-mvp-architecture.md
- docs/tui-control-protocol.md
- docs/project-plan.md

## Notes
- provider-native ids (e.g. Codex `threadId`) are documented as MCP-internal only
- D.3 explicitly flags `crates/atm-daemon/src/plugins/worker_adapter/hook_watcher.rs` for non-MCP `thread_id` review
