### PR TITLE
docs: synchronize Phase X plan, requirements, and test plans

### DIFF
--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -163,6 +163,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | R | Session Handoff + Hook Installer | Daemon singleton lock, session registry, `atm doctor` | COMPLETE |
 | S | Runtime Adapters + Hook Installer | Gemini adapter, `atm init` hook installer | COMPLETE |
 | T | Daemon Reliability + Bug Debt | Fix daemon auto-start, config sync, TUI bugs, deferred S work | COMPLETE |
+| X | Team Onboarding + TUI/Doctor Stability | Close onboarding race, daemon test flakes, and prioritized TUI/doctor blockers | PLANNED |
 
 ---
 
@@ -1183,6 +1184,152 @@ This section exists to resolve cross-phase references used by Phase V and QA rev
 **V.4 dependency note**: V.4 is a daemon lifecycle cleanup sprint scoped to #331/#334. It was executed as an independently testable guard/hardening pass before V.2 merge completion to stop active regressions; V.2 remains the broader teardown-policy sprint. V.4 is intentionally independent from V.1 doctor reconciliation.
 
 ---
+## 17.12 Phase X: Team Onboarding + TUI/Doctor Stability (Planning)
+
+**Goal**: Close active blockers across onboarding, daemon test stability, TUI correctness, and doctor correctness.
+**Execution reference**: `docs/test-plan-phase-X.md`.
+
+**Integration branch**: `integrate/phase-X` off `develop`.
+
+**Execution order**:
+1. High priority (foundational blockers): X.3 → X.4 → X.5.
+2. Medium priority (correctness + core feature): X.6 → X.7.
+3. Low priority (polish): X.8.
+4. Onboarding/test-stability track: X.1 → X.2 (can run in parallel with X.3-X.8 when ownership does not overlap).
+
+### X.1 — Atomic inbox creation in `atm teams add-member` *(bug fix, [#338](https://github.com/randlee/agent-team-mail/issues/338))*
+
+**Problem**: `atm teams add-member` updates team roster but does not create `inboxes/<member>.json` in the same operation. This creates roster/inbox drift and first-send bootstrap failures.
+
+**Deliverables**:
+1. Make `atm teams add-member` create member inbox atomically as part of add flow.
+2. Reuse shared atomic file-write path used by send/bootstrap logic (no bespoke writer).
+3. Preserve idempotency: re-adding existing member does not corrupt existing inbox.
+4. Add regression tests for add-member + immediate inbox existence.
+5. Add doctor integration coverage proving no false drift after add-member.
+
+**Acceptance criteria**:
+- Immediately after `atm teams add-member <team> <member>`, `inboxes/<member>.json` exists.
+- First `atm send` to that member works without bootstrap side-effects.
+- `atm doctor` reports no roster/inbox integrity finding for that newly added member.
+
+### X.2 — Serialize daemon integration tests mutating `ATM_HOME` *(bug fix, [#337](https://github.com/randlee/agent-team-mail/issues/337))*
+
+**Problem**: 27 daemon integration tests mutate process env (`ATM_HOME`) without serialization, causing nondeterministic failures under parallel test execution.
+
+**Deliverables**:
+1. Add `#[serial]` to all daemon integration tests that read/write `ATM_HOME` in:
+   - `crates/atm-daemon/tests/issues_error_tests.rs`
+   - `crates/atm-daemon/tests/ci_monitor_error_tests.rs`
+   - `crates/atm-daemon/tests/issues_integration.rs`
+2. Keep unaffected tests parallel to avoid unnecessary runtime regression.
+3. Add/adjust test docs comments so env-mutating tests clearly indicate serialization requirement.
+4. Validate with local parallel stress run and existing CI matrix.
+
+**Acceptance criteria**:
+- No env-race flakes in daemon test suite under parallel execution (`--test-threads=8` baseline check).
+- Linux/macOS/Windows CI daemon test jobs stay green without intermittent ATM_HOME failures.
+
+### X.3 — Daemon auto-start reliability for TUI entry *(bug fix, [#181](https://github.com/randlee/agent-team-mail/issues/181))*
+
+**Priority**: High (foundational blocker).
+
+**Problem**: If daemon does not auto-start reliably, TUI cannot establish live state and appears broken on first use.
+
+**Deliverables**:
+1. Ensure TUI/CLI paths that require daemon trigger deterministic auto-start.
+2. Return explicit failure details when auto-start fails (not silent empty-state behavior).
+3. Add regression coverage for fresh-machine/no-daemon startup path.
+
+**Acceptance criteria**:
+- Starting TUI on a machine without a running daemon auto-starts daemon and loads state.
+- Startup failure yields actionable error output instead of empty/contradictory TUI state.
+
+### X.4 — Roster seeding from `config.json` at startup *(bug fix, [#182](https://github.com/randlee/agent-team-mail/issues/182))*
+
+**Priority**: High (depends on X.3).
+
+**Problem**: TUI/daemon present empty roster despite configured team members because startup seeding/reconciliation is incomplete.
+
+**Deliverables**:
+1. Seed daemon roster from team `config.json` during startup.
+2. Verify roster correctness in TUI immediately after startup.
+3. Add startup seeding and reconciliation tests to prevent regressions.
+
+**Acceptance criteria**:
+- With existing team config, first TUI render shows configured members without manual refresh hacks.
+- Roster state matches `config.json` after daemon startup.
+
+### X.5 — TUI right/left panel state convergence *(bug fix, [#184](https://github.com/randlee/agent-team-mail/issues/184))*
+
+**Priority**: High (after X.3 + X.4).
+
+**Problem**: Right panel status can contradict left panel and stream panel behavior, reducing trust in UI correctness.
+
+**Deliverables**:
+1. Make both panels read from one normalized state source.
+2. Ensure stream panel emptiness is handled consistently with status indicators.
+3. Add regression tests for multi-panel consistency.
+
+**Acceptance criteria**:
+- No contradictory status between left and right panels under identical runtime state.
+- Stream panel and status indicators remain consistent across state transitions.
+
+### X.6 — `parse_since_input` rejects `0m`/negative durations *(bug fix, [#287](https://github.com/randlee/agent-team-mail/issues/287))*
+
+**Priority**: Medium.
+
+**Problem**: Doctor duration parsing currently accepts invalid ranges that violate requirement expectations.
+
+**Deliverables**:
+1. Reject zero and negative duration inputs in `parse_since_input`.
+2. Return clear validation errors for invalid values.
+3. Add unit tests for valid/invalid boundary cases.
+
+**Acceptance criteria**:
+- `0m` and negative durations are rejected with explicit error output.
+- Positive duration inputs continue to work as before.
+
+### X.7 — TUI message viewing capability *(bug fix, [#185](https://github.com/randlee/agent-team-mail/issues/185))*
+
+**Priority**: Medium (larger scope; after core correctness blockers).
+
+**Problem**: TUI cannot view inbox messages, limiting operational use despite daemon/status fixes.
+
+**Deliverables**:
+1. Message list view with basic navigation/filtering as needed.
+2. Message detail pane for full payload visibility.
+3. Read-state behavior and related tests.
+
+**Acceptance criteria**:
+- Operators can view and inspect inbox messages directly from TUI.
+- Message viewing behavior is covered by integration/UI tests.
+
+### X.8 — TUI header version visibility *(bug fix, [#187](https://github.com/randlee/agent-team-mail/issues/187))*
+
+**Priority**: Low (polish).
+
+**Problem**: TUI header omits version string, reducing supportability during debugging.
+
+**Deliverables**:
+1. Render ATM version in TUI header from compile-time package version.
+2. Add lightweight regression check.
+
+**Acceptance criteria**:
+- Header consistently displays expected version string in packaged and dev runs.
+
+| Sprint | Name | Depends On | Size | Status | Issue |
+|--------|------|------------|------|--------|-------|
+| X.1 | Atomic inbox creation in `atm teams add-member` | — | S | PLANNED | [#338](https://github.com/randlee/agent-team-mail/issues/338) |
+| X.2 | Serialize daemon tests mutating `ATM_HOME` | X.1 | S | PLANNED | [#337](https://github.com/randlee/agent-team-mail/issues/337) |
+| X.3 | Daemon auto-start reliability for TUI entry | — | M | PLANNED | [#181](https://github.com/randlee/agent-team-mail/issues/181) |
+| X.4 | Roster seeding from `config.json` at startup | X.3 | M | PLANNED | [#182](https://github.com/randlee/agent-team-mail/issues/182) |
+| X.5 | TUI right/left panel state convergence | X.4 | M | PLANNED | [#184](https://github.com/randlee/agent-team-mail/issues/184) |
+| X.6 | Doctor duration parser boundary fix (`parse_since_input`) | X.5 | XS | PLANNED | [#287](https://github.com/randlee/agent-team-mail/issues/287) |
+| X.7 | TUI message viewing capability | X.6 | L | PLANNED | [#185](https://github.com/randlee/agent-team-mail/issues/185) |
+| X.8 | TUI header version visibility | X.7 | XS | PLANNED | [#187](https://github.com/randlee/agent-team-mail/issues/187) |
+
+---
 ## 18. Future Plugins
 
 | Plugin | Priority | Notes |
@@ -1322,7 +1469,7 @@ This section exists to resolve cross-phase references used by Phase V and QA rev
 
 **Completed**: 99+ sprints across 23 phases (CI green)
 **Current version**: v0.27.0
-**Next**: Phase U (TBD)
+**Next**: Phase X (planned)
 
 ---
 
@@ -1355,19 +1502,22 @@ This section exists to resolve cross-phase references used by Phase V and QA rev
 
 **WARNING**: All issues below are OPEN on GitHub. Do not mark as resolved without verifying the fix exists AND closing the GitHub issue.
 
-| Issue | Description | Phase T Sprint | Notes |
+| Issue | Description | Planned Sprint | Notes |
 |-------|-------------|----------------|-------|
-| [#181](https://github.com/randlee/agent-team-mail/issues/181) | Daemon not auto-starting | T.1 | **Critical** — blocks all daemon-dependent features |
-| [#182](https://github.com/randlee/agent-team-mail/issues/182) | Agent roster not seeded from config.json | T.2 | **Critical** — daemon starts with empty roster |
+| [#181](https://github.com/randlee/agent-team-mail/issues/181) | Daemon not auto-starting | X.3 | **Critical** — foundational TUI blocker |
+| [#182](https://github.com/randlee/agent-team-mail/issues/182) | Agent roster not seeded from config.json | X.4 | **Critical** — TUI roster correctness blocker |
 | [#183](https://github.com/randlee/agent-team-mail/issues/183) | Agent state never transitions | T.2 | **Critical** — state tracking broken (consolidated into T.2, PR #289) |
-| [#184](https://github.com/randlee/agent-team-mail/issues/184) | TUI right panel contradicts left panel | T.4 | Needs investigation — may be fixed by Phase L |
-| [#185](https://github.com/randlee/agent-team-mail/issues/185) | No message viewing in TUI | T.5 | Enhancement |
+| [#184](https://github.com/randlee/agent-team-mail/issues/184) | TUI right panel contradicts left panel | X.5 | High priority correctness bug after daemon/roster foundation |
+| [#185](https://github.com/randlee/agent-team-mail/issues/185) | No message viewing in TUI | X.7 | Medium priority core feature (deferred larger scope) |
 | [#186](https://github.com/randlee/agent-team-mail/issues/186) | Per-agent output.log never written | — | May be superseded by Phase L unified logging — **needs verification** |
-| [#187](https://github.com/randlee/agent-team-mail/issues/187) | TUI header missing version number | T.6 | Quick fix |
+| [#187](https://github.com/randlee/agent-team-mail/issues/187) | TUI header missing version number | X.8 | Low priority polish / quick win |
+| [#287](https://github.com/randlee/agent-team-mail/issues/287) | `parse_since_input` accepts `0m` and negative durations | X.6 | Medium priority doctor correctness bug |
 | [#188](https://github.com/randlee/agent-team-mail/issues/188) | Logging overhaul prerequisite | — | May be addressed by Phase L — **needs verification** |
 | [#45](https://github.com/randlee/agent-team-mail/issues/45) | Tmux Sentinel Injection | T.11 | Enhancement |
 | [#46](https://github.com/randlee/agent-team-mail/issues/46) | Codex Idle Detection via Notify Hook | T.12 | Enhancement |
 | [#47](https://github.com/randlee/agent-team-mail/issues/47) | Ephemeral Pub/Sub for Agent Availability | T.13 | Enhancement |
+| [#337](https://github.com/randlee/agent-team-mail/issues/337) | Missing `#[serial]` on env-mutating daemon tests (`ATM_HOME`) | X.2 | Medium — CI flake prevention/hardening |
+| [#338](https://github.com/randlee/agent-team-mail/issues/338) | `add-member` does not create inbox atomically | X.1 | High — onboarding reliability bug |
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -561,6 +561,28 @@ atm status <team>                # specific team
 
 **Output**: Team info, member list with activity, unread message counts, pending tasks.
 
+#### `atm teams add-member`
+
+Add a member to a team roster with mailbox bootstrap guarantees.
+
+```
+atm teams add-member <team> <agent> [--agent-type <type>] [--model <model>] [--cwd <path>] [--inactive]
+```
+
+**Required behavior**:
+- Add/update the member entry in `config.json`.
+- Create `inboxes/<agent>.json` as part of the same add-member operation using the
+  same atomic write path used for inbox creation elsewhere.
+- The command must be idempotent: re-running add-member for an existing member
+  must not corrupt or truncate an existing inbox.
+- Command completion is not successful unless roster and mailbox converge together
+  (member exists in `config.json` and inbox file exists).
+
+**Acceptance checks**:
+- Immediately after add-member returns success, `inboxes/<agent>.json` exists.
+- First `atm send <agent>@<team>` succeeds without requiring a bootstrap side effect.
+- `atm doctor` reports no roster/mailbox drift for a newly added member.
+
 ### 4.3.1 Lifecycle Teardown and Cleanup Semantics
 
 Daemon-managed teammate shutdown and cleanup MUST follow one canonical flow so that
@@ -674,6 +696,8 @@ atm doctor --full
 - Accepted units: `s` = seconds, `m` = minutes, `h` = hours, `d` = days.
 - Examples: `30m`, `2h`, `1d`, `45s`.
 - Invalid examples: `0m`, `1w`, `1.5h`, `-5m`, `m30`.
+- Zero/negative duration inputs MUST fail validation with actionable error text and
+  must not be coerced into a valid range.
 
 **Output requirements**:
 - Human-readable output MUST start with a concise team member snapshot table (equivalent
@@ -767,6 +791,26 @@ Acceptance checks:
 - Clearing and re-introducing the fault must emit a new alert.
 - Monitor can be launched as a background teammate and continues polling/sending
   alerts without interactive prompting.
+
+### 4.3.3b TUI Baseline Correctness Requirements
+
+TUI behavior must remain consistent with daemon-backed state and inbox data.
+
+Required behavior:
+- Left and right status panels must derive from one normalized state source.
+  Contradictory panel state for the same agent/session is invalid.
+- When daemon state is unavailable, TUI must render explicit degraded/unavailable
+  state guidance instead of silent empty or contradictory status.
+- TUI must provide inbox message viewing:
+  - message list view for selected agent/team context,
+  - message detail view for full payload content,
+  - mark-as-read persistence using the same atomic write guarantees as CLI reads.
+- TUI header must display ATM version from build metadata (`CARGO_PKG_VERSION`).
+
+Acceptance checks:
+- Panel-consistency tests fail on divergent left/right state and pass on unified state.
+- Message list/detail and mark-read persistence tests pass for representative inbox fixtures.
+- Header-render tests assert visible version string in normal TUI startup.
 
 ### 4.3.4 Runtime-Agnostic Teammate Spawn Contract
 
@@ -2008,6 +2052,10 @@ The core has no awareness of whether a team member is local or remote.
 - **Plugin trait tests**: Default test harness for plugin implementations
 - **No external dependencies in tests**: Mock file system, no network calls
 - **Schema evolution tests**: Verify round-trip with unknown fields, missing optional fields
+- **Global env mutation safety**: Tests that read/write process-global env vars
+  (for example `ATM_HOME`) MUST be serialized to avoid cross-test races.
+- **Parallel stability gate**: CI/local suites must include a parallel run baseline
+  (`--test-threads=8` or equivalent) for env-sensitive integration tests.
 
 ### 8.4 Performance
 

--- a/docs/test-plan-phase-U.md
+++ b/docs/test-plan-phase-U.md
@@ -175,8 +175,8 @@ Each sprint verifies Phase T deliverables against v0.27.0 on `develop`. Verifica
 |------|--------|----------|-------|
 | Tmux sentinel injection (#45) | T.11 (never started) | Medium | Runtime signaling improvement — schedule if capacity allows |
 | S.2a/S.1 plan accuracy (#283) | T.16 (never started) | Medium | Doc-only — can be done outside sprint structure |
-| Env-var `#[serial]` violations in daemon integration tests | Tech debt | Medium | 27 tests across 3 files; flakiness risk on parallel CI |
-| `atm teams add-member` does not create inbox file | New bug (observed) | High | Blocks reliable team member onboarding |
+| Env-var `#[serial]` violations in daemon integration tests | Tech debt | Medium | Moved to Phase X (`X.2`, issue #337) |
+| `atm teams add-member` does not create inbox file | New bug (observed) | High | Moved to Phase X (`X.1`, issue #338) |
 | Version bump cherry-pick (v0.27.0 → develop) | Release hygiene | High | `release/v0.27.0` has version bump not yet on develop |
 
 ---
@@ -197,4 +197,3 @@ Each sprint verifies Phase T deliverables against v0.27.0 on `develop`. Verifica
 **Sequencing constraint**: U.1/U.2/U.3 (doctor hardening) MUST complete and merge before U.4–U.8 begin. Doctor is used as a verification tool in the Phase T verification sprints — it must be reliable first.
 
 **Parallel tracks within each wave**: U.1/U.2/U.3 can run in parallel with each other. U.4–U.8 can run in parallel with each other once the doctor wave is complete.
-

--- a/docs/test-plan-phase-W.md
+++ b/docs/test-plan-phase-W.md
@@ -128,10 +128,10 @@
 
 | Item | Source | Priority | Notes |
 |------|--------|----------|-------|
-| Flaky daemon integration tests (`#[serial]` missing) | Phase U backlog | Medium | 27 tests across 3 files; `atm-daemon/tests/`: issues_error_tests.rs, ci_monitor_error_tests.rs, issues_integration.rs |
+| Flaky daemon integration tests (`#[serial]` missing) | Moved to Phase X | Medium | Phase X `X.2` / issue #337 tracks this explicitly |
 | `acquire_lock` max_retries 3→8 in daemon_client.rs | Observed flakiness | Medium | Races during fast CI test runs |
 | Doctor regression: `LEAD_SESSION_RECOVERY_REQUIRED` shown when lead is functional | Post-Phase-U finding | High | After daemon restart, doctor shows team-lead offline even when messaging works. Phase U U.2 hardening may not cover this path. Needs investigation. |
-| `atm teams add-member` does not create inbox file | Phase U backlog | High | Blocks reliable team member onboarding; add-member should create inbox atomically |
+| `atm teams add-member` does not create inbox file | Moved to Phase X | High | Phase X `X.1` / issue #338 tracks atomic add-member inbox creation |
 | Phase V release hygiene: cherry-pick gate hook fix to develop if not already present | Cleanup | High | Commit 0863bd5 must be on develop |
 
 ---

--- a/docs/test-plan-phase-X.md
+++ b/docs/test-plan-phase-X.md
@@ -1,0 +1,128 @@
+# Phase X Test Plan: Onboarding + TUI/Doctor Stability
+
+Last updated: 2026-03-02
+
+## Goal
+
+Define verification coverage for all Phase X planned issues so implementation can be validated against requirements without ambiguity.
+
+## Scope
+
+- Onboarding atomicity (`atm teams add-member` + mailbox bootstrap)
+- Daemon env-sensitive test stability
+- TUI foundational blockers and core usability
+- Doctor duration validation correctness
+
+## Requirements References
+
+- `docs/requirements.md` section `4.3` (`atm teams add-member`)
+- `docs/requirements.md` section `4.3.3` (`atm doctor --since` duration validation)
+- `docs/requirements.md` section `4.3.3b` (TUI baseline correctness)
+- `docs/requirements.md` section `4.7` (daemon auto-start + roster seeding)
+- `docs/requirements.md` section `8.3` (env-mutation test serialization)
+
+## Issue Mapping
+
+| Sprint | Focus | Issue |
+|---|---|---|
+| X.1 | Atomic inbox creation on member add | [#338](https://github.com/randlee/agent-team-mail/issues/338) |
+| X.2 | Serialize env-mutating daemon tests | [#337](https://github.com/randlee/agent-team-mail/issues/337) |
+| X.3 | Daemon auto-start reliability for TUI entry | [#181](https://github.com/randlee/agent-team-mail/issues/181) |
+| X.4 | Roster seeding from config at startup | [#182](https://github.com/randlee/agent-team-mail/issues/182) |
+| X.5 | TUI panel state convergence | [#184](https://github.com/randlee/agent-team-mail/issues/184) |
+| X.6 | Doctor `parse_since_input` boundary validation | [#287](https://github.com/randlee/agent-team-mail/issues/287) |
+| X.7 | TUI message viewing capability | [#185](https://github.com/randlee/agent-team-mail/issues/185) |
+| X.8 | TUI header version visibility | [#187](https://github.com/randlee/agent-team-mail/issues/187) |
+
+## X.1 Verification — `atm teams add-member` Atomic Inbox Creation (#338)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Roster update + inbox creation converge | `atm teams add-member <team> <agent>` then check `config.json` + `inboxes/<agent>.json` | Both exist immediately after success |
+| Idempotent re-run | run add-member twice for same agent | No inbox corruption/truncation |
+| First-send path | `atm send <agent>@<team> "ping"` immediately after add-member | Send succeeds without mailbox bootstrap warning |
+| Doctor integrity | `atm doctor --team <team>` | No roster/mailbox drift for new member |
+
+Pass criteria: all checks pass.
+
+## X.2 Verification — Env-Mutating Daemon Tests Serialized (#337)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Serialization coverage in target files | inspect `crates/atm-daemon/tests/issues_error_tests.rs`, `ci_monitor_error_tests.rs`, `issues_integration.rs` | Env-mutating tests are marked serialized |
+| Parallel stability baseline | `cargo test -p agent-team-mail-daemon -- --test-threads=8` | No `ATM_HOME` race flakes |
+| CI matrix stability | Linux/macOS/Windows CI for daemon test suites | No intermittent env-race failures |
+
+Pass criteria: no flake reproduction under repeated parallel runs.
+
+## X.3 Verification — Daemon Auto-Start Reliability (#181)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Status auto-start | stop daemon, run `atm status` | Daemon auto-starts and status returns |
+| Doctor auto-start | stop daemon, run `atm doctor` | Report produced; no manual daemon start |
+| TUI entry auto-start | stop daemon, launch TUI path | Daemon starts and TUI does not land in silent empty state |
+
+Pass criteria: daemon-backed commands/TUI recover automatically from no-daemon state.
+
+## X.4 Verification — Roster Seeding from `config.json` (#182)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Startup seeding | pre-populate team config, start daemon | In-memory roster matches config |
+| Config watcher add | add member to `config.json` | New member appears within one watch cycle |
+| Config watcher remove | remove member from `config.json` | Roster reconciles remove/update correctly |
+
+Pass criteria: seeded + watched roster state converges to config state.
+
+## X.5 Verification — TUI Panel Convergence (#184)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Unified panel state source | TUI panel consistency tests | Left/right panel state cannot diverge for same agent |
+| Stream/status consistency | TUI stream-panel tests with state transitions | Stream emptiness and status indicators remain coherent |
+
+Pass criteria: no contradictory panel output in covered fixtures.
+
+## X.6 Verification — Doctor Duration Parser Boundaries (#287)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Reject `0m` | `atm doctor --since 0m` | Validation error, non-success exit |
+| Reject negative duration | `atm doctor --since -5m` | Validation error, non-success exit |
+| Accept positive durations | `atm doctor --since 30m` and `atm doctor --since 45s` | Valid execution path |
+
+Pass criteria: invalid durations are rejected; valid durations continue to work.
+
+## X.7 Verification — TUI Message Viewing Capability (#185)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Message list rendering | TUI message list tests with fixture inboxes | Expected message rows appear |
+| Message detail rendering | TUI detail view tests | Full content visible |
+| Mark-read persistence | TUI mark-read tests with atomic write path | Read status persists in inbox file |
+
+Pass criteria: operators can list, inspect, and mark messages read from TUI.
+
+## X.8 Verification — TUI Header Version Visibility (#187)
+
+| Check | Command / Test | Expected |
+|---|---|---|
+| Header version render | TUI header render tests | Version string shown from build metadata |
+| Manual smoke | launch TUI in dev build | Visible version in header |
+
+Pass criteria: version is consistently visible in header.
+
+## Suggested Execution Commands
+
+```bash
+cargo test -p agent-team-mail-daemon -- --test-threads=8
+cargo test -p agent-team-mail-tui
+cargo test -p agent-team-mail doctor -- --nocapture
+```
+
+## Exit Criteria
+
+- Every X.* issue has at least one explicit verification path in this plan.
+- Requirements references for each verification area are present and current.
+- CI matrix is green for touched suites.


### PR DESCRIPTION
## Summary\n- add Phase X planning section and issue/sprint mapping for #181, #182, #184, #185, #187, #287, #337, #338\n- add explicit requirements for:\n  - \'atm teams add-member\' atomic inbox creation + idempotency\n  - doctor duration validation for zero/negative inputs\n  - TUI baseline correctness expectations\n  - env-mutation test serialization for ATM_HOME-sensitive tests\n- add dedicated Phase X verification document: docs/test-plan-phase-X.md\n- update Phase U/W backlog notes to mark #337/#338 as moved to Phase X\n\n## Scope\nDocumentation-only changes (no runtime code changes).\n\n## Validation\n- reviewed consistency across docs/project-plan.md, docs/requirements.md, and phase test-plan docs\n- verified issue mapping aligns to planned Phase X sprint IDs\n