### PR TITLE
release: v0.14.0 — Phase D (TUI) + E.1 (session fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           key: ${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Build release binaries
-        run: cargo build --release --target ${{ matrix.target }} --bin atm --bin atm-daemon --bin atm-agent-mcp
+        run: cargo build --release --target ${{ matrix.target }} --bin atm --bin atm-daemon --bin atm-agent-mcp --bin atm-tui
 
       - name: Package (unix)
         if: matrix.archive == 'tar.gz'
@@ -114,7 +114,7 @@ jobs:
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
           cd target/${{ matrix.target }}/release
-          tar czf "../../../${ARCHIVE}" atm atm-daemon atm-agent-mcp
+          tar czf "../../../${ARCHIVE}" atm atm-daemon atm-agent-mcp atm-tui
           cd ../../..
           echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
 
@@ -124,7 +124,7 @@ jobs:
         run: |
           $VERSION = '${{ needs.gate-and-tag.outputs.release_version }}'
           $ARCHIVE = "atm_${VERSION}_${{ matrix.target }}.zip"
-          Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe","target/${{ matrix.target }}/release/atm-daemon.exe","target/${{ matrix.target }}/release/atm-agent-mcp.exe" -DestinationPath $ARCHIVE
+          Compress-Archive -Path "target/${{ matrix.target }}/release/atm.exe","target/${{ matrix.target }}/release/atm-daemon.exe","target/${{ matrix.target }}/release/atm-agent-mcp.exe","target/${{ matrix.target }}/release/atm-tui.exe" -DestinationPath $ARCHIVE
           echo "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload artifact
@@ -204,3 +204,11 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish -p atm-agent-mcp
+
+      - name: Wait for crates.io indexing
+        run: sleep 60
+
+      - name: Publish atm-tui
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p atm-tui

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -47,7 +47,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "atm-agent-mcp"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "atm-tui"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.13.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.14.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -12,7 +12,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.13.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.14.0" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.13.0 to 0.14.0
- Add `atm-tui` binary to release workflow (build, package, crates.io publish)
- Update internal `agent-team-mail-core` dependency version pins

## Release Contents (since v0.13.0)
- **Phase D**: `atm-tui` binary crate — live streaming TUI + interactive controls (PRs #136, #138, #143, #144, integration #140)
- **Phase E.1**: Fix `atm teams resume` session ID reliability (PR #147)
- Release workflow hardening: dispatch-based gate (PR #139)
- Hook documentation (PR #146)

## Release Process
1. ✅ Version bump + CI validation (this PR)
2. Merge this PR to `develop`
3. Create PR `develop → main`, merge
4. Trigger `workflow_dispatch` release with version `0.14.0`
5. Workflow tags `origin/main`, builds 4 targets, creates GitHub Release, publishes crates

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 1,338 tests pass
- [ ] CI passes on this PR
- [ ] Merge to develop, then PR to main
- [ ] Dispatch release workflow after main merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)