### PR TITLE
fix(attach): match approval sub-classes + deviation entries

### DIFF
--- a/crates/atm-agent-mcp/src/commands/attach.rs
+++ b/crates/atm-agent-mcp/src/commands/attach.rs
@@ -504,7 +504,9 @@ fn print_frame(agent_id: &str, frame: Value, as_json: bool) -> anyhow::Result<()
             }
         }
         "turn.lifecycle" => println!("turn: {payload}"),
-        "approval" => println!("approval: {payload}"),
+        "approval.exec" | "approval.patch" | "approval.review" => {
+            println!("approval: {payload}")
+        }
         "elicitation.request" => println!("input-request: {payload}"),
         "file.edit" => print_file_edit_lines(&payload),
         _ => println!("[{}][{}] {}", env.class, env.source_kind, payload),

--- a/docs/atm-agent-mcp/phase-o-deviation-log.md
+++ b/docs/atm-agent-mcp/phase-o-deviation-log.md
@@ -80,3 +80,17 @@ Owner: `arch-ctm`
 - approved_by: team-lead
 - approved_date: 2026-02-25
 - rationale: telemetry closure delivered for TUI watch path in O-R.5; attach telemetry flush deferred.
+
+### DEV-OR5-006: attach stdin payload sanitization deferred
+- Requirement context: FR-23.23 stdin input sanitization.
+- Current behavior: `parse_attach_input()` trims whitespace only before forwarding payload to `send_stdin_control()`. No null-byte stripping, control-character filtering, or ANSI-sequence rejection.
+- approved_by: team-lead
+- approved_date: 2026-02-25
+- rationale: TUI-first scope for O-R.5; attach stdin sanitization deferred to input-hardening phase.
+
+### DEV-OR5-007: attach help text missing Ctrl-C/SIGINT documentation
+- Requirement context: FR-23.25, GAP-014 help text completeness.
+- Current behavior: `print_input_contract()` omits Ctrl-C/SIGINT behavior description.
+- approved_by: team-lead
+- approved_date: 2026-02-25
+- rationale: Ctrl-C follows default process signal behavior (DEV-O3-002); explicit documentation deferred to help-text hardening pass.


### PR DESCRIPTION
## Summary
- Fix dead `"approval"` match arm in `print_frame()` — replaced with `"approval.exec" | "approval.patch" | "approval.review"` to match `classify_event_class()` output
- Add DEV-OR5-006 (stdin sanitization deferral) and DEV-OR5-007 (Ctrl-C help text deferral) deviation entries

Integration QA blockers QA-001, QA-002, QA-003 resolved.

## Test plan
- [x] Cargo clippy clean
- [x] All tests pass
- [x] quality-mgr re-verify PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)