### PR TITLE
fix(read): only mark own inbox messages as read (Sprint E.2)

### DIFF
--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -268,9 +268,14 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         }
     }
 
+    // Determine the calling identity so we never touch another agent's read flags.
+    let calling_identity = config.core.identity.clone();
+
     // Mark messages as read (unless --no-mark specified)
+    // Only mark when the caller is reading their own inbox — peeking at another
+    // agent's inbox must never alter that agent's read state.
     let mut marked_count: u64 = 0;
-    if !args.no_mark && !filtered_messages.is_empty() {
+    if !args.no_mark && !filtered_messages.is_empty() && agent_name == calling_identity {
         // Find message IDs that need to be marked
         let filtered_ids: Vec<String> = filtered_messages
             .iter()

--- a/crates/atm/tests/integration_e2e_workflows.rs
+++ b/crates/atm/tests/integration_e2e_workflows.rs
@@ -127,10 +127,11 @@ fn test_send_read_verify_basic() {
     assert_eq!(messages.len(), 1);
     assert_eq!(messages[0]["read"], false);
 
-    // Read message
+    // Read message (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -168,10 +169,11 @@ fn test_send_multiple_read_verify_all_marked() {
     assert_eq!(messages.len(), 3);
     assert!(messages.iter().all(|m| m["read"] == false));
 
-    // Read all messages
+    // Read all messages (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -211,10 +213,11 @@ fn test_send_read_with_from_filter_verify() {
         .assert()
         .success();
 
-    // Read with --from filter
+    // Read with --from filter (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -253,10 +256,11 @@ fn test_send_read_with_limit_verify() {
             .success();
     }
 
-    // Read with limit of 2
+    // Read with limit of 2 (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -331,10 +335,11 @@ fn test_send_cross_team_read_verify() {
     let messages: Vec<serde_json::Value> = serde_json::from_str(&content).unwrap();
     assert_eq!(messages[0]["read"], false);
 
-    // Read from team-b
+    // Read from team-b (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "team-b")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -417,11 +422,12 @@ fn test_broadcast_read_all_inboxes_verify() {
         assert_eq!(messages[0]["read"], false);
     }
 
-    // Read each agent's inbox
+    // Read each agent's inbox (as that agent — identity must match to trigger mark-read)
     for agent in &["agent-a", "agent-b", "agent-c"] {
         let mut cmd = cargo::cargo_bin_cmd!("atm");
         set_home_env(&mut cmd, &temp_dir);
         cmd.env("ATM_TEAM", "test-team")
+            .env("ATM_IDENTITY", agent)
             .arg("read")
         .arg("--no-since-last-seen")
             .arg(agent)
@@ -465,11 +471,12 @@ fn test_broadcast_cross_team_verify() {
         assert_eq!(messages[0]["text"], "Cross-team broadcast");
     }
 
-    // Read all team-b inboxes
+    // Read all team-b inboxes (as each agent — identity must match to trigger mark-read)
     for agent in &["agent-a", "agent-b", "agent-c"] {
         let mut cmd = cargo::cargo_bin_cmd!("atm");
         set_home_env(&mut cmd, &temp_dir);
         cmd.env("ATM_TEAM", "team-b")
+            .env("ATM_IDENTITY", agent)
             .arg("read")
         .arg("--no-since-last-seen")
             .arg(agent)
@@ -510,11 +517,12 @@ fn test_broadcast_multiple_times_verify_all_received() {
         assert_eq!(messages.len(), 3);
     }
 
-    // Read all messages for each agent
+    // Read all messages for each agent (as that agent — identity must match to trigger mark-read)
     for agent in &["agent-a", "agent-b", "agent-c"] {
         let mut cmd = cargo::cargo_bin_cmd!("atm");
         set_home_env(&mut cmd, &temp_dir);
         cmd.env("ATM_TEAM", "test-team")
+            .env("ATM_IDENTITY", agent)
             .arg("read")
         .arg("--no-since-last-seen")
             .arg(agent)
@@ -724,10 +732,11 @@ fn test_conversation_workflow() {
         .assert()
         .success();
 
-    // Step 2: Agent B reads the message
+    // Step 2: Agent B reads the message (as agent-b — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-b")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-b")
@@ -751,10 +760,11 @@ fn test_conversation_workflow() {
         .assert()
         .success();
 
-    // Step 4: Agent A reads the reply
+    // Step 4: Agent A reads the reply (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -810,10 +820,11 @@ fn test_team_discussion_workflow() {
             .success();
     }
 
-    // Step 4: Team lead reads all replies
+    // Step 4: Team lead reads all replies (as team-lead — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_IDENTITY", "team-lead")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("team-lead")
@@ -845,10 +856,11 @@ fn test_cross_team_relay_workflow() {
         .assert()
         .success();
 
-    // Step 2: Agent in team-a reads the message
+    // Step 2: Agent in team-a reads the message (as agent-a — identity must match to trigger mark-read)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "team-a")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")
@@ -872,10 +884,11 @@ fn test_cross_team_relay_workflow() {
         .assert()
         .success();
 
-    // Step 4: Team-b agent reads the forwarded message
+    // Step 4: Team-b agent reads the forwarded message (as agent-a — identity must match)
     let mut cmd = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut cmd, &temp_dir);
     cmd.env("ATM_TEAM", "team-b")
+        .env("ATM_IDENTITY", "agent-a")
         .arg("read")
         .arg("--no-since-last-seen")
         .arg("agent-a")

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2426,8 +2426,8 @@ C.3 is a single sprint (one SM, one dev agent). The three components are natural
 
 | Sprint | Name | Depends On | Status |
 |--------|------|------------|--------|
-| E.1 | Fix `atm teams resume` session ID reliability | Phase D | 🔄 IN PROGRESS |
-| E.2 | Fix inbox read marking other agents' messages as read | — | ⏳ PLANNED |
+| E.1 | Fix `atm teams resume` session ID reliability | Phase D | ✅ MERGED |
+| E.2 | Fix inbox read marking other agents' messages as read | — | 🔄 IN PROGRESS |
 | E.3 | Hook-to-daemon state bridge | E.1 | ⏳ PLANNED |
 
 **Execution model**: E.1 is priority (unblocks session startup). E.2 and E.3 can run in parallel after E.1 merges.


### PR DESCRIPTION
## Summary

- **Bug fixed**: `atm read arch-ctm` run by team-lead was marking arch-ctm's messages as `read: true`, causing arch-ctm to silently miss messages that team-lead had already polled
- **Root cause**: The mark-read block in `read.rs` unconditionally wrote to the target agent's inbox file, regardless of whether the caller owned that inbox
- **Fix**: Single-condition guard `&& agent_name == calling_identity` — mark-read is skipped entirely when reading another agent's inbox (peek-only semantics)

## Changes

| File | Change |
|------|--------|
| `crates/atm/src/commands/read.rs` | Add `calling_identity` from config; guard mark-read block |
| `crates/atm/tests/integration_read.rs` | New regression test `test_read_does_not_mark_other_agents_messages`; set `ATM_IDENTITY` on `test_read_marks_as_read` |
| `crates/atm/tests/integration_e2e_workflows.rs` | Set `ATM_IDENTITY` on 11 e2e `read` invocations that expect mark-read to fire |
| `docs/project-plan.md` | E.1 → MERGED, E.2 → IN PROGRESS |

## QA

- ✅ **Technical QA** (rust-qa-agent): PASS — clippy clean, 934+ tests pass, regression test confirmed
- ✅ **Compliance QA** (atm-qa-agent): PASS — 0 blocking findings, 3 minor informational notes
- Iteration 1 of 3 (first pass)

## Test Plan

- `test_read_does_not_mark_other_agents_messages`: team-lead reads arch-ctm inbox without `--no-mark`; verifies `read: false` is preserved in `arch-ctm.json`
- `test_read_marks_as_read`: confirms own-inbox marking still works correctly
- 11 e2e workflow tests updated and passing

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)