### PR TITLE
fix(ci): indent Python heredoc in release workflow YAML

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -825,32 +825,32 @@ jobs:
             # Ensure stale daemon is terminated on install/upgrade.
             # Must be non-fatal when no daemon is running.
             python3 - "$formula" <<'PY'
-import sys
-from pathlib import Path
+          import sys
+          from pathlib import Path
 
-path = Path(sys.argv[1])
-content = path.read_text(encoding="utf-8")
+          path = Path(sys.argv[1])
+          content = path.read_text(encoding="utf-8")
 
-block = (
-    "  def post_install\n"
-    "    system \"sh\", \"-c\", \"pkill -x atm-daemon || true\"\n"
-    "  end\n\n"
-)
+          block = (
+              "  def post_install\n"
+              "    system \"sh\", \"-c\", \"pkill -x atm-daemon || true\"\n"
+              "  end\n\n"
+          )
 
-if "def post_install" not in content:
-    marker = "\n  test do\n"
-    if marker not in content:
-        raise SystemExit(f"Unable to insert post_install: missing test block marker in {path}")
-    content = content.replace(marker, f"\n{block}  test do\n", 1)
-    path.write_text(content, encoding="utf-8")
-elif "pkill -x atm-daemon" not in content:
-    content = content.replace(
-        "def post_install\n",
-        "def post_install\n    system \"sh\", \"-c\", \"pkill -x atm-daemon || true\"\n",
-        1,
-    )
-    path.write_text(content, encoding="utf-8")
-PY
+          if "def post_install" not in content:
+              marker = "\n  test do\n"
+              if marker not in content:
+                  raise SystemExit(f"Unable to insert post_install: missing test block marker in {path}")
+              content = content.replace(marker, f"\n{block}  test do\n", 1)
+              path.write_text(content, encoding="utf-8")
+          elif "pkill -x atm-daemon" not in content:
+              content = content.replace(
+                  "def post_install\n",
+                  "def post_install\n    system \"sh\", \"-c\", \"pkill -x atm-daemon || true\"\n",
+                  1,
+              )
+              path.write_text(content, encoding="utf-8")
+          PY
             echo "Updated $formula"
           done
 


### PR DESCRIPTION
## Summary
- Fix YAML parsing error in `.github/workflows/release.yml` that blocks all release workflow dispatches
- The `python3 <<'PY'` heredoc from X.4 (Homebrew post_install pkill) had zero-indented Python code, which prematurely terminates the YAML literal block scalar
- Indent heredoc content to 10 spaces matching the YAML block level, consistent with all other Python heredocs in the workflow

## Context
This blocks the v0.31.0 release. GitHub Actions cannot parse the workflow file, returning "Workflow does not have 'workflow_dispatch' trigger".

## Test plan
- [x] YAML validates with `yaml.safe_load()`
- [ ] CI passes on this PR
- [ ] After merge to develop + main, release workflow can be dispatched

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>