### PR TITLE
fix(send): remove default offline action prefix; update skill doc (#328, #329)

### DIFF
--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -416,7 +416,7 @@ fn resolve_offline_action(args: &SendArgs, config: &Config) -> String {
         return action.clone();
     }
 
-    "PENDING ACTION - execute when online".to_string()
+    String::new()
 }
 
 /// Generate summary from message text (first ~100 chars)
@@ -528,10 +528,7 @@ mod tests {
     fn test_resolve_offline_action_default() {
         let args = make_send_args(None);
         let config = Config::default();
-        assert_eq!(
-            resolve_offline_action(&args, &config),
-            "PENDING ACTION - execute when online"
-        );
+        assert_eq!(resolve_offline_action(&args, &config), "");
     }
 
     #[test]

--- a/docs/agent-teams-mail-skill.md
+++ b/docs/agent-teams-mail-skill.md
@@ -36,7 +36,7 @@ However, when an agent respawns with a **new session**, the last-seen watermark 
 
 - **Clean inbox** (few messages): Plain instructions are generally acted on
 - **Noisy inbox** (many old messages): Plain instructions are treated as stale history and ignored
-- **With call-to-action tag**: Instructions prefixed with `[PENDING ACTION]` or `[OFFLINE MESSAGE - Acknowledge and respond]` are reliably acted on regardless of inbox noise
+- **With call-to-action tag**: Instructions prefixed with `[OFFLINE MESSAGE - Acknowledge and respond]` (via `--offline-action` flag) are reliably acted on regardless of inbox noise
 
 The root cause is disambiguation — without a signal, the agent cannot distinguish "new task waiting for me" from "old task that was already handled by a previous instance."
 
@@ -138,7 +138,7 @@ Claude Code reads `leadSessionId` (and likely other team config) once at session
 
 1. **Offline delivery documented** in API docs ✅
 2. **Use spawn prompts for task assignment** — more reliable than inbox queuing ✅
-3. **`[PENDING ACTION]` tag pattern** — defensive measure for queued messages ✅
+3. **`--offline-action` flag** — optional call-to-action prefix for queued messages (no prefix by default) ✅
 4. **`atm send` offline detection** — warns if recipient `isActive == false` ✅
 5. **`--since-last-seen` cursor** — default for `atm read`, prevents inbox flooding ✅
 


### PR DESCRIPTION
## Summary

- `resolve_offline_action()` returns `String::new()` by default — silent delivery is the correct default
- Users who want a prefix can still use `--offline-action "text"` or `config.messaging.offline_action`
- `docs/agent-teams-mail-skill.md`: replaced `[PENDING ACTION]` tag guidance with `--offline-action` flag documentation

## Test plan
- `test_resolve_offline_action_default` updated to assert `""`
- Existing `--offline-action` flag tests unchanged

Closes #328, #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)