### PR TITLE
rename: crate packages to agent-team-mail-{mcp,tui} convention

### DIFF
--- a/.claude/agents/publisher.md
+++ b/.claude/agents/publisher.md
@@ -37,7 +37,8 @@ If the gate fails: stop and report; do not workaround.
   - `agent-team-mail-core`
   - `agent-team-mail`
   - `agent-team-mail-daemon`
-  - `atm-agent-mcp`
+  - `agent-team-mail-mcp`
+  - `agent-team-mail-tui`
 - Published crates’ `.cargo_vcs_info.json` points to the expected release commit.
 - Homebrew formulas (`agent-team-mail.rb` and `atm.rb`) both match the released version and checksums.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Publish atm-agent-mcp
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p atm-agent-mcp || echo "already published (skipping)"
+        run: cargo publish -p agent-team-mail-mcp || echo "already published (skipping)"
 
       - name: Wait for crates.io indexing
         run: sleep 60
@@ -210,4 +210,4 @@ jobs:
       - name: Publish atm-tui
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish -p atm-tui || echo "already published (skipping)"
+        run: cargo publish -p agent-team-mail-tui || echo "already published (skipping)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-team-mail-mcp"
+version = "0.14.0"
+dependencies = [
+ "agent-team-mail-core",
+ "anyhow",
+ "async-trait",
+ "clap",
+ "dirs",
+ "libc",
+ "serde",
+ "serde_json",
+ "serial_test",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-team-mail-tui"
+version = "0.14.0"
+dependencies = [
+ "agent-team-mail-core",
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossterm",
+ "ratatui",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,44 +230,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atm-agent-mcp"
-version = "0.14.0"
-dependencies = [
- "agent-team-mail-core",
- "anyhow",
- "async-trait",
- "clap",
- "dirs",
- "libc",
- "serde",
- "serde_json",
- "serial_test",
- "tempfile",
- "thiserror 2.0.18",
- "tokio",
- "toml",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "atm-tui"
-version = "0.14.0"
-dependencies = [
- "agent-team-mail-core",
- "anyhow",
- "chrono",
- "clap",
- "crossterm",
- "ratatui",
- "serde",
- "serde_json",
- "tempfile",
- "tokio",
- "uuid",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ cargo install agent-team-mail
 cargo install agent-team-mail-daemon
 
 # Install the MCP proxy (optional)
-cargo install atm-agent-mcp
+cargo install agent-team-mail-mcp
+
+# Install the TUI dashboard (optional)
+cargo install agent-team-mail-tui
 ```
 
 ### Build from Source

--- a/crates/atm-agent-mcp/Cargo.toml
+++ b/crates/atm-agent-mcp/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "atm-agent-mcp"
+name = "agent-team-mail-mcp"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -8,6 +8,9 @@ repository.workspace = true
 rust-version.workspace = true
 description = "MCP proxy for managing Codex agent sessions with ATM team integration"
 default-run = "atm-agent-mcp"
+
+[lib]
+name = "atm_agent_mcp"
 
 [[bin]]
 name = "atm-agent-mcp"

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "atm-tui"
+name = "agent-team-mail-tui"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary
Rename crate package names for crates.io naming consistency:
- `atm-agent-mcp` → `agent-team-mail-mcp` (binary stays `atm-agent-mcp`)
- `atm-tui` → `agent-team-mail-tui` (binary stays `atm-tui`)

**Why**: `atm-tui` was already taken on crates.io by another project. Aligning both crates to the `agent-team-mail-*` convention.

## Changes
- `crates/atm-agent-mcp/Cargo.toml`: package name + `[lib]` name override for Rust identifier compat
- `crates/atm-tui/Cargo.toml`: package name
- `.github/workflows/release.yml`: publish step references
- `README.md`: install commands
- `.claude/agents/publisher.md`: crate list

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all tests pass
- [ ] CI passes
- [ ] After merge to main: yank old crates, re-tag, re-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)