### PR TITLE
fix(atm-tui): add crates.io description

### DIFF
--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+description = "Terminal UI for agent-team-mail: live streaming dashboard for AI agent teams"
 
 [[bin]]
 name = "atm-tui"


### PR DESCRIPTION
## Summary
- Add missing `description` field to `atm-tui/Cargo.toml` required by crates.io

The v0.14.0 release workflow completed builds and GitHub Release successfully, but `cargo publish -p atm-tui` failed due to missing description metadata. This fix needs to reach main so we can manually re-publish.

## Test plan
- [x] Cargo.toml is valid (builds locally)
- [ ] CI passes
- [ ] Merge to develop → PR to main → manual `cargo publish -p atm-tui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)