### PR TITLE
fix(release): make tag creation idempotent for re-dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,25 +41,24 @@ jobs:
       - name: Run release gate
         run: scripts/release_gate.sh
 
-      - name: Ensure tag does not already exist
+      - name: Ensure tag is correct or create it
         shell: bash
         run: |
           set -euo pipefail
           tag='${{ steps.meta.outputs.release_tag }}'
-          if git show-ref --tags --verify --quiet "refs/tags/${tag}"; then
-            echo "Tag already exists locally: ${tag}" >&2
-            exit 1
+          main_sha="$(git rev-parse origin/main)"
+          # Check if tag already exists on remote
+          remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${tag}" | awk '{print $1}' || true)"
+          if [[ -n "$remote_tag_sha" ]]; then
+            if [[ "$remote_tag_sha" == "$main_sha" ]]; then
+              echo "Tag ${tag} already exists and points to origin/main (${main_sha}), skipping creation"
+              exit 0
+            else
+              echo "Tag ${tag} exists but points to ${remote_tag_sha}, not origin/main (${main_sha})" >&2
+              exit 1
+            fi
           fi
-          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-            echo "Tag already exists on origin: ${tag}" >&2
-            exit 1
-          fi
-
-      - name: Create and push release tag from origin/main
-        shell: bash
-        run: |
-          set -euo pipefail
-          tag='${{ steps.meta.outputs.release_tag }}'
+          echo "Creating tag ${tag} at origin/main (${main_sha})"
           git tag "$tag" origin/main
           git push origin "$tag"
 


### PR DESCRIPTION
## Summary
- Allow release workflow to re-dispatch when tag already exists pointing to origin/main
- Combined with the publish idempotency fix, enables full re-runs of the release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)