### PR TITLE
fix(atm-tui): add crates.io description for v0.14.0

### DIFF
--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 repository.workspace = true
 homepage.workspace = true
+description = "Terminal UI for agent-team-mail: live streaming dashboard for AI agent teams"
 
 [[bin]]
 name = "atm-tui"


### PR DESCRIPTION
## Summary
Add missing `description` field to `atm-tui/Cargo.toml` so it can be published to crates.io.

The v0.14.0 release published all other crates successfully but `atm-tui` failed due to missing metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)