### PR TITLE
Phase U U.4: daemon reliability verification evidence (#181 #182 #183)

### DIFF
--- a/docs/adr/phase-u-u4-daemon-verification.md
+++ b/docs/adr/phase-u-u4-daemon-verification.md
@@ -1,0 +1,58 @@
+# Phase U Sprint U.4 Verification Report
+
+Date: 2026-03-02  
+Branch: `feature/pU-s4-daemon-verification`  
+Base: `integrate/phase-U` (v0.27.0)
+
+## Scope
+
+Verification target issues:
+- #181 Daemon auto-start reliability
+- #182 Roster seeding/config watcher reliability
+- #183 Agent state transition reliability
+
+## Verification Environment
+
+Live CLI checks were run in an isolated sandbox to avoid impacting active team sessions:
+- `ATM_HOME=/tmp/atm-u4-9Xf0bs`
+- Team: `verify-u4`
+- Seeded `config.json` roster: `team-lead`, `arch-ctm`, `arch-gtm`
+
+## Matrix Results
+
+| Check | Issue | Result | Evidence |
+|---|---|---|---|
+| Daemon auto-starts on `atm status` with no running daemon | #181 | PASS | After removing sandbox PID/socket, `atm status --team verify-u4` succeeded and created `.claude/daemon/atm-daemon.pid` + `.claude/daemon/atm-daemon.sock`. |
+| Daemon auto-starts on `atm doctor` | #181 | PASS | After removing sandbox PID/socket, `atm doctor --team verify-u4` returned `Findings: critical=0 warn=0 info=0` and recreated daemon PID/socket. |
+| `atm members` shows all `config.json` roster on fresh daemon start | #182 | PASS | On fresh daemon start, `atm members --team verify-u4` listed all seeded members (`team-lead`, `arch-ctm`, `arch-gtm`). |
+| Config member add reflected within one watch cycle | #182 | PASS | `atm teams add-member verify-u4 qa-bot ...` then `sleep 2` showed `qa-bot` present in `atm members`. Follow-up `atm doctor --team verify-u4` had no integrity warnings. |
+| Agent state transitions after registration/event | #183 | PASS (test-backed) | Verified via daemon integration test `test_hook_watcher_converges_without_pubsub_delivery` (active->idle convergence from hook event). |
+| `cargo test -p agent-team-mail-daemon daemon_autostart` | #181 | PASS* | Command succeeded but matched `0` tests (selector mismatch; see Regression Note). |
+| `cargo test -p agent-team-mail-daemon roster` | #182/#183 | PASS | Command executed and passed roster-related unit/integration coverage (`8` roster unit tests + startup reconcile test). |
+
+## Additional Targeted Evidence
+
+To ensure issue-scoped behavior was actually exercised:
+
+- `cargo test -p agent-team-mail-daemon test_startup_reconcile_seeds_roster_without_interval_delay -- --nocapture`  
+  Result: PASS  
+  Coverage: daemon startup reconcile seeds roster promptly from config (#182)
+
+- `cargo test -p agent-team-mail-daemon test_hook_watcher_converges_without_pubsub_delivery -- --nocapture`  
+  Result: PASS  
+  Coverage: state convergence to idle from hook ingestion without pub/sub dependency (#183)
+
+## Regression Note
+
+The selector command in the sprint matrix:
+- `cargo test -p agent-team-mail-daemon daemon_autostart`
+
+currently matches zero tests in this crate layout. This is a **test-command selection drift** in the plan, not a runtime daemon failure. Functional autostart behavior was validated by live CLI checks above.
+
+Recommended follow-up:
+- Update U.4 test-plan command selectors to names that execute the intended tests in current crate organization.
+
+## Conclusion
+
+U.4 verification outcome for #181/#182/#183: **PASS with one documentation/test-selector correction needed**.
+


### PR DESCRIPTION
## Summary
- executed U.4 daemon reliability verification matrix for #181/#182/#183
- captured live CLI verification in an isolated `ATM_HOME` sandbox
- documented evidence and outcomes in `docs/adr/phase-u-u4-daemon-verification.md`
- recorded one regression note: the `daemon_autostart` selector command in the plan currently matches 0 tests

## Evidence Highlights
- `atm status --team verify-u4` autostarts daemon after PID/socket removal
- `atm doctor --team verify-u4` autostarts daemon and returns daemon-backed report
- `atm teams add-member` reflected in roster within one watch cycle
- targeted daemon tests for startup reconcile and state convergence passed

## Validation Commands
- `cargo test -p agent-team-mail-daemon daemon_autostart -- --nocapture`
- `cargo test -p agent-team-mail-daemon roster -- --nocapture`
- `cargo test -p agent-team-mail-daemon test_startup_reconcile_seeds_roster_without_interval_delay -- --nocapture`
- `cargo test -p agent-team-mail-daemon test_hook_watcher_converges_without_pubsub_delivery -- --nocapture`
