### PR TITLE
chore: bump version to 0.20.0 for Phase O-R release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.18.0"
+version = "0.20.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.19.0"
+version = "0.20.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.19.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.20.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.19.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.20.0" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -734,7 +734,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | **O-R** | O-R.5 | Error/replay/telemetry/session hardening closure | PLANNED | — |
 
 **Completed**: 94+ sprints across 20 phases (CI green)
-**Current version**: v0.19.0
+**Current version**: v0.20.0
 **Next**: Phase O-R renderer parity sprints
 
 ---


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.19.0 to 0.20.0
- Updates `agent-team-mail-core` pinned dependency in workspace root and `atm-tui/Cargo.toml`
- Updates `docs/project-plan.md` current version line

## Phase
Phase O-R (Renderer Parity) is complete and merged to develop via PR #238. This version bump marks the release.

## Test plan
- [x] `cargo check` passes cleanly across all crates at v0.20.0
- [x] Cargo.lock updated automatically by cargo check

🤖 Generated with [Claude Code](https://claude.com/claude-code)