### PR TITLE
release: add release-inventory.json for v0.26.0

### DIFF
--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -1,0 +1,84 @@
+{
+  "releaseVersion": "0.26.0",
+  "releaseTag": "v0.26.0",
+  "releaseCommit": "fd559be803dd0b45c9b19491f1404722d7f215b5",
+  "generatedAt": "2026-03-02T01:00:00Z",
+  "items": [
+    {
+      "artifact": "agent-team-mail-core",
+      "version": "0.26.0",
+      "sourceRef": "crates/atm-core",
+      "publishTarget": "crates.io",
+      "verifyCommands": [
+        "cargo info agent-team-mail-core",
+        "cargo package -p agent-team-mail-core --dry-run"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "agent-team-mail",
+      "version": "0.26.0",
+      "sourceRef": "crates/atm",
+      "publishTarget": "crates.io",
+      "verifyCommands": [
+        "cargo info agent-team-mail",
+        "cargo package -p agent-team-mail --dry-run"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "agent-team-mail-daemon",
+      "version": "0.26.0",
+      "sourceRef": "crates/atm-daemon",
+      "publishTarget": "crates.io",
+      "verifyCommands": [
+        "cargo info agent-team-mail-daemon",
+        "cargo package -p agent-team-mail-daemon --dry-run"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "agent-team-mail-tui",
+      "version": "0.26.0",
+      "sourceRef": "crates/atm-tui",
+      "publishTarget": "crates.io",
+      "verifyCommands": [
+        "cargo info agent-team-mail-tui",
+        "cargo package -p agent-team-mail-tui --dry-run"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "agent-team-mail-mcp",
+      "version": "0.26.0",
+      "sourceRef": "crates/atm-agent-mcp",
+      "publishTarget": "crates.io",
+      "verifyCommands": [
+        "cargo info agent-team-mail-mcp",
+        "cargo package -p agent-team-mail-mcp --dry-run"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "atm-github-release",
+      "version": "0.26.0",
+      "sourceRef": ".github/workflows/release.yml",
+      "publishTarget": "github-release",
+      "verifyCommands": [
+        "gh release view v0.26.0 --json tagName,assets"
+      ],
+      "required": true
+    },
+    {
+      "artifact": "atm-homebrew",
+      "version": "0.26.0",
+      "sourceRef": "randlee/homebrew-tap",
+      "publishTarget": "homebrew",
+      "verifyCommands": [
+        "brew info randlee/tap/agent-team-mail",
+        "brew info randlee/tap/atm"
+      ],
+      "required": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `release/release-inventory.json` defining all v0.26.0 release artifacts
- Covers all 5 crates (core, atm, daemon, mcp, tui), GitHub release, and Homebrew formulas
- Validated by `release-preflight.yml` workflow during pre-release checks

## Context
This file was generated locally by arch-ctm during preflight validation and needs to be in source control for the `release-preflight` workflow to validate against.

## Test plan
- [ ] CI passes on this PR
- [ ] `release-preflight.yml` can locate and validate the inventory file

🤖 Generated with [Claude Code](https://claude.com/claude-code)