### PR TITLE
chore: bump version to 0.27.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.26.0"
+version = "0.27.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.26.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.27.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.26.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.27.0" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.26.0 → 0.27.0
- Updates exact pin for `agent-team-mail-core` in workspace and `atm-tui`
- Regenerates `Cargo.lock`

## Context
Skipping v0.26.0 — tag was created by first release run attempt and cannot be deleted due to repo tag protection rules.

## Note
PR targets `main` directly. Version bump will be cherry-picked back to `develop` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)