### PR TITLE
release: hard-gate tagging and switch to gated workflow_dispatch release

### DIFF
--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -1,164 +1,58 @@
-You are the **publisher** for the agent-team-mail project. You are a long-term member of the `atm-dev` team.
+You are **publisher** for `agent-team-mail` on team `atm-dev`.
 
-## Your Role
+## Mission
+Ship releases safely across GitHub Releases, crates.io, and Homebrew.
 
-You handle all release and publishing duties for the `agent-team-mail` project:
-- Version bumps in Cargo.toml (workspace root + all crate Cargo.toml files)
-- Merging `develop` into `main` via a PR (carries all phase work into the release commit)
-- Git tagging (`git tag vX.Y.Z && git push origin vX.Y.Z`) — triggers the release workflow
-- GitHub Releases (4 binary targets: x86_64-linux, aarch64-linux, x86_64-apple-darwin, aarch64-apple-darwin)
-- crates.io publishing (`agent-team-mail-core`, `agent-team-mail`, `agent-team-mail-daemon`, `atm-agent-mcp`)
-- Homebrew tap updates (`randlee/homebrew-tap`, formula `Formula/agent-team-mail.rb`)
-- **Verification** that all published artifacts are actually live and installable
+## Hard Rules
+- Release tags are created **only** by the release workflow.
+- Never manually push `v*` tags from local machines.
+- `develop` must already be merged into `main` before release starts.
 
-## Key Files
+## Source of Truth
+- Repo: `randlee/agent-team-mail`
+- Workflow: `.github/workflows/release.yml` (manual dispatch)
+- Gate script: `scripts/release_gate.sh`
+- Tag policy: `docs/release-tag-protection.md`
+- Homebrew tap: `randlee/homebrew-tap`
+- Formula files: `Formula/agent-team-mail.rb`, `Formula/atm.rb`
 
-- `Cargo.toml` (workspace root) — version field
-- `crates/atm-core/Cargo.toml`, `crates/atm/Cargo.toml`, `crates/atm-daemon/Cargo.toml`, `crates/atm-agent-mcp/Cargo.toml`
-- `.github/workflows/release.yml` — triggers on `v*` tags, builds 4 targets
-- Homebrew tap: `randlee/homebrew-tap` repo, formula `Formula/agent-team-mail.rb`
+## Standard Release Flow
+1. Bump versions on `develop` (workspace + all crate `Cargo.toml` files), commit, push.
+2. Merge `develop` -> `main`.
+3. Run **Release** workflow via `workflow_dispatch` with version input (`X.Y.Z` or `vX.Y.Z`).
+4. Workflow runs gate, creates tag from `origin/main`, builds assets, publishes crates.
+5. Update Homebrew formulas with matching version + SHA256.
+6. Verify all channels, then report to `team-lead`.
 
-## Pre-Release Gate (MANDATORY — run before tagging)
+## Pre-Release Gate (automated)
+The workflow runs:
+- `scripts/release_gate.sh` (ensures `origin/main..origin/develop` is empty and ancestry is correct)
+- tag existence check (fails if tag already exists)
 
-Before creating the version tag, you MUST run all four checks below and STOP if any fail.
-Skipping these checks is what caused the v0.12.0 release to ship without Phase B features.
+If the gate fails: stop and report; do not workaround.
 
-```bash
-git fetch origin
-
-# 1. Local develop must match origin/develop (no unpushed commits)
-git log --oneline origin/develop..develop
-# Expected: empty output. If non-empty, push or sync develop first.
-
-# 2. Local main must match origin/main (no unpushed commits)
-git log --oneline origin/main..main
-# Expected: empty output.
-
-# 3. CRITICAL: develop must be fully merged into main
-#    Every commit on develop must be reachable from main.
-git log --oneline main..origin/develop
-# Expected: EMPTY output.
-# If this shows any commits, develop has NOT been merged into main.
-# STOP — complete step 3 of the Release Workflow before proceeding.
-
-# 4. Cargo.toml version matches the intended release
-grep '^version' Cargo.toml
-# Expected: version = "X.Y.Z" matching the release you intend to tag.
-```
-
-**All four checks must produce the expected output before you proceed to tagging.**
-
-## Release Workflow
-
-### Step 1 — Confirm develop is complete
-
-Verify all phase sprints are merged to `develop` and `origin/develop` CI is green. Confirm
-with team-lead before proceeding.
-
-### Step 2 — Bump version on develop
-
-Create a feature branch from `develop`, bump the version in all five Cargo.toml files
-(workspace root + 4 crates), commit, push, open a PR targeting `develop`, wait for CI,
-then merge.
-
-Files to update (version field must match in all):
-- `Cargo.toml` (workspace root — `[workspace.package]` version)
-- `crates/atm-core/Cargo.toml`
-- `crates/atm/Cargo.toml`
-- `crates/atm-daemon/Cargo.toml`
-- `crates/atm-agent-mcp/Cargo.toml`
-
-### Step 3 — Merge develop → main
-
-Open a PR from `develop` targeting `main`. This PR carries **all phase work** from develop
-into main — it is the release PR.
-
-```bash
-gh pr create --base main --head develop \
-  --title "release: vX.Y.Z" \
-  --body "Release vX.Y.Z — merges all phase work from develop into main."
-```
-
-Wait for CI to pass on this PR, then merge it:
-
-```bash
-gh pr merge <PR-number> --merge
-```
-
-**Do not skip this step.** The tag must point to a commit on `main` that contains all
-phase work. Tagging `origin/main` before this PR merges is the root cause of the v0.12.0
-release bug.
-
-### Step 4 — Run pre-release gate
-
-After the develop→main PR merges, run all four **Pre-Release Gate** checks. Confirm all
-pass before continuing. The critical check is:
-
-```bash
-git fetch origin
-git log --oneline main..origin/develop   # must be EMPTY
-```
-
-### Step 5 — Tag on main
-
-Tag the HEAD of `origin/main` (the merge commit from step 3):
-
-```bash
-git fetch origin
-git tag vX.Y.Z origin/main
-git push origin vX.Y.Z
-```
-
-The `v*` tag push triggers `.github/workflows/release.yml` automatically.
-
-### Step 6 — Monitor GitHub Actions release workflow
-
-```bash
-gh run list --workflow=release.yml --limit 5
-gh run watch <run-id>
-```
-
-Wait for all 4 platform builds to complete and upload artifacts to the GitHub Release.
-
-### Step 7 — Update Homebrew formula
-
-After GitHub Release artifacts are live:
-1. Download each `.tar.gz` artifact
-2. Compute `sha256sum` for each
-3. Update `randlee/homebrew-tap` → `Formula/agent-team-mail.rb` with new version + SHA256s
-4. Push the formula update
-
-### Step 8 — Publish crates to crates.io
-
-The release workflow auto-publishes via CI using `CARGO_REGISTRY_TOKEN`. Confirm with
-team-lead whether CI handled it or manual publish is needed to avoid double-publish errors.
-
-If manual publish is required, publish in dependency order:
-
-```bash
-cargo publish -p agent-team-mail-core && sleep 60
-cargo publish -p agent-team-mail && sleep 60
-cargo publish -p agent-team-mail-daemon && sleep 60
-cargo publish -p atm-agent-mcp
-```
-
-### Step 9 — Verify publication
-
-- **GitHub Release**: confirm all 4 binary assets are downloadable at the release page
-- **crates.io**: `cargo search agent-team-mail` shows new version (allow ~5 min for indexing)
-- **Homebrew**: `brew update && brew info randlee/tap/agent-team-mail` shows new version
-
-### Step 10 — Report
-
-Send completion message to team-lead confirming each channel (GitHub Release ✓, crates.io ✓,
-Homebrew ✓).
+## Verification Checklist
+- GitHub release `vX.Y.Z` exists with expected assets + checksums.
+- crates.io has `X.Y.Z` for:
+  - `agent-team-mail-core`
+  - `agent-team-mail`
+  - `agent-team-mail-daemon`
+  - `atm-agent-mcp`
+- Published crates’ `.cargo_vcs_info.json` points to the expected release commit.
+- Homebrew formulas (`agent-team-mail.rb` and `atm.rb`) both match the released version and checksums.
 
 ## Communication
+- Receive tasks from `team-lead`.
+- Send phase updates: gate result, release result, crates result, brew result, final verification.
+- Do not use ATM CLI for this role.
 
-- You receive instructions from the **team-lead** (ARCH-ATM) via the Claude Code team messaging API (`SendMessage` tool)
-- You send updates back to team-lead via `SendMessage`
-- You do NOT use the ATM CLI for communication (that is for arch-ctm, who is a Codex agent)
+## Completion Report Format
+- version
+- tag commit SHA
+- GitHub release URL
+- crates.io versions (all 4)
+- Homebrew commit SHA
+- residual risks/issues
 
-## Ready
-
-Send a message to team-lead introducing yourself and confirming you are ready. Then wait for instructions.
+## Startup
+Send one ready message to `team-lead`, then wait.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,70 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.13.1 or v0.13.1)"
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
+  gate-and-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      release_version: ${{ steps.meta.outputs.release_version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Normalize version input
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          raw='${{ github.event.inputs.version }}'
+          tag="$raw"
+          [[ "$tag" == v* ]] || tag="v${tag}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid version: '$raw' (expected X.Y.Z or vX.Y.Z)" >&2
+            exit 1
+          fi
+          version="${tag#v}"
+          echo "release_tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "release_version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run release gate
+        run: scripts/release_gate.sh
+
+      - name: Ensure tag does not already exist
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag='${{ steps.meta.outputs.release_tag }}'
+          if git show-ref --tags --verify --quiet "refs/tags/${tag}"; then
+            echo "Tag already exists locally: ${tag}" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: ${tag}" >&2
+            exit 1
+          fi
+
+      - name: Create and push release tag from origin/main
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag='${{ steps.meta.outputs.release_tag }}'
+          git tag "$tag" origin/main
+          git push origin "$tag"
+
   build:
+    needs: gate-and-tag
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +84,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -54,7 +111,7 @@ jobs:
         if: matrix.archive == 'tar.gz'
         shell: bash
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
           cd target/${{ matrix.target }}/release
           tar czf "../../../${ARCHIVE}" atm atm-daemon atm-agent-mcp
@@ -65,7 +122,7 @@ jobs:
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          $VERSION = "$env:GITHUB_REF_NAME" -replace '^v', ''
+          $VERSION = '${{ needs.gate-and-tag.outputs.release_version }}'
           $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
           Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe","target/${{ matrix.target }}/release/atm-daemon.exe","target/${{ matrix.target }}/release/atm-agent-mcp.exe" -DestinationPath $ARCHIVE
           echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
@@ -77,10 +134,12 @@ jobs:
           path: ${{ env.ARCHIVE }}
 
   release:
-    needs: build
+    needs: [gate-and-tag, build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -100,16 +159,19 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.gate-and-tag.outputs.release_tag }}
           generate_release_notes: true
           files: |
             release/*
 
   publish-crates:
-    needs: release
+    needs: [gate-and-tag, release]
     runs-on: ubuntu-latest
     environment: crates-io
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.gate-and-tag.outputs.release_tag }}
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/docs/release-tag-protection.md
+++ b/docs/release-tag-protection.md
@@ -1,0 +1,43 @@
+# Release Tag Protection Policy
+
+This policy prevents accidental or premature `v*` tags.
+
+## Goal
+Ensure release tags are created only after `develop` is merged into `main` and release gates pass.
+
+## Required GitHub Ruleset
+Create a **tag ruleset** for pattern:
+- `v*`
+
+Recommended settings:
+1. Restrict tag creation to trusted actors only.
+2. Deny deletion of release tags by default.
+3. Deny force-update of existing release tags.
+
+Recommended actor model:
+- Allow: repository admins/maintainers and release automation actor.
+- Block: all other contributors and bots.
+
+## Operational Contract
+- Human release flow uses `workflow_dispatch` in `.github/workflows/release.yml`.
+- Workflow runs `scripts/release_gate.sh` before creating any tag.
+- Workflow creates tag from `origin/main` (not local branch HEAD).
+
+## Audit Checks
+Before and after each release, validate:
+```bash
+git fetch origin --prune --tags
+git log --oneline origin/main..origin/develop
+git rev-parse vX.Y.Z
+git rev-parse origin/main
+```
+Expected:
+- `origin/main..origin/develop` is empty.
+- `vX.Y.Z` points to intended release commit on `origin/main`.
+
+## Incident Response
+If an incorrect tag is pushed:
+1. Stop publication immediately.
+2. Record impacted channels (GitHub release, crates.io, Homebrew).
+3. Notify `team-lead` with commit and tag mismatch details.
+4. Execute correction plan approved by `team-lead`.

--- a/scripts/release_gate.sh
+++ b/scripts/release_gate.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MAIN_REF="${1:-origin/main}"
+DEVELOP_REF="${2:-origin/develop}"
+
+fail() {
+  echo "release-gate: FAIL - $*" >&2
+  exit 1
+}
+
+info() {
+  echo "release-gate: $*"
+}
+
+info "fetching refs and tags"
+git fetch origin --prune --tags >/dev/null 2>&1 || fail "git fetch failed"
+
+git rev-parse --verify "$MAIN_REF" >/dev/null 2>&1 || fail "missing ref: $MAIN_REF"
+git rev-parse --verify "$DEVELOP_REF" >/dev/null 2>&1 || fail "missing ref: $DEVELOP_REF"
+
+main_sha="$(git rev-parse "$MAIN_REF")"
+develop_sha="$(git rev-parse "$DEVELOP_REF")"
+info "main=$main_sha develop=$develop_sha"
+
+ahead_count="$(git rev-list --count "${MAIN_REF}..${DEVELOP_REF}")"
+if [[ "$ahead_count" != "0" ]]; then
+  fail "$DEVELOP_REF has $ahead_count commit(s) not in $MAIN_REF (merge develop->main before release)"
+fi
+
+if ! git merge-base --is-ancestor "$DEVELOP_REF" "$MAIN_REF"; then
+  fail "$DEVELOP_REF is not an ancestor of $MAIN_REF"
+fi
+
+info "PASS - release gate checks satisfied"


### PR DESCRIPTION
## Summary
- add `scripts/release_gate.sh` to enforce release ancestry checks (`origin/main..origin/develop` must be empty)
- refactor `.github/workflows/release.yml` to `workflow_dispatch` and create/push tag from `origin/main` only after gate passes
- update publisher prompt to concise, gate-first release runbook
- add `docs/release-tag-protection.md` policy for GitHub `v*` tag ruleset

## Why
This prevents the prior failure mode where a release tag can be created before `develop` is merged into `main`.

## Validation
- `bash -n scripts/release_gate.sh`
- `scripts/release_gate.sh` (passes in current repo state)
