### PR TITLE
feat(E.5): TUI preferences, interrupt confirmation, follow mode, perf validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,8 +227,10 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
+ "toml",
  "uuid",
 ]
 

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -22,6 +22,8 @@ anyhow = "1.0"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time", "fs", "io-util"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }
+toml = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"

--- a/crates/atm-tui/src/app.rs
+++ b/crates/atm-tui/src/app.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 
 use agent_team_mail_core::daemon_client::AgentSummary;
 
+use crate::config::TuiConfig;
+
 /// A single row shown in the Dashboard panel.
 #[derive(Debug, Clone)]
 pub struct MemberRow {
@@ -82,11 +84,33 @@ pub struct App {
     ///
     /// The UI renders a `[FROZEN]` indicator in the stream pane when this is set.
     pub stream_source_error: Option<String>,
+    /// User preferences loaded from `~/.config/atm/tui.toml` at startup.
+    pub config: TuiConfig,
+    /// When `true`, a `Ctrl-I` was pressed while [`InterruptPolicy::Confirm`] is
+    /// active. The status bar shows `"Send interrupt? [y/N]"` and the next
+    /// `y`/`Enter` dispatches the interrupt; `n`/`Esc` cancels.
+    pub confirm_interrupt_pending: bool,
+    /// Whether the stream pane auto-scrolls to the latest line on each append.
+    ///
+    /// Toggled at runtime with `F`. Initialized from
+    /// [`TuiConfig::follow_mode_default`].
+    pub follow_mode: bool,
+    /// Current scroll offset for the stream pane, counted from the top of
+    /// [`stream_lines`](Self::stream_lines).
+    ///
+    /// When [`follow_mode`](Self::follow_mode) is `true` this is updated
+    /// automatically on every [`append_stream_lines`](Self::append_stream_lines)
+    /// call so the view stays pinned to the bottom. When follow mode is off the
+    /// value is preserved, allowing the user to read earlier output.
+    pub stream_scroll_offset: usize,
 }
 
 impl App {
-    /// Create a new [`App`] for the given team.
-    pub fn new(team: String) -> Self {
+    /// Create a new [`App`] for the given team with the provided user config.
+    ///
+    /// `follow_mode` is initialised from [`TuiConfig::follow_mode_default`].
+    pub fn new(team: String, config: TuiConfig) -> Self {
+        let follow_mode = config.follow_mode_default;
         Self {
             team,
             members: Vec::new(),
@@ -103,6 +127,10 @@ impl App {
             status_message: None,
             pending_control: None,
             stream_source_error: None,
+            config,
+            confirm_interrupt_pending: false,
+            follow_mode,
+            stream_scroll_offset: 0,
         }
     }
 
@@ -141,12 +169,23 @@ impl App {
 
     /// Append new log lines to [`stream_lines`](Self::stream_lines), keeping
     /// the buffer bounded to the last 1000 lines.
+    ///
+    /// When [`follow_mode`](Self::follow_mode) is `true`,
+    /// [`stream_scroll_offset`](Self::stream_scroll_offset) is updated so the
+    /// stream pane remains pinned to the bottom of the buffer. When follow mode
+    /// is `false` the offset is preserved as-is.
     pub fn append_stream_lines(&mut self, new_lines: Vec<String>) {
         self.stream_lines.extend(new_lines);
         const MAX_LINES: usize = 1000;
         if self.stream_lines.len() > MAX_LINES {
             let drain_count = self.stream_lines.len() - MAX_LINES;
             self.stream_lines.drain(..drain_count);
+        }
+        if self.follow_mode {
+            // The UI renders the last `visible_height` lines; the offset is the
+            // index into stream_lines where the visible window starts. Pinning
+            // to `len()` here lets the draw function clamp correctly.
+            self.stream_scroll_offset = self.stream_lines.len();
         }
     }
 
@@ -156,6 +195,7 @@ impl App {
         self.stream_pos = 0;
         self.session_log_path = None;
         self.stream_source_error = None;
+        self.stream_scroll_offset = 0;
     }
 
     /// Returns `true` if the selected agent is "live" (control input is available).
@@ -191,10 +231,15 @@ impl App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::TuiConfig;
+
+    fn new_app(team: &str) -> App {
+        App::new(team.to_string(), TuiConfig::default())
+    }
 
     #[test]
     fn test_select_next_wraps() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         app.members = vec![
             MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 },
             MemberRow { agent: "b".into(), state: "idle".into(), inbox_count: 0 },
@@ -206,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_select_previous_wraps() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         app.members = vec![
             MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 },
             MemberRow { agent: "b".into(), state: "idle".into(), inbox_count: 0 },
@@ -218,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_append_stream_lines_bounded() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         // Fill past the 1000-line limit.
         let lines: Vec<String> = (0..1100).map(|i| format!("line {i}")).collect();
         app.append_stream_lines(lines);
@@ -230,7 +275,7 @@ mod tests {
 
     #[test]
     fn test_cycle_focus() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         assert_eq!(app.focus, FocusPanel::Dashboard);
         app.cycle_focus();
         assert_eq!(app.focus, FocusPanel::AgentTerminal);
@@ -240,7 +285,7 @@ mod tests {
 
     #[test]
     fn test_is_live_idle() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 }];
         assert!(app.is_live());
@@ -248,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_is_live_busy() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "busy".into(), inbox_count: 0 }];
         assert!(app.is_live());
@@ -256,7 +301,7 @@ mod tests {
 
     #[test]
     fn test_not_live_launching() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "launching".into(), inbox_count: 0 }];
         assert!(!app.is_live());
@@ -265,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_not_live_killed() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "killed".into(), inbox_count: 0 }];
         assert!(!app.is_live());
@@ -274,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_not_live_stale() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "stale".into(), inbox_count: 0 }];
         assert!(!app.is_live());
@@ -283,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_not_live_closed() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "closed".into(), inbox_count: 0 }];
         assert!(!app.is_live());
@@ -292,14 +337,14 @@ mod tests {
 
     #[test]
     fn test_not_live_no_members() {
-        let app = App::new("test".to_string());
+        let app = new_app("test");
         assert!(!app.is_live());
         assert_eq!(app.not_live_reason(), Some("Not live"));
     }
 
     #[test]
     fn test_not_live_unknown_state() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "unknown-state".into(), inbox_count: 0 }];
         assert!(!app.is_live());
@@ -308,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_live_reason_is_none_for_idle() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "idle".into(), inbox_count: 0 }];
         assert_eq!(app.not_live_reason(), None);
@@ -316,7 +361,7 @@ mod tests {
 
     #[test]
     fn test_live_reason_is_none_for_busy() {
-        let mut app = App::new("test".to_string());
+        let mut app = new_app("test");
         app.members =
             vec![MemberRow { agent: "a".into(), state: "busy".into(), inbox_count: 0 }];
         assert_eq!(app.not_live_reason(), None);
@@ -325,7 +370,7 @@ mod tests {
     /// Stale agents must not be considered live — TUI must block control input.
     #[test]
     fn test_is_live_returns_false_for_stale_state() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         app.members = vec![
             MemberRow { agent: "arch-ctm".into(), state: "stale".into(), inbox_count: 0 },
         ];
@@ -336,11 +381,74 @@ mod tests {
     /// Closed agents must not be considered live — TUI must block control input.
     #[test]
     fn test_is_live_returns_false_for_closed_state() {
-        let mut app = App::new("atm-dev".to_string());
+        let mut app = new_app("atm-dev");
         app.members = vec![
             MemberRow { agent: "arch-ctm".into(), state: "closed".into(), inbox_count: 0 },
         ];
         app.selected_index = 0;
         assert!(!app.is_live(), "closed agent must not be live");
+    }
+
+    // ── Follow mode ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_follow_mode_initialized_from_config() {
+        let mut cfg = TuiConfig::default();
+        cfg.follow_mode_default = false;
+        let app = App::new("test".to_string(), cfg);
+        assert!(!app.follow_mode, "follow_mode must reflect config default");
+    }
+
+    #[test]
+    fn test_follow_mode_updates_scroll_offset_on_append() {
+        let mut app = new_app("test");
+        app.follow_mode = true;
+        let lines: Vec<String> = (0..50).map(|i| format!("line {i}")).collect();
+        app.append_stream_lines(lines);
+        assert_eq!(
+            app.stream_scroll_offset, 50,
+            "scroll offset must equal line count when follow mode is on"
+        );
+    }
+
+    #[test]
+    fn test_follow_mode_off_preserves_scroll_offset() {
+        let mut app = new_app("test");
+        app.follow_mode = false;
+        app.stream_scroll_offset = 7;
+        let lines: Vec<String> = (0..10).map(|i| format!("line {i}")).collect();
+        app.append_stream_lines(lines);
+        assert_eq!(
+            app.stream_scroll_offset, 7,
+            "scroll offset must not change when follow mode is off"
+        );
+    }
+
+    #[test]
+    fn test_reset_stream_clears_scroll_offset() {
+        let mut app = new_app("test");
+        app.stream_scroll_offset = 42;
+        app.reset_stream();
+        assert_eq!(app.stream_scroll_offset, 0, "reset_stream must clear scroll offset");
+    }
+
+    /// Stress test: append 10,000 lines in rapid succession.
+    /// Validates that the 1000-line bound is enforced and no panic occurs.
+    /// SLO: append + bound enforcement < 200ms for 10k lines.
+    #[test]
+    fn test_stress_stream_append_bounded() {
+        let mut app = new_app("test");
+        let start = std::time::Instant::now();
+        let lines: Vec<String> = (0..10_000).map(|i| format!("line {i}")).collect();
+        // Simulate batched appends as would happen in production
+        for chunk in lines.chunks(100) {
+            app.append_stream_lines(chunk.to_vec());
+        }
+        let elapsed = start.elapsed();
+        assert_eq!(app.stream_lines.len(), 1000, "buffer must stay bounded at 1000");
+        assert!(
+            elapsed.as_millis() < 200,
+            "10k line stress append must complete in <200ms, took {elapsed:?}"
+        );
     }
 }

--- a/crates/atm-tui/src/config.rs
+++ b/crates/atm-tui/src/config.rs
@@ -1,0 +1,292 @@
+//! Per-user TUI preferences loaded from `{home}/.config/atm/tui.toml`.
+//!
+//! The config file is optional. If it is absent or cannot be parsed, all
+//! fields fall back to [`TuiConfig::default()`] silently. Parse errors are
+//! reported to stderr so the user can diagnose formatting mistakes without
+//! crashing the TUI.
+//!
+//! # File location
+//!
+//! ```text
+//! ~/.config/atm/tui.toml
+//! ```
+//!
+//! Override the base directory with `ATM_HOME`:
+//!
+//! ```text
+//! ATM_HOME=/custom/home atm-tui --team atm-dev
+//! # loads: /custom/home/.config/atm/tui.toml
+//! ```
+//!
+//! # Example configuration
+//!
+//! ```toml
+//! # ~/.config/atm/tui.toml
+//! interrupt_policy = "confirm"   # "always" | "never" | "confirm"
+//! follow_mode_default = true     # auto-scroll stream pane on startup
+//! stdin_timeout_secs = 10        # total wait budget for stdin control actions
+//! interrupt_timeout_secs = 5     # total wait budget for interrupt control actions
+//! ```
+
+use serde::Deserialize;
+
+use agent_team_mail_core::home::get_home_dir;
+
+/// TUI runtime preferences.
+///
+/// Loaded once at startup from `{home}/.config/atm/tui.toml`. All fields
+/// have documented defaults that are used when the file is absent or when
+/// individual fields are omitted.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TuiConfig {
+    /// Controls how the TUI reacts to a `Ctrl-I` interrupt keystroke.
+    ///
+    /// - [`InterruptPolicy::Always`] — sends the interrupt immediately.
+    /// - [`InterruptPolicy::Never`] — silently discards the keystroke.
+    /// - [`InterruptPolicy::Confirm`] — shows a `[y/N]` prompt in the status
+    ///   bar and waits for confirmation before dispatching.
+    ///
+    /// Defaults to [`InterruptPolicy::Confirm`].
+    #[serde(default)]
+    pub interrupt_policy: InterruptPolicy,
+
+    /// Whether the stream pane should auto-scroll to the latest line on
+    /// startup.
+    ///
+    /// When `true` (default), the stream pane follows new log output as it
+    /// arrives. Press `F` to toggle follow mode at runtime.
+    #[serde(default = "default_follow_mode")]
+    pub follow_mode_default: bool,
+
+    /// Total wait budget in seconds for a stdin control action.
+    ///
+    /// On a first-attempt timeout the request is retried once after
+    /// `stdin_timeout_secs / 2` seconds with the same idempotency key.
+    /// Defaults to `10`.
+    #[serde(default = "default_stdin_timeout")]
+    pub stdin_timeout_secs: u64,
+
+    /// Total wait budget in seconds for an interrupt control action.
+    ///
+    /// On a first-attempt timeout the request is retried once after
+    /// `interrupt_timeout_secs / 2` seconds with the same idempotency key.
+    /// Defaults to `5`.
+    #[serde(default = "default_interrupt_timeout")]
+    pub interrupt_timeout_secs: u64,
+}
+
+// ── Serde field defaults ──────────────────────────────────────────────────────
+
+fn default_follow_mode() -> bool {
+    true
+}
+
+fn default_stdin_timeout() -> u64 {
+    10
+}
+
+fn default_interrupt_timeout() -> u64 {
+    5
+}
+
+// ── Default impl ──────────────────────────────────────────────────────────────
+
+impl Default for TuiConfig {
+    fn default() -> Self {
+        Self {
+            interrupt_policy: InterruptPolicy::Confirm,
+            follow_mode_default: true,
+            stdin_timeout_secs: 10,
+            interrupt_timeout_secs: 5,
+        }
+    }
+}
+
+// ── InterruptPolicy ───────────────────────────────────────────────────────────
+
+/// Determines how `Ctrl-I` interrupt keystrokes are handled.
+///
+/// Configured via the `interrupt_policy` field in `tui.toml`.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum InterruptPolicy {
+    /// Send the interrupt immediately without any confirmation dialog.
+    Always,
+    /// Silently discard the interrupt keystroke — interrupt is disabled.
+    Never,
+    /// Show a `[y/N]` confirmation prompt in the status bar before sending.
+    #[default]
+    Confirm,
+}
+
+// ── Config loader ─────────────────────────────────────────────────────────────
+
+/// Load TUI configuration from `{home}/.config/atm/tui.toml`.
+///
+/// Returns [`TuiConfig::default()`] if:
+/// - The file does not exist (expected for first-time users).
+/// - The home directory cannot be determined.
+/// - The file cannot be read (permissions, I/O error).
+/// - The TOML is malformed or contains unrecognised fields.
+///
+/// Parse errors are printed to stderr so users can diagnose formatting
+/// mistakes without crashing the TUI.
+pub fn load_tui_config() -> TuiConfig {
+    let home = match get_home_dir() {
+        Ok(h) => h,
+        Err(_) => return TuiConfig::default(),
+    };
+
+    let path = home.join(".config/atm/tui.toml");
+
+    if !path.exists() {
+        return TuiConfig::default();
+    }
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("atm-tui: warning: could not read {}: {e}", path.display());
+            return TuiConfig::default();
+        }
+    };
+
+    match toml::from_str::<TuiConfig>(&content) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            eprintln!(
+                "atm-tui: warning: could not parse {}: {e}. Using defaults.",
+                path.display()
+            );
+            TuiConfig::default()
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // ── Default values ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_default_interrupt_policy_is_confirm() {
+        let cfg = TuiConfig::default();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Confirm);
+    }
+
+    #[test]
+    fn test_default_follow_mode_is_true() {
+        assert!(TuiConfig::default().follow_mode_default);
+    }
+
+    #[test]
+    fn test_default_stdin_timeout_is_10() {
+        assert_eq!(TuiConfig::default().stdin_timeout_secs, 10);
+    }
+
+    #[test]
+    fn test_default_interrupt_timeout_is_5() {
+        assert_eq!(TuiConfig::default().interrupt_timeout_secs, 5);
+    }
+
+    // ── TOML parsing ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_parse_always_policy() {
+        let cfg: TuiConfig = toml::from_str("interrupt_policy = \"always\"").unwrap();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Always);
+    }
+
+    #[test]
+    fn test_parse_never_policy() {
+        let cfg: TuiConfig = toml::from_str("interrupt_policy = \"never\"").unwrap();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Never);
+    }
+
+    #[test]
+    fn test_parse_confirm_policy() {
+        let cfg: TuiConfig = toml::from_str("interrupt_policy = \"confirm\"").unwrap();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Confirm);
+    }
+
+    #[test]
+    fn test_parse_full_config() {
+        let toml = r#"
+            interrupt_policy = "always"
+            follow_mode_default = false
+            stdin_timeout_secs = 20
+            interrupt_timeout_secs = 8
+        "#;
+        let cfg: TuiConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Always);
+        assert!(!cfg.follow_mode_default);
+        assert_eq!(cfg.stdin_timeout_secs, 20);
+        assert_eq!(cfg.interrupt_timeout_secs, 8);
+    }
+
+    #[test]
+    fn test_parse_empty_toml_uses_defaults() {
+        let cfg: TuiConfig = toml::from_str("").unwrap();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Confirm);
+        assert!(cfg.follow_mode_default);
+        assert_eq!(cfg.stdin_timeout_secs, 10);
+        assert_eq!(cfg.interrupt_timeout_secs, 5);
+    }
+
+    // ── load_tui_config file behaviour ────────────────────────────────────────
+
+    #[test]
+    #[serial]
+    fn test_load_tui_config_missing_file_returns_defaults() {
+        let dir = tempfile::TempDir::new().unwrap();
+        unsafe { std::env::set_var("ATM_HOME", dir.path()) };
+
+        let cfg = load_tui_config();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Confirm);
+        assert!(cfg.follow_mode_default);
+
+        unsafe { std::env::remove_var("ATM_HOME") };
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_tui_config_valid_file_parsed() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_dir = dir.path().join(".config/atm");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(
+            config_dir.join("tui.toml"),
+            "interrupt_policy = \"never\"\nfollow_mode_default = false\n",
+        )
+        .unwrap();
+
+        unsafe { std::env::set_var("ATM_HOME", dir.path()) };
+
+        let cfg = load_tui_config();
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Never);
+        assert!(!cfg.follow_mode_default);
+
+        unsafe { std::env::remove_var("ATM_HOME") };
+    }
+
+    #[test]
+    #[serial]
+    fn test_load_tui_config_malformed_file_returns_defaults() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_dir = dir.path().join(".config/atm");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("tui.toml"), "this is not valid toml!!!").unwrap();
+
+        unsafe { std::env::set_var("ATM_HOME", dir.path()) };
+
+        let cfg = load_tui_config();
+        // Malformed file must silently fall back to defaults.
+        assert_eq!(cfg.interrupt_policy, InterruptPolicy::Confirm);
+
+        unsafe { std::env::remove_var("ATM_HOME") };
+    }
+}

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2634,13 +2634,13 @@ The TUI MVP is functional but untested under sustained real-world load. Several 
 
 #### Exit Criteria
 
-- [ ] Stress test passes: sustained stream + control activity without UI starvation (documented SLO met)
-- [ ] Interrupt confirmation policy is configurable via preferences file
-- [ ] Per-user preferences file (`tui.toml`) schema defined, parsed, and applied on TUI startup
-- [ ] Per-action-type timeout/backoff configurable
-- [ ] Operational troubleshooting section added to TUI docs
-- [ ] `cargo clippy --workspace -- -D warnings` clean
-- [ ] `cargo test --workspace` passes
+- [x] Stress test passes: 10k-line append bounded to 1000 in <200ms; stream truncation/recovery paths validated (SLO: render tick ≤100ms, ack visibility ≤3s documented in tui-troubleshooting.md)
+- [x] Interrupt confirmation policy is configurable via preferences file (`InterruptPolicy::Always|Never|Confirm`)
+- [x] Per-user preferences file (`tui.toml`) schema defined, parsed, and applied on TUI startup (`~/.config/atm/tui.toml`, ATM_HOME-aware)
+- [x] Per-action-type timeout/backoff configurable (`stdin_timeout_secs`, `interrupt_timeout_secs`)
+- [x] Operational troubleshooting guide created (`docs/tui-troubleshooting.md`, 8 sections)
+- [x] `cargo clippy --workspace -- -D warnings` clean
+- [x] `cargo test --workspace` passes (1433 tests, 0 failures)
 
 ---
 
@@ -2729,8 +2729,8 @@ Additionally, when an external agent reconnects with a new session/agent ID, the
 | E.1 | `atm teams resume` session ID reliability | Phase D | ✅ MERGED (#147) |
 | E.2 | Inbox read scoping | E.1 (or parallel) | ✅ MERGED (#149) |
 | E.3 | Hook-to-daemon state bridge | E.1 (parallel with E.2) | ✅ MERGED (#152) |
-| E.4 | TUI reliability hardening (restart, reconnect, failure injection) | E.3 | 🔄 IN PROGRESS |
-| E.5 | TUI performance, UX polish, and operational validation | E.4 | ⏳ PLANNED |
+| E.4 | TUI reliability hardening (restart, reconnect, failure injection) | E.3 | ✅ MERGED (#158) |
+| E.5 | TUI performance, UX polish, and operational validation | E.4 | ✅ DONE (PR pending) |
 | E.6 | External agent member management and model registry | E.3 | ⏳ PLANNED |
 
 **Execution model**: E.1–E.3 are bug fixes / infrastructure. E.4–E.5 are TUI hardening deferred from Phase D design docs (`tui-mvp-architecture.md` §14, `tui-control-protocol.md` §11). E.6 is member management for external agents (Codex/Gemini). E.2 ∥ E.3 after E.1. E.4 after E.3. E.5 after E.4. E.6 can run parallel to E.4/E.5.

--- a/docs/tui-mvp-architecture.md
+++ b/docs/tui-mvp-architecture.md
@@ -182,7 +182,8 @@ Baseline controls:
 - `f`: filter editor
 - `c`: clear filters
 - `F`: follow mode toggle
-- `Ctrl+C`: interrupt action in Agent Terminal (with optional confirmation)
+- `Ctrl+I`: interrupt action in Agent Terminal (with confirmation policy from `tui.toml`)
+- `q` / `Ctrl+C`: quit (global — always quits, not an interrupt)
 
 Clipboard and text:
 

--- a/docs/tui-troubleshooting.md
+++ b/docs/tui-troubleshooting.md
@@ -1,0 +1,237 @@
+# ATM TUI Troubleshooting Guide
+
+This guide covers the most common failure modes for `atm-tui` and how to diagnose them.
+
+---
+
+## 1. Daemon Not Running / Degraded State
+
+**Symptom**: The Dashboard panel shows `(no members — daemon may be offline)` and the agent
+list remains empty. The status bar may display `[FROZEN]` immediately on startup.
+
+**Cause**: The `atm-daemon` process is not running or the Unix socket is unavailable.
+
+**Resolution**:
+1. Verify the daemon is running:
+   ```bash
+   atm daemon status
+   ```
+2. If stopped, restart it:
+   ```bash
+   atm daemon start
+   ```
+3. Check the daemon log at `~/.claude/teams/<team>/daemon.log` for startup errors.
+4. Confirm the Unix socket exists:
+   ```bash
+   ls -la /tmp/atm-daemon.sock
+   ```
+
+---
+
+## 2. Stream Frozen — Log File Missing or Unreadable
+
+**Symptom**: The Agent Terminal panel shows `[FROZEN]` with a message such as
+`"stream frozen: log unreadable"` or `"stream reset: log truncated (daemon restart?)"`.
+
+**Causes and checks**:
+
+| Cause | How to check |
+|-------|-------------|
+| Agent session not started | Verify the agent is `idle` or `busy` in the Dashboard |
+| Log file was never created | Session log appears only after the agent produces output |
+| Daemon restarted, cleared the log | A truncation event resets the stream automatically |
+| Permissions changed | `ls -la ~/.claude/teams/<team>/<agent>/session.log` |
+
+**Resolution**:
+- Wait: the TUI polls every 100 ms and will recover automatically when the file becomes readable.
+- If the log file is permanently missing, try switching to another agent with `↑`/`↓` and back.
+- Restart the daemon if the socket is gone.
+
+---
+
+## 3. Interrupt Not Sending
+
+**Symptom**: Pressing `Ctrl-I` has no visible effect, or the status bar does not change.
+
+**Possible reasons**:
+
+1. **Agent is not live** — the selected agent must be in `idle` or `busy` state. The control
+   input field at the bottom of the Agent Terminal panel shows a `[disabled]` indicator when
+   the agent is not live. States that block interrupts: `launching`, `killed`, `stale`, `closed`.
+
+2. **`interrupt_policy = "never"`** — the interrupt is silently discarded when this policy is
+   set in `~/.config/atm/tui.toml`. Change to `"confirm"` or `"always"` to re-enable.
+
+3. **Confirmation dialog is open** — with `interrupt_policy = "confirm"` (the default), `Ctrl-I`
+   opens a `"Send interrupt? [y/N]"` prompt. Press `y` or `Enter` to confirm, or `n`/`Esc` to
+   cancel. No other keys are accepted while the dialog is open.
+
+4. **Wrong panel focus** — `Ctrl-I` only works when the Agent Terminal panel is focused.
+   Press `Tab` to switch focus if the Dashboard is currently active.
+
+---
+
+## 4. Control Ack Timeout
+
+**Symptom**: The status bar shows `"timeout"` after a stdin or interrupt action.
+
+**What happens**: `atm-tui` automatically retries the control request once after
+`stdin_timeout_secs / 2` seconds (stdin) or `interrupt_timeout_secs / 2` seconds (interrupt).
+If the retry also times out, `"timeout"` is shown and no further retries are attempted.
+
+**Resolution**:
+- Check whether the daemon is responsive: `atm daemon status`.
+- Increase the per-action timeout in `~/.config/atm/tui.toml`:
+  ```toml
+  stdin_timeout_secs = 20
+  interrupt_timeout_secs = 10
+  ```
+- Restart the daemon if it appears hung.
+
+---
+
+## 5. Garbled Display / Terminal Rendering Issues
+
+**Symptom**: The TUI displays overlapping text, incomplete borders, or the layout looks
+broken on resize.
+
+**Common causes and mitigations**:
+
+| Symptom | Mitigation |
+|---------|-----------|
+| Terminal too small | Resize to at least 80x24; `atm-tui` does not enforce a minimum size |
+| Mouse events interfering | `atm-tui` captures mouse events; some terminal emulators conflict. Try disabling mouse capture by modifying the startup sequence (not yet a CLI flag) |
+| Raw mode left active after crash | Run `reset` in the terminal to restore normal state |
+| Nesting inside another TUI | Avoid running `atm-tui` inside `tmux` panes that themselves have full-screen apps |
+
+If the terminal is left in raw mode after a crash, restore it:
+```bash
+reset
+# or:
+stty sane
+```
+
+---
+
+## 6. Config File Location and ATM_HOME Override
+
+The TUI preferences file is loaded from:
+
+```
+{home}/.config/atm/tui.toml
+```
+
+where `{home}` is resolved in priority order:
+
+1. `ATM_HOME` environment variable (if set and non-empty)
+2. Platform default home directory (`$HOME` on Linux/macOS; Windows API on Windows)
+
+**Override example**:
+```bash
+ATM_HOME=/custom/home atm-tui --team atm-dev
+# Loads: /custom/home/.config/atm/tui.toml
+```
+
+**Minimal config file**:
+```toml
+# ~/.config/atm/tui.toml
+interrupt_policy = "confirm"   # "always" | "never" | "confirm"
+follow_mode_default = true     # auto-scroll on startup
+stdin_timeout_secs = 10        # total wait budget for stdin actions
+interrupt_timeout_secs = 5     # total wait budget for interrupt actions
+```
+
+The file is optional. If it is absent the built-in defaults apply without any error.
+
+---
+
+## 7. Preferences Not Loading / Silently Using Defaults
+
+**Symptom**: Changes to `tui.toml` are not reflected when `atm-tui` starts. The TUI
+behaves as if the file does not exist.
+
+**Causes**:
+
+1. **Parse error** — if `tui.toml` contains invalid TOML syntax or an unrecognised field
+   value, `atm-tui` logs a warning to stderr (visible before the TUI switches to alternate
+   screen) and falls back to defaults. Check for typos:
+   ```bash
+   # Quickly validate TOML syntax
+   python3 -c "import tomllib, sys; tomllib.load(open(sys.argv[1], 'rb'))" \
+       ~/.config/atm/tui.toml
+   ```
+
+2. **Wrong path** — verify the file is at the correct location for your `ATM_HOME`:
+   ```bash
+   echo "${ATM_HOME:-$HOME}/.config/atm/tui.toml"
+   ls -la "${ATM_HOME:-$HOME}/.config/atm/tui.toml"
+   ```
+
+3. **File not readable** — check permissions:
+   ```bash
+   ls -la "${ATM_HOME:-$HOME}/.config/atm/tui.toml"
+   ```
+
+4. **Wrong field value** — `interrupt_policy` must be one of the three lowercase strings:
+   `"always"`, `"never"`, or `"confirm"`. Any other value causes a parse error and falls
+   back to defaults.
+
+**Valid `interrupt_policy` values**:
+
+| Value | Behaviour |
+|-------|-----------|
+| `"confirm"` | (default) Show `[y/N]` prompt before sending interrupt |
+| `"always"` | Send interrupt immediately on `Ctrl-I` |
+| `"never"` | Silently discard `Ctrl-I` — interrupt is disabled |
+
+---
+
+## 8. Follow Mode
+
+The stream pane auto-scrolls to the latest log line when follow mode is enabled.
+
+| State | Indicator in status bar |
+|-------|------------------------|
+| Follow on | `F: follow:ON` |
+| Follow off | `F: follow:OFF` |
+
+- Default is controlled by `follow_mode_default` in `tui.toml` (default: `true`).
+- Toggle at runtime with `F` (uppercase).
+- When follow mode is off, the scroll position is preserved so you can read earlier output.
+  New lines still accumulate in the buffer — switch follow back on to jump to the bottom.
+
+---
+
+## 9. Performance SLO Targets
+
+These targets define the expected responsiveness of the TUI under normal operating conditions.
+
+| Metric | SLO Target | Notes |
+|--------|-----------|-------|
+| **Render tick latency** | ≤ 100 ms | Main loop ticks every 100 ms; drawing happens once per tick |
+| **Control ack visibility latency** | ≤ 3 s (first attempt) + 5 s (retry) | One automatic retry on timeout using the same `request_id` |
+| **Stream tail update latency** | ≤ 100 ms | Log tail read on every tick; capped at 256 KiB per read |
+| **Daemon refresh latency** | ≤ 2 s | Member list rate-limited to once per 2 seconds |
+| **Stream buffer bound** | 1000 lines | Oldest lines dropped when limit is exceeded; prevents unbounded memory growth |
+
+**Stress test baseline** (validated in `app::tests::test_stress_stream_append_bounded`):
+- 10,000 line append in batches of 100 completes in < 200 ms
+- Buffer correctly bounded to 1000 lines throughout
+
+If the TUI appears sluggish:
+- Check that the daemon is responsive (`atm daemon status`) — slow daemon queries block the 2-second refresh
+- Reduce terminal emulator font rendering load (smaller window, simpler font)
+- Ensure the session log file is on a fast filesystem (not a network mount)
+
+---
+
+## Quick Reference
+
+| Problem | First thing to check |
+|---------|---------------------|
+| No agents visible | `atm daemon status` — restart if stopped |
+| `[FROZEN]` in stream | Agent session started? Log file readable? |
+| `Ctrl-I` no effect | Agent live? Interrupt policy? Focus in Agent Terminal? |
+| Status shows `"timeout"` | Daemon responsive? Increase `interrupt_timeout_secs` in config |
+| Garbled display | Run `reset` to restore terminal after crash |
+| Config not loading | Parse errors on stderr? File path correct? |


### PR DESCRIPTION
## Summary

Sprint E.5 — TUI Performance, UX Polish, and Operational Validation

- **Per-user `tui.toml` preferences** (`~/.config/atm/tui.toml`, ATM_HOME-aware): `interrupt_policy`, `follow_mode_default`, `stdin_timeout_secs`, `interrupt_timeout_secs`
- **Interrupt confirmation policy** (`InterruptPolicy::Always|Never|Confirm`) — `Confirm` is the default; shows inline `y/N` dialog before dispatching Ctrl-I interrupt
- **Follow mode** — `F` key toggles auto-scroll to latest stream line; status bar shows `follow:ON/OFF`
- **Per-action timeouts** — configurable per action type, flow from config through `execute_control → send_with_retry`
- **Operational docs** — new `docs/tui-troubleshooting.md` (8 sections + SLO targets table)
- **Architecture doc updated** — `tui-mvp-architecture.md §7` corrected: `Ctrl+I` = interrupt, `Ctrl+C` = quit

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` — 0 warnings, 0 errors
- [x] `cargo test --workspace` — 1433 tests, 0 failures
- [x] 32 new atm-tui tests (config, interrupt policy, confirm dialog, follow mode, stress test)
- [x] Stress test: 10k-line append bounded to 1000, completes in <200ms
- [x] Cross-platform: no `HOME`/`USERPROFILE` in tests; all use `ATM_HOME`

## QA verdicts

- **rust-qa-agent**: PASS (iteration 1 of 3)
- **atm-qa-agent**: PASS (iteration 1 of 3) — 3 minor findings resolved in this PR

## Closes open items from tui-mvp-architecture.md §15

- Interrupt confirmation policy finalized (Always/Never/Confirm)
- Per-user UI preferences file defined, parsed, applied at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)