### PR TITLE
docs: Phase V V.0 baseline investigation + test plan mapping

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -46,7 +46,7 @@ Last updated: 2026-03-02
 |---|---|---|---|---|
 | Keep provisional sprint mappings synchronized across planning docs | Documentation | Open | Medium | Source-of-truth sequencing for current draft is `docs/test-plan-phase-T.md`; update `project-plan.md` + `issues.md` together on mapping changes |
 
-## New Doctor Findings (Needs GitHub Issue Creation)
+## New Doctor Findings (Issue Creation Completed)
 
 | Item | Type | Status | Priority | Notes |
 |---|---|---|---|---|
@@ -57,6 +57,22 @@ Last updated: 2026-03-02
 | Session registry drift after team recreation/removal (`DAEMON_TRACKS_UNKNOWN_AGENT`) | Bug | Open | High | Daemon continues tracking removed agents (for example `arch-ctm`) after roster reset/recreate, causing persistent unknown-agent warnings. |
 | `isActive=true` members without daemon session (`ACTIVE_WITHOUT_SESSION`) after restore/recreate | Bug | Open | Medium | Restored/re-added members can remain marked active with no live daemon session record; doctor warns until explicit registration/reconciliation occurs. |
 | `atm doctor` recommends `atm register` even when `CLAUDE_SESSION_ID` is unavailable | UX/Diagnostics | Open | Medium | In non-hook shells, `atm register` fails with \"Cannot determine session_id\"; recommendation should be context-aware or include actionable fallback guidance (`--as`, run from managed session, etc.). |
+
+## Phase V Active Mapping (Issue-Backed)
+
+| Sprint | Focus | Issue |
+|---|---|---|
+| V.1 | Team-scoped doctor reconciliation | [#333](https://github.com/randlee/agent-team-mail/issues/333) |
+| V.2 | Lead/non-lead teardown semantics | [#332](https://github.com/randlee/agent-team-mail/issues/332) |
+| V.3 | `isActive`/liveness separation | [#330](https://github.com/randlee/agent-team-mail/issues/330) |
+| V.4 | Terminal cleanup convergence + stale tracked members | [#331](https://github.com/randlee/agent-team-mail/issues/331), [#334](https://github.com/randlee/agent-team-mail/issues/334) |
+| V.5 | Recommendation actionability | [#336](https://github.com/randlee/agent-team-mail/issues/336) |
+| V.6 | Doctor output context snapshot ordering | [#335](https://github.com/randlee/agent-team-mail/issues/335) |
+
+## Phase W Coordination
+
+- Release automation moved to Phase W (`W.1`–`W.4`) to avoid naming collision with Phase V.
+- `send.rs` overlap between W.1 and V.3 requires W.1 to land first.
 
 ### Root-Cause Notes (Documented, Not Yet Implemented)
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1145,6 +1145,27 @@ Update project-plan.md S.2a deliverable #6 to reflect actual hooks installed (Se
 | T.16 | S.2a/S.1 plan deliverable accuracy | — | XS | PLANNED | [#283](https://github.com/randlee/agent-team-mail/issues/283) |
 
 ---
+
+## 17.10 Phase V: Doctor State-Model Convergence (Planning)
+
+**Goal**: Eliminate remaining doctor/lifecycle state-model gaps with requirements-first implementation and explicit regression coverage.
+
+**Execution reference**: `docs/test-plan-phase-V.md`
+
+**Coordination note**: `send.rs` overlap with Phase W.1 means **W.1 must merge before V.3**.
+
+| Sprint | Name | Depends On | Size | Status | Issue |
+|--------|------|------------|------|--------|-------|
+| V.0 | Baseline diagnostics fixture capture | — | S | IN PROGRESS | prerequisite |
+| V.1 | Team-scoped doctor reconciliation | V.0 | M | PLANNED | [#333](https://github.com/randlee/agent-team-mail/issues/333) |
+| V.2 | Lead/non-lead teardown semantics | V.0 | M | PLANNED | [#332](https://github.com/randlee/agent-team-mail/issues/332) |
+| V.3 | `isActive`/liveness separation hardening | V.1, W.1 | M | PLANNED | [#330](https://github.com/randlee/agent-team-mail/issues/330) |
+| V.4 | Terminal-member cleanup convergence | V.2 | M | PLANNED | [#331](https://github.com/randlee/agent-team-mail/issues/331), [#334](https://github.com/randlee/agent-team-mail/issues/334) |
+| V.5 | Recommendation engine hardening | V.2 | S | PLANNED | [#336](https://github.com/randlee/agent-team-mail/issues/336) |
+| V.6 | Doctor UX snapshot/report ordering | V.1 | S | PLANNED | [#335](https://github.com/randlee/agent-team-mail/issues/335) |
+| V.7 | Logging identity contract coverage | V.0 | S | PLANNED | (Phase V umbrella) |
+
+---
 ## 18. Future Plugins
 
 | Plugin | Priority | Notes |

--- a/docs/test-plan-phase-V.md
+++ b/docs/test-plan-phase-V.md
@@ -1,0 +1,66 @@
+# Phase V Test Plan: Doctor State + Lifecycle Convergence
+
+Last updated: 2026-03-02
+
+## Goal
+
+Define implementation-ready tests for Phase V doctor/lifecycle fixes so each issue has explicit acceptance coverage before coding merges.
+
+## Scope
+
+- Team-scoped doctor reconciliation
+- Teardown convergence (lead vs non-lead)
+- `isActive` (busy signal) vs liveness separation
+- Recommendation quality/actionability
+- Doctor output context ordering
+- Logging process identity coverage (`pid`/`ppid`)
+
+## Issue Mapping
+
+| Sprint | Focus | Issue(s) |
+|---|---|---|
+| V.0 | Baseline fixtures + failing-path capture | prerequisite (no dedicated issue) |
+| V.1 | Team-scoped reconciliation | [#333](https://github.com/randlee/agent-team-mail/issues/333) |
+| V.2 | Lead/non-lead teardown semantics | [#332](https://github.com/randlee/agent-team-mail/issues/332) |
+| V.3 | `isActive`/liveness separation | [#330](https://github.com/randlee/agent-team-mail/issues/330) |
+| V.4 | Terminal-member cleanup convergence | [#331](https://github.com/randlee/agent-team-mail/issues/331), [#334](https://github.com/randlee/agent-team-mail/issues/334) |
+| V.5 | Recommendation engine hardening | [#336](https://github.com/randlee/agent-team-mail/issues/336) |
+| V.6 | Doctor UX snapshot ordering | [#335](https://github.com/randlee/agent-team-mail/issues/335) |
+| V.7 | Logging identity contract coverage | track under Phase V umbrella (issue optional) |
+
+## Coordination Constraint
+
+- `send.rs` overlap exists between Phase W.1 (offline prefix behavior) and V.3 (`isActive` semantics). Sequence: **W.1 must merge before V.3**.
+
+## V.0 Baseline Fixture Tasks
+
+1. Add reproducible test fixtures for currently observed finding classes:
+   - `DAEMON_TRACKS_UNKNOWN_AGENT`
+   - `PARTIAL_TEARDOWN`
+   - `TERMINAL_MEMBER_NOT_CLEANED`
+   - `ACTIVE_WITHOUT_SESSION`
+2. For each fixture, codify current behavior as:
+   - failing test with `#[ignore]` (documenting known drift), or
+   - passing guard test where behavior is already corrected.
+3. Record fixture locations and invocation commands in sprint PR notes.
+
+## Harness Targets
+
+- `crates/atm/src/commands/doctor.rs` (classification/recommendation unit tests)
+- `crates/atm-daemon/tests/` (lifecycle/cleanup integration)
+- `crates/atm/tests/` (CLI human output + recommendation wiring)
+- `crates/atm-core/tests/` (logging contract: `pid`/`ppid`)
+
+## Execution Commands (Baseline)
+
+```bash
+cargo test -p agent-team-mail doctor -- --nocapture
+cargo test -p agent-team-mail-daemon -- --nocapture
+cargo test -p agent-team-mail-core log -- --nocapture
+```
+
+## Exit Criteria
+
+- Every V.* sprint has explicit tests mapped to acceptance criteria.
+- Critical doctor findings are reproducible via fixtures and eliminated by covered fixes.
+- CI matrix remains green for touched suites.


### PR DESCRIPTION
## Summary
- add `docs/test-plan-phase-V.md` with V.0-V.7 matrix and issue mapping (#330-#336)
- add Phase V section (17.10) to project plan with dependencies and W.1 -> V.3 sequencing
- update issues doc with Phase V active mapping and Phase W coordination notes

## Scope
Documentation/planning only. No runtime code changes.

## Validation
- reviewed doc consistency across `issues.md`, `project-plan.md`, and `test-plan-phase-V.md`
