### PR TITLE
feat(M.1): watch-stream per-agent file naming/scoping cleanup

### DIFF
--- a/.claude/agents/log-monitor.md
+++ b/.claude/agents/log-monitor.md
@@ -29,9 +29,12 @@ You are aware of the current logging design and paths:
 - **Note**: FR-9.3 does not define an ATM_HOME variant for this path.
 - **Note**: Path is emitted by `atm-agent-mcp` via `sessions_dir().join(team).join(\"audit.jsonl\")`.
 
-4. Watch-stream local feed:
-- `~/.config/atm/watch-stream/events.jsonl`
-- **Note**: This shared path is subject to change in Phase M.1 (migration to per-agent files). Treat as pre-M.1 path.
+4. Watch-stream local feed (per-agent, Phase M.1+):
+- `~/.config/atm/watch-stream/<agent-id>.jsonl` where `agent-id` is the agent's identifier
+- One file per agent; prevents cross-session ambiguity and makes per-agent inspection straightforward
+- Example: `~/.config/atm/watch-stream/arch-atm.jsonl`
+- Each file rotates to `<agent-id>.jsonl.1` when it exceeds the size cap (~10 MB)
+- When ATM_HOME is set: `${ATM_HOME}/watch-stream/<agent-id>.jsonl`
 
 5. Fallback spool directory:
 - `${ATM_HOME}/log-spool/*.jsonl` when ATM_HOME is set
@@ -79,6 +82,15 @@ LOG="${LOG:-$HOME/.config/atm/atm.log.jsonl}"
 SPOOL="${ATM_HOME:+$ATM_HOME/log-spool}"
 SPOOL="${SPOOL:-$HOME/.config/atm/log-spool}"
 (timeout 600 tail -F "$SPOOL"/*.jsonl 2>/dev/null | jq -c 'select(.level=="error") // empty' 2>/dev/null)
+
+# Tail per-agent watch-stream feed (Phase M.1+)
+AGENT_ID="arch-atm"
+if [ -n "$ATM_HOME" ]; then
+  WATCH_FILE="$ATM_HOME/watch-stream/${AGENT_ID}.jsonl"
+else
+  WATCH_FILE="$HOME/.config/atm/watch-stream/${AGENT_ID}.jsonl"
+fi
+(timeout 600 tail -F "$WATCH_FILE" | jq -c 'select(.rendered != null)' 2>/dev/null)
 ```
 
 If `jq` is unavailable, fall back to `rg`/substring filters.
@@ -114,6 +126,6 @@ When reporting findings:
 
 ## Known Design Caveats
 
-- Watch-stream cache path is shared (`watch-stream/events.jsonl`), not per-agent/per-session. Treat as local UI stream feed, not canonical history. Phase M.1 will migrate to per-agent files.
+- Watch-stream files are per-agent (`watch-stream/<agent-id>.jsonl`) as of Phase M.1. Treat as local UI stream feed, not canonical history.
 - Legacy bridge log (surface 6) is conditionally present based on ATM_LOG_BRIDGE setting.
 - Spool files may contain incomplete records; always use error-tolerant jq invocations.

--- a/crates/atm-agent-mcp/src/audit.rs
+++ b/crates/atm-agent-mcp/src/audit.rs
@@ -129,7 +129,7 @@ impl AuditLog {
     ///
     /// Creates parent directories if needed. Swallows all errors.
     async fn append(&self, entry: &AuditEntry) {
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "audit_event",

--- a/crates/atm-agent-mcp/src/lifecycle_emit.rs
+++ b/crates/atm-agent-mcp/src/lifecycle_emit.rs
@@ -94,7 +94,7 @@ pub async fn emit_lifecycle_event(
     process_id: Option<u32>,
 ) {
     // Emit structured log event for the lifecycle transition.
-    agent_team_mail_core::event_log::emit_event_best_effort(
+    agent_team_mail_core::event_log::emit_event_best_effort( // TODO(M.1b): remove emit_event_best_effort call
         agent_team_mail_core::event_log::EventFields {
             level: "info",
             source: "atm-agent-mcp",

--- a/crates/atm-agent-mcp/src/proxy.rs
+++ b/crates/atm-agent-mcp/src/proxy.rs
@@ -66,7 +66,9 @@ const CHILD_DRAIN_GRACE_MS: u64 = 100;
 const WATCH_RENDER_MAX_CHARS: usize = 200;
 /// Truncated prefix length before appending ellipsis (`...`).
 const WATCH_RENDER_TRUNCATE_AT: usize = WATCH_RENDER_MAX_CHARS - 3;
-/// Hard cap for `~/.config/atm/watch-stream/events.jsonl` before rotation.
+/// Hard cap for per-agent watch-stream files before rotation.
+/// Path: `$ATM_HOME/watch-stream/<agent-id>.jsonl` (when ATM_HOME is set)
+///       or `~/.config/atm/watch-stream/<agent-id>.jsonl` otherwise.
 const WATCH_FEED_MAX_BYTES: u64 = 10 * 1024 * 1024;
 /// Counter for unknown watch event kinds skipped by the MVP publisher gate.
 static WATCH_UNKNOWN_EVENT_COUNT: AtomicU64 = AtomicU64::new(0);
@@ -2506,7 +2508,7 @@ Session ending. Write a concise summary of:\n\
                     match event_type {
                         JsonlEventType::Idle => {
                             idle_flag.store(true, std::sync::atomic::Ordering::SeqCst);
-                            agent_team_mail_core::event_log::emit_event_best_effort(
+                            agent_team_mail_core::event_log::emit_event_best_effort( // TODO(M.1b): remove emit_event_best_effort call
                                 agent_team_mail_core::event_log::EventFields {
                                     level: "info",
                                     source: "atm-agent-mcp",
@@ -2541,7 +2543,7 @@ Session ending. Write a concise summary of:\n\
                             continue;
                         }
                         JsonlEventType::Done => {
-                            agent_team_mail_core::event_log::emit_event_best_effort(
+                            agent_team_mail_core::event_log::emit_event_best_effort( // TODO(M.1b): remove emit_event_best_effort call
                                 agent_team_mail_core::event_log::EventFields {
                                     level: "info",
                                     source: "atm-agent-mcp",
@@ -2806,12 +2808,12 @@ async fn forward_event(
             .lock()
             .await
             .publish(&agent_id, frame.clone());
-        append_watch_frame_for_tui(&frame);
+        append_watch_frame_for_tui(&frame, &agent_id);
     } else if let Some(kind) = event.pointer("/params/type").and_then(|v| v.as_str())
         && !kind.is_empty()
     {
         WATCH_UNKNOWN_EVENT_COUNT.fetch_add(1, Ordering::Relaxed);
-        agent_team_mail_core::event_log::emit_event_best_effort(
+        agent_team_mail_core::event_log::emit_event_best_effort( // TODO(M.1b): remove emit_event_best_effort call
             agent_team_mail_core::event_log::EventFields {
                 level: "debug",
                 source: "atm-agent-mcp",
@@ -2988,17 +2990,39 @@ fn format_watch_frame(frame: &Value) -> String {
     base
 }
 
-fn watch_feed_path() -> Option<std::path::PathBuf> {
+fn watch_feed_path(agent_id: &str) -> Option<std::path::PathBuf> {
+    // Sanitize agent_id to be filesystem-safe: replace path separators with '_'.
+    let safe_id: std::borrow::Cow<str> = if agent_id.contains('/') || agent_id.contains('\\') {
+        std::borrow::Cow::Owned(agent_id.replace(['/', '\\'], "_"))
+    } else {
+        std::borrow::Cow::Borrowed(agent_id)
+    };
+    // ATM_HOME convention: when ATM_HOME is set, use it as the base directory
+    // directly (no `.config/atm/` nesting). Matches the canonical log path
+    // `$ATM_HOME/atm.log.jsonl` established in atm-core/src/event_log.rs.
+    if let Ok(atm_home) = std::env::var("ATM_HOME") {
+        let trimmed = atm_home.trim();
+        if !trimmed.is_empty() {
+            return Some(
+                std::path::PathBuf::from(trimmed)
+                    .join("watch-stream")
+                    .join(format!("{safe_id}.jsonl")),
+            );
+        }
+    }
     let home = agent_team_mail_core::home::get_home_dir().ok()?;
-    Some(home.join(".config/atm/watch-stream/events.jsonl"))
+    Some(
+        home.join(".config/atm/watch-stream")
+            .join(format!("{safe_id}.jsonl")),
+    )
 }
 
-fn append_watch_frame_for_tui(frame: &Value) {
-    append_watch_frame_for_tui_with_cap(frame, WATCH_FEED_MAX_BYTES);
+fn append_watch_frame_for_tui(frame: &Value, agent_id: &str) {
+    append_watch_frame_for_tui_with_cap(frame, WATCH_FEED_MAX_BYTES, agent_id);
 }
 
-fn append_watch_frame_for_tui_with_cap(frame: &Value, max_bytes: u64) {
-    let Some(path) = watch_feed_path() else {
+fn append_watch_frame_for_tui_with_cap(frame: &Value, max_bytes: u64, agent_id: &str) {
+    let Some(path) = watch_feed_path(agent_id) else {
         return;
     };
     append_watch_frame_for_tui_at_path(frame, max_bytes, &path);
@@ -4100,7 +4124,7 @@ mod tests {
     #[serial_test::serial]
     fn test_append_watch_frame_for_tui_with_cap_rotates_file() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let watch_path = dir.path().join(".config/atm/watch-stream/events.jsonl");
+        let watch_path = dir.path().join(".config/atm/watch-stream/test-agent.jsonl");
         std::fs::create_dir_all(
             watch_path
                 .parent()
@@ -5223,5 +5247,25 @@ mod tests {
         );
 
         unsafe { std::env::remove_var("ATM_HOME") };
+    }
+
+    /// When ATM_HOME is set, `watch_feed_path` must produce
+    /// `$ATM_HOME/watch-stream/<agent-id>.jsonl` (no `.config/atm/` nesting).
+    #[test]
+    #[serial_test::serial]
+    fn test_watch_feed_path_uses_atm_home() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        unsafe { std::env::set_var("ATM_HOME", dir.path()) };
+
+        let result = watch_feed_path("test-agent");
+
+        unsafe { std::env::remove_var("ATM_HOME") };
+
+        let path = result.expect("watch_feed_path should return Some when ATM_HOME is set");
+        let expected = dir.path().join("watch-stream").join("test-agent.jsonl");
+        assert_eq!(
+            path, expected,
+            "ATM_HOME path must not include .config/atm/ nesting"
+        );
     }
 }

--- a/crates/atm-agent-mcp/src/stdin_queue.rs
+++ b/crates/atm-agent-mcp/src/stdin_queue.rs
@@ -76,7 +76,7 @@ pub async fn enqueue(team: &str, agent_id: &str, content: &str) -> anyhow::Resul
     let path = dir.join(format!("{id}.json"));
     tokio::fs::write(&path, content.as_bytes()).await?;
 
-    emit_event_best_effort(EventFields {
+    emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
         level: "info",
         source: "atm-agent-mcp",
         action: "stdin_queue_enqueue",
@@ -222,7 +222,7 @@ pub async fn drain(
         }
     }
 
-    emit_event_best_effort(EventFields {
+    emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
         level: "info",
         source: "atm-agent-mcp",
         action: "stdin_queue_drain",

--- a/crates/atm-agent-mcp/src/transport.rs
+++ b/crates/atm-agent-mcp/src/transport.rs
@@ -177,7 +177,7 @@ impl McpTransport {
     /// Emits a `transport_init` structured log event.
     pub fn new(config: AgentMcpConfig, team: impl Into<String>) -> Self {
         let team = team.into();
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_init",
@@ -197,7 +197,7 @@ impl Drop for McpTransport {
     /// Emits a `transport_shutdown` structured log event when the transport
     /// is dropped (i.e. when the proxy shuts down).
     fn drop(&mut self) {
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_shutdown",
@@ -317,7 +317,7 @@ impl JsonCodecTransport {
     /// Emits a `transport_init` structured log event.
     pub fn new(config: AgentMcpConfig, team: impl Into<String>) -> Self {
         let team = team.into();
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_init",
@@ -337,7 +337,7 @@ impl JsonCodecTransport {
 
 impl Drop for JsonCodecTransport {
     fn drop(&mut self) {
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_shutdown",
@@ -458,7 +458,7 @@ impl CodexTransport for JsonCodecTransport {
                                 crate::stream_emit::emit_stream_event(&event).await;
                             });
                         }
-                        emit_event_best_effort(EventFields {
+                        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                             level: "info",
                             source: "atm-agent-mcp",
                             action: "idle_detected",
@@ -468,7 +468,7 @@ impl CodexTransport for JsonCodecTransport {
                         });
                     }
                     TransportEventType::Done => {
-                        emit_event_best_effort(EventFields {
+                        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                             level: "info",
                             source: "atm-agent-mcp",
                             action: "codex_done",
@@ -670,7 +670,7 @@ impl AppServerTransport {
     /// Emits a `transport_init` structured log event.
     pub fn new(config: AgentMcpConfig, team: impl Into<String>) -> Self {
         let team = team.into();
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_init",
@@ -1007,7 +1007,7 @@ impl AppServerTransport {
 
 impl Drop for AppServerTransport {
     fn drop(&mut self) {
-        emit_event_best_effort(EventFields {
+        emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
             level: "info",
             source: "atm-agent-mcp",
             action: "transport_shutdown",
@@ -1349,7 +1349,7 @@ pub async fn drive_notification_task(
                             crate::stream_emit::emit_stream_event(&event).await;
                         });
                     }
-                    emit_event_best_effort(EventFields {
+                    emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                         level: "info",
                         source: "atm-agent-mcp",
                         action: "turn_started",
@@ -1426,7 +1426,7 @@ pub async fn drive_notification_task(
                             crate::stream_emit::emit_stream_event(&idle_event).await;
                         });
                     }
-                    emit_event_best_effort(EventFields {
+                    emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                         level: "info",
                         source: "atm-agent-mcp",
                         action: "turn_completed",
@@ -1503,7 +1503,7 @@ pub async fn drive_notification_task(
                     turn_id: terminal_turn_id,
                     status: TurnStatus::Failed,
                 };
-                emit_event_best_effort(EventFields {
+                emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                     level: "warn",
                     source: "atm-agent-mcp",
                     action: "turn_terminal_crash",
@@ -1611,7 +1611,7 @@ impl CodexTransport for AppServerTransport {
 
         if let Some(ref ver) = negotiated_version {
             *self.protocol_version.lock().await = Some(ver.clone());
-            emit_event_best_effort(EventFields {
+            emit_event_best_effort(EventFields { // TODO(M.1b): remove emit_event_best_effort call
                 level: "info",
                 source: "atm-agent-mcp",
                 action: "protocol_version_negotiated",


### PR DESCRIPTION
## Sprint M.1 — Watch-stream file naming/scoping cleanup

### Summary

- Replaces shared `~/.config/atm/watch-stream/events.jsonl` with per-agent files `watch-stream/<agent-id>.jsonl`
- Fixes ATM_HOME path convention: `$ATM_HOME/watch-stream/<agent-id>.jsonl` (no `.config/atm/` nesting, consistent with canonical log)
- Adds `// TODO(M.1b)` markers on all 19 `emit_event_best_effort` call sites in `atm-agent-mcp` — establishes M.1b starting inventory
- Updates `.claude/agents/log-monitor.md` with M.1+ per-agent path semantics, ATM_HOME variant, and tail-and-return example

### Files Changed

| File | Change |
|------|--------|
| `crates/atm-agent-mcp/src/proxy.rs` | Per-agent `watch_feed_path(agent_id)`, ATM_HOME-aware paths, new ATM_HOME test, WATCH_FEED_MAX_BYTES doc |
| `crates/atm-agent-mcp/src/transport.rs` | 12× TODO(M.1b) markers |
| `crates/atm-agent-mcp/src/lifecycle_emit.rs` | 1× TODO(M.1b) marker |
| `crates/atm-agent-mcp/src/audit.rs` | 1× TODO(M.1b) marker |
| `crates/atm-agent-mcp/src/stdin_queue.rs` | 2× TODO(M.1b) markers |
| `.claude/agents/log-monitor.md` | Section 4 updated, tail example added |

### QA Results

- **rust-qa-agent**: PASS — 437 tests passing, clippy clean (iteration 2)
- **atm-qa-agent**: PASS — all 6 prior findings RESOLVED, no new findings (iteration 2)
- Dev-QA loop: 2 iterations (iteration 1 caught ATM_HOME path inconsistency and missing M.1b markers)

### Acceptance Criteria (from project-plan.md §17.1)

- [x] Shared `events.jsonl` replaced with `watch-stream/<agent-id>.jsonl`
- [x] Naming semantics clarified — watch-stream not confused with canonical log/audit
- [x] ATM_HOME path consistent with canonical log convention
- [x] `.claude/agents/log-monitor.md` updated with final M.1 log-path semantics and monitoring rules
- [x] M.1/M.1b boundary traceable via TODO(M.1b) markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)