### PR TITLE
Phase V + W planning: doctor/lifecycle + release automation

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,18 +1,55 @@
 # Known Issues
 
-Last updated: 2026-03-02 (Phase V)
+Last updated: 2026-03-02 (Phase V + Phase W)
 
-## Phase V Issues
+## Phase V Issues (Doctor/Lifecycle — arch-ctm's V.0–V.7)
 
 | Issue | Summary | Type | Status | Priority | Planned Sprint | Notes |
 |---|---|---|---|---|---|---|
-| [#323](https://github.com/randlee/agent-team-mail/issues/323) | Release workflow: post-publish-verify crates.io API 403 | Bug | Open | High | V.3 | Add retry logic to curl checks |
-| [#324](https://github.com/randlee/agent-team-mail/issues/324) | Release workflow: add Homebrew formula publishing job | Enhancement | Open | High | V.3 | Automate Homebrew tap update |
-| [#325](https://github.com/randlee/agent-team-mail/issues/325) | Release workflow: pre-publish audit + waiver gate | Enhancement | Open | High | V.4 | `cargo package --locked` gate before publish |
-| [#326](https://github.com/randlee/agent-team-mail/issues/326) | Release workflow: cross-channel verification + completion report | Enhancement | Open | High | V.4 | Consolidated summary in workflow UI |
-| [#327](https://github.com/randlee/agent-team-mail/issues/327) | publisher agent: eliminate sub-agent spawning | Bug | Open | High | V.2 | Rewrite publisher.md; trigger gh workflow run directly |
-| [#328](https://github.com/randlee/agent-team-mail/issues/328) | atm send: remove default offline action prefix | Bug | Open | High | V.1 | send.rs:419 → `String::new()` |
-| [#329](https://github.com/randlee/agent-team-mail/issues/329) | docs/agent-teams-mail-skill.md: remove [PENDING ACTION] tag pattern guidance | Documentation | Open | Medium | V.1 | Skill doc reinforces bad pattern |
+| [#330](https://github.com/randlee/agent-team-mail/issues/330) | isActive conflated with liveness across 9+ code paths | Bug | Open | Critical | V.3 | Root cause of all offline-while-functional reports |
+| [#331](https://github.com/randlee/agent-team-mail/issues/331) | TERMINAL_MEMBER_NOT_CLEANED — dead non-lead persists in roster/mailbox | Bug | Open | Critical | V.4 | Lifecycle cleanup not guaranteed on all paths |
+| [#332](https://github.com/randlee/agent-team-mail/issues/332) | PARTIAL_TEARDOWN misclassifies team-lead dead session as critical | Bug | Open | High | V.2 | Lead retention policy not in classification logic |
+| [#333](https://github.com/randlee/agent-team-mail/issues/333) | cross-team doctor bleed — DAEMON_TRACKS_UNKNOWN_AGENT across teams | Bug | Open | High | V.1 | Unscoped query_list_agents() |
+| [#334](https://github.com/randlee/agent-team-mail/issues/334) | Session registry drift after team recreation (DAEMON_TRACKS_UNKNOWN_AGENT persists) | Bug | Open | High | V.4 | Daemon registry not pruned on recreate |
+| [#335](https://github.com/randlee/agent-team-mail/issues/335) | Doctor member snapshot header missing (findings shown without context table) | Enhancement | Open | Medium | V.6 | Output ordering: members before findings |
+| [#336](https://github.com/randlee/agent-team-mail/issues/336) | Doctor recommends `atm register` when CLAUDE_SESSION_ID unavailable | Bug | Open | Medium | V.5 | Non-actionable recommendation in plain shells |
+
+## Phase W Issues (Release Automation + ATM Bugs — team-lead's W.1–W.4)
+
+| Issue | Summary | Type | Status | Priority | Planned Sprint | Notes |
+|---|---|---|---|---|---|---|
+| [#323](https://github.com/randlee/agent-team-mail/issues/323) | Release workflow: post-publish-verify crates.io API 403 | Bug | Open | High | W.3 | Add retry logic to curl checks |
+| [#324](https://github.com/randlee/agent-team-mail/issues/324) | Release workflow: add Homebrew formula publishing job | Enhancement | Open | High | W.3 | Automate Homebrew tap update |
+| [#325](https://github.com/randlee/agent-team-mail/issues/325) | Release workflow: pre-publish audit + waiver gate | Enhancement | Open | High | W.4 | `cargo package --locked` gate before publish |
+| [#326](https://github.com/randlee/agent-team-mail/issues/326) | Release workflow: cross-channel verification + completion report | Enhancement | Open | High | W.4 | Consolidated summary in workflow UI |
+| [#327](https://github.com/randlee/agent-team-mail/issues/327) | publisher agent: eliminate sub-agent spawning | Bug | Open | High | W.2 | Rewrite publisher.md; trigger gh workflow run directly |
+| [#328](https://github.com/randlee/agent-team-mail/issues/328) | atm send: remove default offline action prefix | Bug | Open | High | W.1 | send.rs:419 → `String::new()` |
+| [#329](https://github.com/randlee/agent-team-mail/issues/329) | docs/agent-teams-mail-skill.md: remove [PENDING ACTION] tag pattern guidance | Documentation | Open | Medium | W.1 | Skill doc reinforces bad pattern |
+
+## Deferred Backlog (Now Tracked)
+
+| Issue | Summary | Type | Status | Priority | Notes |
+|---|---|---|---|---|---|
+| [#337](https://github.com/randlee/agent-team-mail/issues/337) | Missing #[serial] on 27 daemon integration tests (ATM_HOME env var races) | Bug | Open | Medium | Flaky CI risk |
+| [#338](https://github.com/randlee/agent-team-mail/issues/338) | `atm teams add-member` does not create inbox file | Bug | Open | High | Blocks reliable onboarding |
+
+## State-Model Inconsistency Inventory (Needs Sprint Planning)
+
+These are code-level inconsistencies against the intended model:
+- daemon/session registry = liveness source of truth
+- `isActive` = activity/busy signal only
+
+| Area | File / Code Path | Current Inconsistency | Next Sprint Action |
+|---|---|---|---|
+| Doctor member snapshot rendering | `crates/atm/src/commands/doctor.rs` (`member_snapshot` status mapping) | Maps `isActive` directly to `Online/Offline`, conflating activity with liveness. | Derive status from daemon/session query; show activity as separate field if needed. |
+| Doctor reconciliation findings | `crates/atm/src/commands/doctor.rs` (`check_pid_session_reconciliation`) | `ACTIVE_WITHOUT_SESSION` / `ACTIVE_FLAG_STALE` logic is based on `is_active`, which is activity metadata. | Reframe findings around daemon liveness vs roster/session invariants; avoid treating activity bit as liveness truth. |
+| Daemon config reconcile writes | `crates/atm-daemon/src/daemon/event_loop.rs` (`reconcile_team_member_activity`) | Overwrites `member.is_active` from PID/session liveness (`member.is_active = Some(alive)`). | Stop writing liveness into `isActive`; persist liveness separately (or derive on read). |
+| Status command fallback | `crates/atm/src/commands/status.rs` (`resolve_member_active`) | Falls back to `member.is_active` when daemon state missing, presenting it as online/offline. | Require explicit liveness source/fallback label; do not silently map activity to online/offline. |
+| Members command labels | `crates/atm/src/commands/members.rs` | Displays `isActive` as `Online/Offline`. | Rename display to activity semantics (`Busy/Idle/Unknown`) or split columns (Liveness + Activity). |
+| Send offline detection | `crates/atm/src/commands/send.rs` | Offline warning path reads `isActive` instead of daemon liveness. | Use daemon/session liveness for offline hint; unknown when daemon unavailable. |
+| Send heartbeat writes | `crates/atm/src/commands/send.rs` (`set_sender_heartbeat`) | Writes `isActive=true` heartbeat that downstream logic treats as liveness. | Keep heartbeat behavior but ensure all consumers treat it as activity-only. |
+| Register/team mutation paths | `crates/atm/src/commands/register.rs`, `crates/atm/src/commands/teams.rs` | Commands set `isActive` in ways interpreted by other components as liveness. | Audit and align all writes/reads to activity semantics; add explicit liveness fields or daemon query adapters. |
+| Test expectations | `crates/atm/tests/integration_conflict_tests.rs`, `integration_send.rs`, `integration_register.rs`, daemon tests | Many tests assert `Online/Offline` based on `isActive` toggles. | Rewrite assertions to separate liveness vs activity semantics and add regression coverage. |
 
 ## Pre-Phase-V Open Issues (Carried Forward)
 
@@ -76,7 +113,7 @@ Last updated: 2026-03-02 (Phase V)
 |---|---|---|
 | Doctor reconciliation appears cross-team (`DAEMON_TRACKS_UNKNOWN_AGENT`) | `crates/atm/src/commands/doctor.rs` currently calls unscoped `query_list_agents()` in `check_roster_session_integrity`, so tracked agents from other teams leak into a single-team doctor run. | Add team-scoped list query (`list-agents` payload with `team`), update doctor to use scoped results, and add regression tests proving no cross-team bleed. |
 | `PARTIAL_TEARDOWN` on `team-lead` after recreation | `check_mailbox_integrity` treats all dead sessions the same, but `team-lead` is intentionally retained in roster by cleanup flows; missing mailbox + dead session can be expected transiently and is currently over-classified as critical drift. | Split teardown logic for lead vs non-lead members; classify lead state with explicit guidance (`register`/recreate session) instead of stale-member cleanup critical. |
-| `ACTIVE_WITHOUT_SESSION` after restore/recreate | `check_pid_session_reconciliation` warns when `member.is_active == true` and `query_session_for_team(...)` returns `None`; restore/recreate paths can leave `is_active` stale while daemon session registry is reset/rebuilt, creating persistent warning drift without explicit reconciliation. | Add deterministic reconciliation path after restore/recreate (or daemon startup) to recompute `is_active` from live session registry, and add tests for restore/recreate transitions. |
+| `ACTIVE_WITHOUT_SESSION` after restore/recreate | `check_pid_session_reconciliation` currently interprets `member.is_active` as liveness-adjacent despite `isActive` being activity metadata; restore/recreate paths expose this conflation when session registry is reset/rebuilt. | Split activity vs liveness semantics in doctor checks; use daemon/session truth for liveness findings and keep `isActive` for activity-only diagnostics. Add regression tests for restore/recreate transitions. |
 | `TERMINAL_MEMBER_NOT_CLEANED` (dead member remains roster+mailbox) | `check_mailbox_integrity` correctly detects dead session + mailbox + roster for non-lead members, but lifecycle cleanup is not guaranteed to run (or complete) on all termination paths, so stale non-lead artifacts survive and doctor repeatedly reports critical drift. | Harden termination/cleanup orchestration so dead non-lead members are removed from roster and mailbox together across all kill/timeout paths; add teardown convergence tests. |
 | Session registry drift after team recreation/removal (`DAEMON_TRACKS_UNKNOWN_AGENT`) | Daemon tracked-state/session entries can persist for removed members after team reset/recreate; stale daemon-side registry data is not deterministically pruned during roster reconciliation, so doctor continues to see unknown tracked agents even when team config is clean. | Add deterministic prune/reconcile pass in daemon roster/session synchronization (remove tracked entries absent from current team config after recreation/reset) and add regression tests covering remove/recreate cycles. |
 | `atm register` recommendation fails without `CLAUDE_SESSION_ID` | `build_recommendations` unconditionally recommends `atm register <team>` for `ACTIVE_WITHOUT_SESSION`/`ACTIVE_FLAG_STALE`, but `atm register` requires a resolvable session id (managed environment or explicit `--as`) and can fail in plain shells. | Make recommendations context-aware: emit actionable alternatives when session id is unavailable (for example `--as` guidance, run from managed session, or daemon-assisted recovery command), with coverage tests for recommendation text/selection. |

--- a/docs/test-plan-phase-W.md
+++ b/docs/test-plan-phase-W.md
@@ -1,8 +1,8 @@
-# Phase V: Release Workflow Automation + ATM Bug Fixes
+# Phase W: Release Workflow Automation + ATM Bug Fixes
 
 **Goal**: (1) Eliminate manual steps from the release pipeline that caused the v0.28.0 disaster. (2) Fix ATM messaging bugs surfaced during dogfooding. (3) Harden the publisher agent to eliminate sub-agent sprawl.
 
-**Integration branch**: `integrate/phase-V` off `develop`.
+**Integration branch**: `integrate/phase-W` off `develop`.
 
 **Background**: The v0.28.0 release required manual intervention at every stage — merge conflicts, Homebrew update, GitHub Release creation (due to crates.io 403), and manual publisher.md sub-agent spawning that created named teammate sprawl. This phase automates the gaps.
 
@@ -140,21 +140,21 @@
 
 | Sprint | Description | Issues | Type | Depends On |
 |--------|-------------|--------|------|------------|
-| V.1 | ATM send offline action + skill doc fix | #328, #329 | Fix | — |
-| V.2 | Publisher agent rewrite (no sub-agents) | #327 | Fix/Docs | — |
-| V.3 | Release workflow: crates.io retry + Homebrew automation | #323, #324 | CI/CD | — |
-| V.4 | Release workflow: pre-publish audit + completion report | #325, #326 | CI/CD | V.3 |
+| W.1 | ATM send offline action + skill doc fix | #328, #329 | Fix | — |
+| W.2 | Publisher agent rewrite (no sub-agents) | #327 | Fix/Docs | — |
+| W.3 | Release workflow: crates.io retry + Homebrew automation | #323, #324 | CI/CD | — |
+| W.4 | Release workflow: pre-publish audit + completion report | #325, #326 | CI/CD | W.3 |
 
 **Parallel tracks**: V.1 and V.2 can run in parallel with each other and with V.3. V.4 depends on V.3 (extends the same workflow file).
 
-**Version**: Phase V targets v0.29.0.
+**Version**: Phase W targets v0.29.0.
 
 ---
 
 ## Key Lessons from Phase U / v0.28.0 Release
 
 1. **Named teammate sprawl**: Publisher spawning sub-agents = pane exhaustion. Gate hook now blocks this, but publisher.md must be rewritten to not try.
-2. **Homebrew is not automated**: Every release requires manual SSH+edit+push to homebrew-tap. V.3 closes this.
+2. **Homebrew is not automated**: Every release requires manual SSH+edit+push to homebrew-tap. W.3 closes this.
 3. **crates.io 403s on CI**: CDN bot protection causes transient failures. Retry logic is the fix.
 4. **Merge conflicts**: `Cargo.lock` stale entries, hardcoded version pins in `atm-tui/Cargo.toml`. Pre-publish audit catches version mismatches before they block releases.
-5. **Doctor "offline" ≠ agent not working**: `atm doctor` shows team-lead/arch-ctm as offline post-daemon-restart because session registry is stale. Agents ARE functional (messaging via filesystem). This is a doctor UX issue, not an actual availability problem.
+5. **State-model separation must be explicit**: mailbox delivery can still work while daemon liveness is stale. Treat this as a state reconciliation bug, not expected behavior; `isActive` must remain activity-only and daemon session state must remain liveness truth.


### PR DESCRIPTION
## Summary

- Adds `docs/test-plan-phase-W.md` — Phase W sprint plan (W.1–W.4): release workflow automation + ATM bug fixes (#323–#329)
- Adds arch-ctm's `docs/test-plan-phase-V.md` (on develop) — Phase V sprint plan (V.0–V.7): doctor state-model convergence (#330–#336)
- Updates `docs/issues.md` with Phase V, Phase W, and deferred issue tables (#330–#338)
- Updates `docs/project-plan.md` section 17.10 (arch-ctm's Phase V doctor sprints)

## Issues Filed This Planning Cycle

**Phase V — Doctor/Lifecycle** (arch-ctm's V.0–V.7):
- #330 isActive/liveness conflation across 9+ code paths
- #331 TERMINAL_MEMBER_NOT_CLEANED
- #332 PARTIAL_TEARDOWN lead misclassification  
- #333 cross-team doctor bleed
- #334 session registry drift after recreate
- #335 doctor snapshot header missing
- #336 atm register recommendation non-actionable in plain shells

**Phase W — Release Automation + ATM Bugs** (W.1–W.4):
- #323–#329 (filed end of Phase U)

**Deferred/Backlog** (now tracked):
- #337 missing `#[serial]` on 27 daemon integration tests
- #338 `atm teams add-member` does not create inbox file

## Test plan

- CI green is the gate (doc-only changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)