### PR TITLE
Release v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -49,7 +49,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -80,7 +80,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.21.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.22.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.21.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.22.0" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.21.0 to 0.22.0
- Includes all Phase P work (PRs #242-#248) already merged to develop
- Skips v0.21.0 release (tag stuck on wrong commit due to repo protection rules)

## Changes
- Workspace version: 0.22.0
- Internal core dependency pins: =0.22.0
- All Phase P features: hook test harness, PID logging, session-end improvements, gate-named-teammate, attach checkpoint hardening

## Test plan
- [x] `cargo check --workspace` passes
- [ ] CI passes on PR
- [ ] Tag v0.22.0 after merge
- [ ] Trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)