### PR TITLE
chore: bump version to 0.23.0 for Phase Q release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.22.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.23.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.22.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.23.0" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -833,7 +833,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | **Q** | Q.4 | Manual MCP Inspector testing with live Codex + collaborative watch verification | PLANNED | — |
 
 **Completed**: 99+ sprints across 22 phases (CI green)
-**Current version**: v0.22.0
+**Current version**: v0.23.0
 **Next**: Phase Q.4 (Manual MCP Inspector testing with live Codex)
 
 ---


### PR DESCRIPTION
## Summary
- v0.22.0 already tagged/released for Phase P
- Bump all workspace crates to 0.23.0 for Phase Q release
- Cargo.toml, Cargo.lock, project-plan.md all consistent

After merge to develop, needs PR to main then tag v0.23.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)