### PR TITLE
Q.3: MCP Inspector smoke tests + protocol fixes

### DIFF
--- a/crates/atm-agent-mcp/src/proxy.rs
+++ b/crates/atm-agent-mcp/src/proxy.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use serde_json::{Value, json};
-use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::process::Child;
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::time::{Duration, timeout};
@@ -763,11 +763,10 @@ impl ProxyServer {
                 // Drain upstream write channel
                 Some(msg) = upstream_rx.recv() => {
                     let serialized = serde_json::to_string(&msg).unwrap_or_default();
-                    let frame = crate::framing::encode_content_length(&serialized);
-                    if upstream_out.write_all(&frame).await.is_err() {
-                        break;
-                    }
-                    if upstream_out.flush().await.is_err() {
+                    if write_newline_delimited(&mut upstream_out, &serialized)
+                        .await
+                        .is_err()
+                    {
                         break;
                     }
                 }

--- a/crates/atm-agent-mcp/tests/atm_tools_integration.rs
+++ b/crates/atm-agent-mcp/tests/atm_tools_integration.rs
@@ -28,10 +28,11 @@ fn make_proxy(identity: Option<&str>, team: &str) -> ProxyServer {
 }
 
 /// Send a `tools/call` JSON-RPC message to the proxy via duplex I/O and return
-/// the first Content-Length-framed response.
+/// the first JSON-RPC response.
 ///
-/// Strategy: send the message, wait for the first complete Content-Length response
-/// from the proxy, then drop the client writer to allow the proxy to shut down.
+/// Strategy: send the message, wait for the first complete response (JSONL or
+/// legacy Content-Length) from the proxy, then drop the client writer to allow
+/// the proxy to shut down.
 async fn roundtrip_tools_call(proxy: &mut ProxyServer, msg: Value) -> Value {
     use atm_agent_mcp::framing::encode_content_length;
     use tokio::io::{AsyncReadExt, AsyncWriteExt, duplex};
@@ -63,14 +64,14 @@ async fn roundtrip_tools_call(proxy: &mut ProxyServer, msg: Value) -> Value {
                 Ok(n) => {
                     buf.extend_from_slice(&tmp[..n]);
                     // Try to parse a complete response
-                    let candidate = parse_first_content_length_response(&buf);
+                    let candidate = parse_first_response(&buf);
                     if candidate != json!(null) {
                         return candidate;
                     }
                 }
             }
         }
-        parse_first_content_length_response(&buf)
+        parse_first_response(&buf)
     })
     .await
     .unwrap_or(json!(null));
@@ -82,12 +83,20 @@ async fn roundtrip_tools_call(proxy: &mut ProxyServer, msg: Value) -> Value {
     response
 }
 
-/// Extract the first JSON body from a Content-Length framed byte stream.
-fn parse_first_content_length_response(data: &[u8]) -> Value {
+/// Extract the first JSON response from a byte stream.
+///
+/// Supports newline-delimited JSON and legacy Content-Length framing.
+fn parse_first_response(data: &[u8]) -> Value {
     let text = match std::str::from_utf8(data) {
         Ok(s) => s,
         Err(_) => return json!(null),
     };
+    if let Some(first_line) = text.lines().next() {
+        let trimmed = first_line.trim();
+        if !trimmed.is_empty() && !trimmed.starts_with("Content-Length:") {
+            return serde_json::from_str(trimmed).unwrap_or(json!(null));
+        }
+    }
     let header_end = match text.find("\r\n\r\n") {
         Some(i) => i,
         None => return json!(null),

--- a/crates/atm-agent-mcp/tests/proxy_integration.rs
+++ b/crates/atm-agent-mcp/tests/proxy_integration.rs
@@ -59,41 +59,23 @@ async fn send_newline(writer: &mut DuplexStream, msg: &Value) {
     writer.flush().await.unwrap();
 }
 
-/// Read a Content-Length framed response from the proxy.
+/// Read a response from the proxy (JSONL preferred; Content-Length tolerated).
 async fn read_response(reader: &mut BufReader<DuplexStream>) -> Option<Value> {
-    let mut header_line = String::new();
-
-    // Try to read the Content-Length header with a timeout
-    match tokio::time::timeout(Duration::from_secs(10), async {
-        loop {
-            header_line.clear();
-            let n = reader.read_line(&mut header_line).await.ok()?;
-            if n == 0 {
-                return None;
-            }
-            let trimmed = header_line.trim();
-            if trimmed.starts_with("Content-Length:") {
-                break;
-            }
-            // skip blank lines or other headers
-        }
-        Some(())
-    })
-    .await
-    {
-        Ok(Some(())) => {}
-        Ok(None) | Err(_) => return None,
+    let mut first_line = String::new();
+    let n = tokio::time::timeout(Duration::from_secs(10), reader.read_line(&mut first_line))
+        .await
+        .ok()?
+        .ok()?;
+    if n == 0 {
+        return None;
+    }
+    let trimmed = first_line.trim();
+    if !trimmed.is_empty() && !trimmed.starts_with("Content-Length:") {
+        return serde_json::from_str(trimmed).ok();
     }
 
-    let len: usize = header_line
-        .trim()
-        .strip_prefix("Content-Length:")
-        .unwrap()
-        .trim()
-        .parse()
-        .unwrap();
-
-    // Read until blank line
+    // Legacy Content-Length path (retained for backward compatibility).
+    let len: usize = trimmed.strip_prefix("Content-Length:")?.trim().parse().ok()?;
     loop {
         let mut line = String::new();
         reader.read_line(&mut line).await.ok()?;
@@ -101,13 +83,9 @@ async fn read_response(reader: &mut BufReader<DuplexStream>) -> Option<Value> {
             break;
         }
     }
-
     let mut body = vec![0u8; len];
-    tokio::io::AsyncReadExt::read_exact(reader, &mut body)
-        .await
-        .ok()?;
-    let s = String::from_utf8(body).ok()?;
-    serde_json::from_str(&s).ok()
+    tokio::io::AsyncReadExt::read_exact(reader, &mut body).await.ok()?;
+    serde_json::from_slice(&body).ok()
 }
 
 /// Read all responses available within a timeout.

--- a/crates/atm-agent-mcp/tests/serve_stdout_purity.rs
+++ b/crates/atm-agent-mcp/tests/serve_stdout_purity.rs
@@ -1,0 +1,190 @@
+//! Verify `atm-agent-mcp serve` keeps stdout clean for MCP JSON-RPC framing.
+//!
+//! Any non-JSON text on stdout corrupts the MCP stdio transport and breaks
+//! clients such as MCP Inspector.
+
+use serde_json::Value;
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn write_content_length_request(stdin: &mut impl Write, body: &str) {
+    let header = format!("Content-Length: {}\r\n\r\n", body.len());
+    stdin
+        .write_all(header.as_bytes())
+        .expect("write content-length header");
+    stdin.write_all(body.as_bytes()).expect("write json body");
+    stdin.flush().expect("flush request");
+}
+
+fn atm_agent_mcp_bin_path() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_atm-agent-mcp") {
+        return PathBuf::from(path);
+    }
+
+    let mut path = std::env::current_exe().expect("resolve current_exe");
+    path.pop(); // test binary
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("atm-agent-mcp");
+    if cfg!(windows) {
+        path.set_extension("exe");
+    }
+    path
+}
+
+fn write_team_config(home: &std::path::Path) {
+    let team_dir = home.join(".claude").join("teams").join("atm-dev");
+    std::fs::create_dir_all(&team_dir).expect("create team dir");
+    let config = serde_json::json!({
+        "name": "atm-dev",
+        "createdAt": 1770765919076_u64,
+        "leadAgentId": "team-lead@atm-dev",
+        "leadSessionId": "6075f866-f103-4be1-b2e9-8dbf66009eb9",
+        "members": [
+            {
+                "agentId": "team-lead@atm-dev",
+                "name": "team-lead",
+                "agentType": "general-purpose",
+                "model": "claude-haiku-4-5-20251001",
+                "joinedAt": 1770765919076_u64,
+                "tmuxPaneId": "",
+                "cwd": "/tmp",
+                "subscriptions": []
+            },
+            {
+                "agentId": "arch-ctm@atm-dev",
+                "name": "arch-ctm",
+                "agentType": "general-purpose",
+                "model": "gpt-5.2",
+                "joinedAt": 1770765919077_u64,
+                "tmuxPaneId": "",
+                "cwd": "/tmp",
+                "subscriptions": []
+            }
+        ]
+    });
+    std::fs::write(
+        team_dir.join("config.json"),
+        serde_json::to_string_pretty(&config).expect("serialize team config"),
+    )
+    .expect("write team config");
+}
+
+fn write_atm_config(path: &std::path::Path) {
+    let config = r#"[core]
+default_team = "atm-dev"
+identity = "arch-ctm"
+
+[plugins.atm-agent-mcp]
+identity = "arch-ctm"
+auto_mail = false
+"#;
+    std::fs::write(path, config).expect("write atm config");
+}
+
+fn read_jsonl_line(reader: &mut BufReader<std::process::ChildStdout>) -> Value {
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read stdout line");
+        assert!(!line.is_empty(), "unexpected EOF waiting for JSONL response");
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        assert!(
+            !trimmed.starts_with("Content-Length:"),
+            "stdout must not contain Content-Length framing; got: {trimmed:?}"
+        );
+        return serde_json::from_str(trimmed).expect("valid jsonl response line");
+    }
+}
+
+#[test]
+fn serve_stdout_emits_only_newline_jsonrpc() {
+    let bin = atm_agent_mcp_bin_path();
+    assert!(
+        bin.exists(),
+        "atm-agent-mcp test binary not found at {}",
+        bin.display()
+    );
+
+    let home = TempDir::new().expect("temp ATM_HOME");
+    write_team_config(home.path());
+
+    let config_path = home.path().join("test.atm.toml");
+    write_atm_config(&config_path);
+
+    let mut child = Command::new(&bin)
+        .arg("--config")
+        .arg(&config_path)
+        .arg("serve")
+        .env("ATM_HOME", home.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn atm-agent-mcp serve");
+
+    let mut stdin = child.stdin.take().expect("child stdin");
+    let stdout = child.stdout.take().expect("child stdout");
+    let mut reader = BufReader::new(stdout);
+
+    // 1) initialize
+    let init_req = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{}}}"#;
+    write_content_length_request(&mut stdin, init_req);
+    let init_resp = read_jsonl_line(&mut reader);
+    assert_eq!(init_resp.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
+    assert_eq!(init_resp.get("id").and_then(Value::as_i64), Some(1));
+    assert!(
+        init_resp.get("result").is_some(),
+        "initialize response should include result"
+    );
+
+    // 2) tools/call (standalone ATM tool path)
+    let tool_req = r#"{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"atm_pending_count","arguments":{}}}"#;
+    write_content_length_request(&mut stdin, tool_req);
+    let tool_resp = read_jsonl_line(&mut reader);
+    assert_eq!(tool_resp.get("jsonrpc").and_then(Value::as_str), Some("2.0"));
+    assert_eq!(tool_resp.get("id").and_then(Value::as_i64), Some(2));
+    assert!(
+        tool_resp.get("result").is_some() || tool_resp.get("error").is_some(),
+        "tools/call response should be valid JSON-RPC success or error"
+    );
+
+    drop(stdin);
+
+    let status = child
+        .wait_timeout(Duration::from_secs(2))
+        .expect("wait for child")
+        .expect("child should exit after stdin closes");
+    assert!(status.success(), "child exited with {status}");
+}
+
+trait ChildWaitTimeout {
+    fn wait_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<Option<std::process::ExitStatus>>;
+}
+
+impl ChildWaitTimeout for std::process::Child {
+    fn wait_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> std::io::Result<Option<std::process::ExitStatus>> {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(status) = self.try_wait()? {
+                return Ok(Some(status));
+            }
+            if start.elapsed() >= timeout {
+                return Ok(None);
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+}

--- a/crates/atm-core/src/logging.rs
+++ b/crates/atm-core/src/logging.rs
@@ -65,6 +65,7 @@ fn _init_stderr() {
     }
     let level = parse_level();
     let _ = tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_max_level(level)
         .with_target(false)
         .try_init();

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -647,14 +647,16 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 
 ---
 
-## 17.6 Phase Q: MCP Server Setup CLI — PLANNED
+## 17.6 Phase Q: MCP Server Setup CLI — IN PROGRESS
 
 **Goal**: Add `atm mcp install/status` commands so users can configure `atm-agent-mcp` as an MCP server for Claude Code, Codex CLI, and Gemini CLI with a single command. See requirements section 4.8.
 
 | Sprint | Name | Depends On | Size | Status |
 |--------|------|------------|------|--------|
-| Q.1 | `atm mcp install` + `atm mcp status` commands | — | M | PLANNED |
-| Q.2 | Integration tests + cross-platform validation | Q.1 | S | PLANNED |
+| Q.1 | `atm mcp install` + `atm mcp status` commands | — | M | COMPLETE |
+| Q.2 | Integration tests + cross-platform validation | Q.1 | S | COMPLETE |
+| Q.3 | MCP Inspector CI smoke tests for `atm-agent-mcp` standalone tools | Q.2 | S | IN PROGRESS |
+| Q.4 | Manual MCP Inspector testing with live Codex + collaborative watch verification | Q.3 | M | PLANNED |
 
 **Q.1 deliverables**:
 - New `crates/atm/src/commands/mcp.rs` module
@@ -674,6 +676,22 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 - Integration tests using `ATM_HOME` isolation
 - Windows CI validation for PATH-based binary detection
 - Edge cases: missing config files, malformed JSON/TOML, already-configured (idempotency)
+
+**Q.3 deliverables**:
+- Extend `scripts/ci/mcp_inspector_smoke.sh` to keep reference-server baseline and add `atm-agent-mcp` smoke coverage
+- Verify `tools/list` includes all 10 ATM tools:
+  - `atm_send`, `atm_read`, `atm_broadcast`, `atm_pending_count`
+  - `agent_sessions`, `agent_status`, `agent_close`
+  - `agent_watch_attach`, `agent_watch_poll`, `agent_watch_detach`
+- Verify `tools/call` contract and response schema for 7 standalone tools in an `ATM_HOME`-isolated environment:
+  - `atm_send`, `atm_read`, `atm_broadcast`, `atm_pending_count`
+  - `agent_sessions`, `agent_status`, `agent_close`
+- Keep CI-safe scope: no live Codex execution in this gate
+
+**Q.4 deliverables**:
+- Run manual MCP Inspector sessions against live Codex-backed `atm-agent-mcp`
+- Validate watch tools end-to-end (`agent_watch_attach`/`poll`/`detach`) and collaborative ATM mail flows
+- Capture runbook evidence, known limitations, and parity notes for Phase Q closeout
 
 ---
 
@@ -809,12 +827,14 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | **P** | P.3 | Attach unsupported-event summary flush parity | COMPLETE | [#244](https://github.com/randlee/agent-team-mail/pull/244) |
 | **P** | P.4 | Attach stdin sanitization hardening | COMPLETE | [#245](https://github.com/randlee/agent-team-mail/pull/245) |
 | **P** | P.5 | Attach help/UX contract parity (`Ctrl-C`/SIGINT) + closeout | COMPLETE | [#246](https://github.com/randlee/agent-team-mail/pull/246) |
-| **Q** | Q.1 | `atm mcp install/uninstall/status` commands | PLANNED | — |
-| **Q** | Q.2 | Integration tests + cross-platform validation | PLANNED | — |
+| **Q** | Q.1 | `atm mcp install/uninstall/status` commands | COMPLETE | [#252](https://github.com/randlee/agent-team-mail/pull/252) |
+| **Q** | Q.2 | Integration tests + cross-platform validation | COMPLETE | [#253](https://github.com/randlee/agent-team-mail/pull/253) |
+| **Q** | Q.3 | MCP Inspector CI smoke tests for `atm-agent-mcp` standalone tools | IN PROGRESS | — |
+| **Q** | Q.4 | Manual MCP Inspector testing with live Codex + collaborative watch verification | PLANNED | — |
 
 **Completed**: 99+ sprints across 22 phases (CI green)
 **Current version**: v0.22.0
-**Next**: Phase Q (MCP Server Setup CLI) — awaiting approval to begin
+**Next**: Phase Q.3 (MCP Inspector CI smoke tests for `atm-agent-mcp`)
 
 ---
 

--- a/scripts/ci/mcp_inspector_smoke.sh
+++ b/scripts/ci/mcp_inspector_smoke.sh
@@ -1,45 +1,215 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-tmp_out="$(mktemp)"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+tmp_dir="$(mktemp -d)"
 cleanup() {
-  rm -f "$tmp_out"
+  rm -rf "$tmp_dir"
 }
 trap cleanup EXIT
 
-echo "Running MCP Inspector CLI smoke check against reference MCP server..."
-if command -v timeout >/dev/null 2>&1; then
-  timeout 60 npx -y @modelcontextprotocol/inspector --cli \
-    npx -y @modelcontextprotocol/server-everything \
-    --method tools/list >"$tmp_out"
-else
-  python3 - <<'PY' >"$tmp_out"
+mkdir -p "$tmp_dir/home/.claude/teams/atm-dev"
+cat >"$tmp_dir/home/.claude/teams/atm-dev/config.json" <<'JSON'
+{
+  "name": "atm-dev",
+  "createdAt": 1770765919076,
+  "leadAgentId": "team-lead@atm-dev",
+  "leadSessionId": "6075f866-f103-4be1-b2e9-8dbf66009eb9",
+  "members": [
+    {
+      "agentId": "team-lead@atm-dev",
+      "name": "team-lead",
+      "agentType": "general-purpose",
+      "model": "claude-haiku-4-5-20251001",
+      "joinedAt": 1770765919076,
+      "tmuxPaneId": "",
+      "cwd": "/tmp",
+      "subscriptions": []
+    },
+    {
+      "agentId": "arch-ctm@atm-dev",
+      "name": "arch-ctm",
+      "agentType": "general-purpose",
+      "model": "gpt-5.2",
+      "joinedAt": 1770765919077,
+      "tmuxPaneId": "",
+      "cwd": "/tmp",
+      "subscriptions": []
+    },
+    {
+      "agentId": "qa-bot@atm-dev",
+      "name": "qa-bot",
+      "agentType": "general-purpose",
+      "model": "claude-haiku-4-5-20251001",
+      "joinedAt": 1770765919078,
+      "tmuxPaneId": "",
+      "cwd": "/tmp",
+      "subscriptions": []
+    }
+  ]
+}
+JSON
+
+echo "Building atm-agent-mcp test binary..."
+cargo build -q -p agent-team-mail-mcp --bin atm-agent-mcp
+
+echo "Running MCP Inspector smoke suite (reference + atm-agent-mcp)..."
+ATM_HOME="$tmp_dir/home" ATM_IDENTITY="arch-ctm" ATM_TEAM="atm-dev" REPO_ROOT="$repo_root" python3 - <<'PY'
+import json
+import os
 import subprocess
-subprocess.run(
-    [
+from pathlib import Path
+
+repo_root = Path(os.environ["REPO_ROOT"])
+atm_bin = repo_root / "target/debug/atm-agent-mcp"
+
+def run(cmd, *, allow_failure=False):
+    proc = subprocess.run(cmd, text=True, capture_output=True, timeout=60, env=os.environ.copy())
+    if not allow_failure and proc.returncode != 0:
+        raise AssertionError(
+            f"Command failed: {' '.join(cmd)}\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        )
+    return proc
+
+def run_inspector(*, method, tool_name=None, tool_args=None, allow_failure=False):
+    cmd = [
         "npx",
         "-y",
         "@modelcontextprotocol/inspector",
         "--cli",
-        "npx",
-        "-y",
-        "@modelcontextprotocol/server-everything",
+        str(atm_bin),
+        "serve",
         "--method",
-        "tools/list",
-    ],
-    check=True,
-    timeout=60,
-    text=True,
+        method,
+    ]
+    if tool_name:
+        cmd.extend(["--tool-name", tool_name])
+    if tool_args:
+        for k, v in tool_args.items():
+            cmd.extend(["--tool-arg", f"{k}={v}"])
+    return run(cmd, allow_failure=allow_failure)
+
+def parse_json_output(proc):
+    return json.loads(proc.stdout)
+
+def assert_text_payload(payload):
+    content = payload.get("content")
+    if not isinstance(content, list) or not content:
+        raise AssertionError(f"Missing content array: {payload}")
+    first = content[0]
+    if first.get("type") != "text":
+        raise AssertionError(f"Expected text content item: {payload}")
+    text = first.get("text")
+    if not isinstance(text, str):
+        raise AssertionError(f"Expected text payload: {payload}")
+    return text
+
+# Baseline reference MCP server.
+baseline = run([
+    "npx", "-y", "@modelcontextprotocol/inspector", "--cli",
+    "npx", "-y", "@modelcontextprotocol/server-everything",
+    "--method", "tools/list",
+])
+if '"name": "echo"' not in baseline.stdout:
+    raise AssertionError("Expected echo tool not present in reference MCP server output")
+
+# 1) tools/list and schema checks for 10 ATM tools.
+tools = parse_json_output(run_inspector(method="tools/list"))
+entries = tools.get("tools")
+if not isinstance(entries, list):
+    raise AssertionError(f"tools/list missing tools array: {tools}")
+expected = {
+    "atm_send",
+    "atm_read",
+    "atm_broadcast",
+    "atm_pending_count",
+    "agent_sessions",
+    "agent_status",
+    "agent_close",
+    "agent_watch_attach",
+    "agent_watch_poll",
+    "agent_watch_detach",
+}
+actual = {e.get("name") for e in entries if isinstance(e, dict)}
+missing = expected - actual
+if missing:
+    raise AssertionError(f"tools/list missing expected ATM tools: {sorted(missing)}")
+for e in entries:
+    if e.get("name") in expected and "inputSchema" not in e:
+        raise AssertionError(f"tool missing inputSchema: {e}")
+
+# 2) tools/call checks for 7 standalone tools.
+send = parse_json_output(run_inspector(
+    method="tools/call",
+    tool_name="atm_send",
+    tool_args={"to": "arch-ctm", "message": "q3-smoke-message"},
+))
+if "Message sent to arch-ctm@atm-dev" not in assert_text_payload(send):
+    raise AssertionError(f"atm_send success text mismatch: {send}")
+
+read = parse_json_output(run_inspector(
+    method="tools/call",
+    tool_name="atm_read",
+    tool_args={"all": "true", "mark_read": "false", "limit": "10"},
+))
+if "q3-smoke-message" not in assert_text_payload(read):
+    raise AssertionError(f"atm_read did not include sent message: {read}")
+
+broadcast = parse_json_output(run_inspector(
+    method="tools/call",
+    tool_name="atm_broadcast",
+    tool_args={"message": "q3-broadcast-message"},
+))
+if "Broadcast sent to" not in assert_text_payload(broadcast):
+    raise AssertionError(f"atm_broadcast success text mismatch: {broadcast}")
+
+pending = parse_json_output(run_inspector(method="tools/call", tool_name="atm_pending_count"))
+pending_obj = json.loads(assert_text_payload(pending))
+if not isinstance(pending_obj.get("unread"), int):
+    raise AssertionError(f"atm_pending_count unread must be int: {pending_obj}")
+
+sessions = parse_json_output(run_inspector(method="tools/call", tool_name="agent_sessions"))
+sessions_obj = json.loads(assert_text_payload(sessions))
+if not isinstance(sessions_obj, list):
+    raise AssertionError(f"agent_sessions must return JSON array text: {sessions_obj}")
+
+status = parse_json_output(run_inspector(method="tools/call", tool_name="agent_status"))
+status_obj = json.loads(assert_text_payload(status))
+for key in ("team", "child_alive", "uptime_secs", "pending_mail_count"):
+    if key not in status_obj:
+        raise AssertionError(f"agent_status missing key '{key}': {status_obj}")
+if status_obj["team"] != "atm-dev":
+    raise AssertionError(f"agent_status team mismatch: {status_obj}")
+
+close_proc = run_inspector(
+    method="tools/call",
+    tool_name="agent_close",
+    tool_args={"agent_id": "does-not-exist"},
+    allow_failure=True,
 )
+close_json = None
+if close_proc.stdout.strip():
+    try:
+        close_json = json.loads(close_proc.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"agent_close output must be JSON payload when available; got:\n{close_proc.stdout}\n{close_proc.stderr}"
+        ) from exc
+
+if close_json is not None:
+    err = close_json.get("error")
+    if not isinstance(err, dict):
+        raise AssertionError(f"agent_close expected JSON-RPC error payload, got: {close_json}")
+    msg = str(err.get("message", ""))
+    if "session not found" not in msg:
+        raise AssertionError(f"agent_close error message missing not-found text: {close_json}")
+else:
+    # Fallback when inspector surfaces tool errors via non-zero process path only.
+    combined = f"{close_proc.stdout}\n{close_proc.stderr}"
+    if "session not found" not in combined:
+        raise AssertionError(f"agent_close missing not-found signal: {combined}")
+
+print("MCP Inspector smoke checks passed.")
 PY
-fi
 
-echo "Validating inspector response payload..."
-if ! grep -q '"name": "echo"' "$tmp_out"; then
-  echo "Expected echo tool not found in MCP Inspector output"
-  echo "--- inspector output ---"
-  cat "$tmp_out"
-  exit 1
-fi
-
-echo "MCP Inspector smoke check passed."
+echo "MCP Inspector smoke suite passed."


### PR DESCRIPTION
## Summary
- Fix stdout logging corruption in atm-agent-mcp (logs were going to stdout, breaking MCP JSON-RPC stream)
- Switch atm-agent-mcp serve from Content-Length framing to JSONL (MCP spec compliance)
- Add MCP Inspector CI smoke tests: tools/list (all 10 tools) + tools/call (7 standalone tools with ATM_HOME isolation)
- Harden Gemini idempotency (field-tolerant matcher)
- Add 15 mcp.rs unit tests + integration_mcp.rs integration suite
- Add serve_stdout_purity test (JSONL + no Content-Length, covers initialize + tools/call)
- Fix lock.rs stale comments, add # Errors doc sections

## Commits
- `0de4a1a` fix(atm): harden gemini mcp idempotency and add mcp unit tests
- `45707c2` test(atm): add mcp coverage and inspector CI smoke
- `4b72125` docs(atm-agent-mcp): align lock acquire comment with create_new semantics
- `71a8ea9` ci: tighten clippy and add inspector smoke timeout guard
- `920483f` ci: use Node.js 22 major for inspector smoke job
- `30b39c4` phase-q: add inspector smoke coverage and stdout purity guard
- `114177f` phase-q: switch serve stdout to jsonl for inspector
- `ece232a` phase-q: harden inspector smoke assertions and purity isolation

## Test plan
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test --workspace (1,919+ tests pass)
- [x] MCP Inspector smoke script passes locally
- [x] MCP Inspector web UI connects and tools work (manually verified)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)