### PR TITLE
chore(release): bump version to 0.33.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -50,7 +50,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -82,7 +82,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.33.1"
+version = "0.33.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.33.1"
+version = "0.33.2"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -33,4 +33,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.33.1" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.33.2" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.33.1" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.33.2" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump workspace version to 0.33.2 (lightweight tag for CI compatibility)
- v0.33.0 tag stuck on develop, v0.33.1 was annotated tag causing gate mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)