### PR TITLE
Phase U U.5: gemini runtime verification evidence (#281 #282)

### DIFF
--- a/docs/adr/phase-u-u5-gemini-runtime-verification.md
+++ b/docs/adr/phase-u-u5-gemini-runtime-verification.md
@@ -1,0 +1,43 @@
+# Phase U Sprint U.5 Verification Report
+
+Date: 2026-03-02  
+Branch: `feature/pU-s5-gemini-verification`  
+Base: `integrate/phase-U`
+
+## Scope
+
+Verification target issues:
+- #281 Gemini resume flag/session drift
+- #282 Gemini runtime spawn wiring
+
+## Matrix Results
+
+| Check | Issue | Result | Evidence |
+|---|---|---|---|
+| GeminiAdapter present in daemon codebase | #282 | PASS* | `grep -R \"GeminiAdapter\" crates/atm-daemon/src/` returned no literal symbol, but Gemini runtime wiring is present in `plugins/worker_adapter/plugin.rs` and `plugins/worker_adapter/codex_tmux.rs` with dedicated Gemini launch/resume tests passing. |
+| Gemini spawn env vars set correctly (`GEMINI_CLI_HOME`, `ATM_RUNTIME_HOME`) | #282 | PASS | `cargo test -p agent-team-mail-daemon test_handle_launch_gemini_ -- --nocapture` passed (2 tests), including env shaping assertions. |
+| Runtime metadata (`runtime`, `runtime_session_id`, `runtime_home`) persisted and queryable | #282 | PASS | `test_session_query_includes_runtime_metadata_fields` and `test_launch_gemini_runtime_metadata_roundtrip` both passed. |
+| Resume binds to correct prior session | #281 | PASS | `cargo test -p agent-team-mail-daemon test_resume_ -- --nocapture` passed (4 tests). |
+| Resume does not drift to wrong session/flags | #281 | PASS | `test_resume_explicit_override_takes_precedence_over_registry` and `test_resume_does_not_drift_to_session_from_other_runtime` passed under the `test_resume_` run. |
+
+## Commands Run
+
+```bash
+grep -R "GeminiAdapter" crates/atm-daemon/src/ || true
+cargo test -p agent-team-mail-daemon test_handle_launch_gemini_ -- --nocapture
+cargo test -p agent-team-mail-daemon test_resume_ -- --nocapture
+cargo test -p agent-team-mail-daemon test_session_query_includes_runtime_metadata_fields -- --nocapture
+cargo test -p agent-team-mail-daemon test_launch_gemini_runtime_metadata_roundtrip -- --nocapture
+```
+
+## Regression/Drift Note
+
+- The checklist item requiring the literal symbol `GeminiAdapter` is stale relative to the current implementation naming. Functional Gemini runtime adapter behavior is implemented, but the exact class/type name is no longer `GeminiAdapter`.
+
+Recommended follow-up:
+- Update `docs/test-plan-phase-U.md` U.5 check wording from literal symbol match to functional adapter presence criteria (runtime wiring + passing Gemini launch/resume tests).
+
+## Conclusion
+
+U.5 verification outcome for #281/#282: **PASS (functional)** with one checklist wording drift noted.
+


### PR DESCRIPTION
## Summary
- executed U.5 Gemini runtime verification matrix for #281/#282
- documented outcomes and evidence in `docs/adr/phase-u-u5-gemini-runtime-verification.md`
- verified launch env shaping, runtime metadata roundtrip, and resume correctness/drift protections via targeted daemon tests

## Validation Commands
- `grep -R "GeminiAdapter" crates/atm-daemon/src/ || true`
- `cargo test -p agent-team-mail-daemon test_handle_launch_gemini_ -- --nocapture`
- `cargo test -p agent-team-mail-daemon test_resume_ -- --nocapture`
- `cargo test -p agent-team-mail-daemon test_session_query_includes_runtime_metadata_fields -- --nocapture`
- `cargo test -p agent-team-mail-daemon test_launch_gemini_runtime_metadata_roundtrip -- --nocapture`

## Notes
- Functional verification passed.
- One checklist wording drift noted: literal `GeminiAdapter` symbol check is stale versus current implementation naming.
