### PR TITLE
feat(Z.7): review findings hardening (deliverables 8-12)

### DIFF
--- a/crates/atm/src/commands/register.rs
+++ b/crates/atm/src/commands/register.rs
@@ -71,7 +71,7 @@ pub fn execute(args: RegisterArgs) -> Result<()> {
     let identity = resolve_session_identity()?;
 
     if let Some(ref name) = args.name {
-        register_teammate(&config_path, &args.team, name, &identity)
+        register_teammate(&home_dir, &config_path, &args.team, name, &identity)
     } else {
         register_team_lead(&home_dir, &config_path, &args.team, &identity, args.force)
     }
@@ -253,11 +253,33 @@ fn register_team_lead(
 
 /// Register as a named teammate: update the member's `sessionId` field.
 fn register_teammate(
+    home_dir: &std::path::Path,
     config_path: &std::path::Path,
     team: &str,
     name: &str,
     identity: &SessionIdentity,
 ) -> Result<()> {
+    let caller_identity = resolve_caller_identity(home_dir, team)?;
+    let caller_identity_explicit = !caller_identity.trim().is_empty() && caller_identity != "human";
+    if caller_identity_explicit && caller_identity != name {
+        // Fail closed: do not allow cross-identity teammate session writes even
+        // when daemon/session sync is unavailable, so ownership guarantees do
+        // not depend on daemon reachability.
+        warn!(
+            attempted_writer = %caller_identity,
+            owner = %name,
+            field = "sessionId",
+            "register teammate ownership guard rejected cross-identity session write"
+        );
+        anyhow::bail!(
+            "Ownership guard rejected sessionId update for '{}': caller identity is '{}'. \
+             Set ATM_IDENTITY/.atm.toml identity to '{}' and retry.",
+            name,
+            caller_identity,
+            name
+        );
+    }
+
     // Verify member exists in team config.
     let existing: TeamConfig = serde_json::from_str(&std::fs::read_to_string(config_path)?)?;
 
@@ -310,6 +332,19 @@ fn register_teammate(
         name, team, identity.session_id
     );
     Ok(())
+}
+
+fn resolve_caller_identity(home_dir: &std::path::Path, team: &str) -> Result<String> {
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let config = resolve_config(
+        &ConfigOverrides {
+            team: Some(team.to_string()),
+            ..Default::default()
+        },
+        &current_dir,
+        home_dir,
+    )?;
+    Ok(config.core.identity)
 }
 
 fn sync_session_with_daemon(

--- a/crates/atm/src/commands/teams.rs
+++ b/crates/atm/src/commands/teams.rs
@@ -63,6 +63,9 @@ pub enum TeamsCommand {
 
 /// Spawn a team member (runtime-aware daemon launch)
 #[derive(Args, Debug)]
+#[command(
+    after_long_help = "Environment:\n  ATM_TEAM     Effective team when --team is omitted.\n  ATM_IDENTITY Effective member identity for spawned runtime sessions.\n\nExamples:\n  atm teams spawn arch-ctm --runtime codex --folder /path/to/repo\n  atm teams spawn qa-gemini --runtime gemini --folder /path/to/repo --model gemini-2.5-pro\n  atm teams spawn team-lead --runtime claude --folder /path/to/repo --team atm-dev\n\nMismatch Handling:\n  If ATM_TEAM conflicts with .atm.toml default_team, pass --override-team to proceed."
+)]
 pub struct SpawnArgs {
     /// Agent name
     agent: String,
@@ -114,6 +117,10 @@ pub struct SpawnArgs {
     /// Canonical spawn directory (`--cwd` is accepted as an alias)
     #[arg(long, alias = "cwd")]
     folder: Vec<PathBuf>,
+
+    /// Allow ATM_TEAM (env) to override conflicting .atm.toml default_team for this invocation
+    #[arg(long)]
+    override_team: bool,
 
     /// Output as JSON
     #[arg(long)]
@@ -394,6 +401,16 @@ fn spawn_member(args: SpawnArgs) -> Result<()> {
     let home_dir = get_home_dir()?;
     let current_dir = std::env::current_dir()?;
     let launch_dir = resolve_spawn_folder(&args.folder, &current_dir)?;
+    let env_team = env_var_nonempty("ATM_TEAM");
+    let repo_default_team = read_repo_default_team(&current_dir);
+    let team_mismatch = if args.team.is_none() {
+        match (env_team.as_deref(), repo_default_team.as_deref()) {
+            (Some(env), Some(repo)) if env != repo => Some((env.to_string(), repo.to_string())),
+            _ => None,
+        }
+    } else {
+        None
+    };
     let config = resolve_config(
         &ConfigOverrides {
             team: args.team.clone(),
@@ -440,6 +457,48 @@ fn spawn_member(args: SpawnArgs) -> Result<()> {
     }
     let launch_command_preview = format_spawn_launch_command(&args.runtime, &spec, &command);
     print_launch_command_preview(&launch_command_preview, args.json);
+
+    if let Some((env_team, repo_team)) = team_mismatch {
+        warn!(
+            "spawn team mismatch detected: ATM_TEAM='{}' vs .atm.toml default_team='{}'",
+            env_team, repo_team
+        );
+        eprintln!(
+            "Warning: team mismatch detected: ATM_TEAM ('{}') != .atm.toml default_team ('{}').",
+            env_team, repo_team
+        );
+        if !args.override_team {
+            anyhow::bail!(
+                "ATM_TEAM ('{}') does not match .atm.toml default_team ('{}'). \
+                 Re-run with --override-team to proceed with the env-var team for this invocation.",
+                env_team,
+                repo_team
+            );
+        }
+        warn!(
+            "spawn override-team: using ATM_TEAM='{}' instead of .atm.toml default_team='{}'",
+            env_team, repo_team
+        );
+        let mut extra_fields = serde_json::Map::new();
+        extra_fields.insert(
+            "conflicting_toml_team".to_string(),
+            serde_json::Value::String(repo_team),
+        );
+        extra_fields.insert(
+            "invoked_at".to_string(),
+            serde_json::Value::String(Utc::now().to_rfc3339()),
+        );
+        emit_event_best_effort(EventFields {
+            level: "warn",
+            source: "atm",
+            action: "spawn_team_override",
+            team: Some(env_team),
+            agent_name: Some(args.agent.clone()),
+            result: Some("override_team".to_string()),
+            extra_fields,
+            ..Default::default()
+        });
+    }
 
     // Preserve legacy spawn UX when daemon is unavailable: return the daemon
     // error + launch command guidance without requiring team-config mutation.
@@ -722,6 +781,41 @@ fn resolve_spawn_folder(folder_args: &[PathBuf], current_dir: &Path) -> Result<P
         );
     }
     Ok(first)
+}
+
+fn env_var_nonempty(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn find_repo_local_atm_toml(current_dir: &Path) -> Option<PathBuf> {
+    let mut dir = current_dir;
+    loop {
+        let config_path = dir.join(".atm.toml");
+        if config_path.exists() {
+            return Some(config_path);
+        }
+        if dir.join(".git").exists() {
+            break;
+        }
+        dir = dir.parent()?;
+    }
+    None
+}
+
+fn read_repo_default_team(current_dir: &Path) -> Option<String> {
+    let config_path = find_repo_local_atm_toml(current_dir)?;
+    let contents = fs::read_to_string(config_path).ok()?;
+    let value: toml::Value = toml::from_str(&contents).ok()?;
+    value
+        .get("core")
+        .and_then(|core| core.get("default_team"))
+        .and_then(toml::Value::as_str)
+        .map(str::trim)
+        .filter(|team| !team.is_empty())
+        .map(ToString::to_string)
 }
 
 fn parse_env_vars(pairs: &[String]) -> Result<std::collections::HashMap<String, String>> {

--- a/crates/atm/tests/integration_register.rs
+++ b/crates/atm/tests/integration_register.rs
@@ -360,3 +360,45 @@ fn test_register_conflicting_lead_session_allows_force_when_daemon_unreachable()
         .stdout(predicate::str::contains("Registered as team-lead"))
         .stdout(predicate::str::contains("forced-new-session-id"));
 }
+
+#[test]
+fn test_register_teammate_ownership_guard_fails_closed_when_daemon_unavailable() {
+    let temp_dir = TempDir::new().unwrap();
+    create_test_team(
+        &temp_dir,
+        "my-team",
+        &[("team-lead", true), ("alice", false), ("bob", false)],
+    );
+    write_atm_toml(&temp_dir, "bob");
+
+    let config_path = temp_dir.path().join(".claude/teams/my-team/config.json");
+    let mut config: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    config["members"][1]["sessionId"] = serde_json::json!("alice-session-existing");
+    config["leadSessionId"] = serde_json::json!("lead-session-existing");
+    fs::write(&config_path, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    configure_cmd(&mut cmd, &temp_dir);
+    cmd.env("CLAUDE_SESSION_ID", "new-cross-identity-session")
+        .env("ATM_TEAM", "my-team")
+        .current_dir(temp_dir.path().join("workdir"))
+        .args(["register", "my-team", "alice"]);
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains(
+            "Ownership guard rejected sessionId update for 'alice'",
+        ))
+        .stderr(predicate::str::contains("caller identity is 'bob'"));
+
+    let config_after: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&config_path).unwrap()).unwrap();
+    let alice_after = config_after["members"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["name"] == "alice")
+        .unwrap();
+    assert_eq!(alice_after["sessionId"], "alice-session-existing");
+}

--- a/crates/atm/tests/integration_spawn_folder.rs
+++ b/crates/atm/tests/integration_spawn_folder.rs
@@ -237,3 +237,82 @@ fn test_spawn_claude_echoes_full_launch_command_on_failure() {
         "expected daemon unavailable failure, got stderr: {stderr}"
     );
 }
+
+#[test]
+fn test_spawn_env_team_mismatch_requires_override_team() {
+    let temp_dir = TempDir::new().unwrap();
+    let folder = temp_dir.path().join("spawn-folder");
+    fs::create_dir_all(&folder).unwrap();
+    let workdir = temp_dir.path().join("workdir");
+    fs::create_dir_all(&workdir).unwrap();
+    let atm_toml_path = workdir.join(".atm.toml");
+    let toml_content = "[core]\ndefault_team = \"toml-team\"\nidentity = \"team-lead\"\n";
+    fs::write(&atm_toml_path, toml_content).unwrap();
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    let assert = cmd
+        .env("ATM_TEAM", "env-team")
+        .args([
+            "teams",
+            "spawn",
+            "agent-mismatch",
+            "--runtime",
+            "codex",
+            "--folder",
+            folder.to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stdout.contains("Launch command:"));
+    assert!(stderr.contains("Warning: team mismatch detected"));
+    assert!(stderr.contains("ATM_TEAM ('env-team')"));
+    assert!(stderr.contains(".atm.toml default_team ('toml-team')"));
+    assert!(stderr.contains("--override-team"));
+    assert_eq!(fs::read_to_string(&atm_toml_path).unwrap(), toml_content);
+}
+
+#[test]
+fn test_spawn_env_team_mismatch_override_team_uses_env_team_without_modifying_toml() {
+    let temp_dir = TempDir::new().unwrap();
+    let folder = temp_dir.path().join("spawn-folder");
+    fs::create_dir_all(&folder).unwrap();
+    let workdir = temp_dir.path().join("workdir");
+    fs::create_dir_all(&workdir).unwrap();
+    let atm_toml_path = workdir.join(".atm.toml");
+    let toml_content = "[core]\ndefault_team = \"toml-team\"\nidentity = \"team-lead\"\n";
+    fs::write(&atm_toml_path, toml_content).unwrap();
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    let assert = cmd
+        .env("ATM_TEAM", "env-team")
+        .args([
+            "teams",
+            "spawn",
+            "agent-override",
+            "--runtime",
+            "codex",
+            "--override-team",
+            "--folder",
+            folder.to_str().unwrap(),
+            "--json",
+        ])
+        .assert()
+        .failure();
+
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).unwrap();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).unwrap();
+    assert!(stderr.contains("Warning: team mismatch detected"));
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(parsed["team"].as_str(), Some("env-team"));
+    assert!(
+        parsed["error"]
+            .as_str()
+            .unwrap()
+            .contains("Daemon is not running")
+    );
+    assert_eq!(fs::read_to_string(&atm_toml_path).unwrap(), toml_content);
+}

--- a/docs/phase-z-summary.md
+++ b/docs/phase-z-summary.md
@@ -1,0 +1,52 @@
+# Phase Z Summary
+
+## Scope
+Phase Z hardened daemon single-source-of-truth behavior and observability across
+`atm`, `atm-daemon`, and `atm-core`.
+
+## Completed Sprints
+
+### Z.1 Quick Wins
+- Prevented false PID/backend mismatch findings when process lookup is inconclusive.
+- Improved human-readable session-id formatting in doctor/member/status views.
+- Stopped reconcile from re-overwriting mismatch-offline states.
+- Reworked release verification path to avoid fragile external curl checks.
+
+### Z.2 Log Format + Doctor UX
+- Normalized send log identity formatting and sender/recipient fields.
+- Enforced `ATM_LOG_MSG=1` as the only message-preview enablement path.
+- Improved doctor log-window display semantics.
+
+### Z.3 SSoT Fast Path
+- Added daemon `register-hint` command path for runtime session registration.
+- Removed send-path liveness shortcuts in favor of daemon session truth.
+- Ensured spawn metadata persistence aligns with daemon-backed launch paths.
+
+### Z.4 Canonical Member State Completion
+- Completed team-scoped canonical member-state union (config + daemon-only sessions).
+- Added daemon-only ghost/unregistered surfacing in status/member/doctor views.
+- Aligned PID/backend mismatch handling across command paths.
+
+### Z.5 Lifecycle Logging + Hook Events
+- Added structured lifecycle transition logging events.
+- Added first-class hook lifecycle events (`session_start`, compact, `session_end`, failures).
+- Aligned Unix-scoped lifecycle assertions in plan/docs.
+
+### Z.6 Cross-Folder Spawn + QA Blocker Closure
+- Added cross-folder spawn behavior and launch command preview fidelity.
+- Added mismatch policy for `ATM_TEAM` vs `.atm.toml` with `--override-team` contract.
+- Closed QA blockers around register-hint compatibility and ownership guard coverage.
+
+### Z.7 Review Findings Hardening (1-7 merged)
+- Removed duplicate spawn metadata write before launch.
+- Added daemon-only PID mismatch diagnostics and parsed mismatch details.
+- Added typed backend mismatch/recovery tests for register-hint/session state.
+- Shared ghost/unregistered display constants across doctor/members/status.
+- Added `ATM_LOG_MSG=""` disable-preview coverage.
+- Added session-start env fallback support for no-`.atm.toml` contexts.
+
+## Follow-Up (Z.7 deliverables 8-12)
+- Regression coverage for `--override-team` mismatch handling (fail/pass paths).
+- Ownership guard fail-closed path coverage when daemon/session sync is unavailable.
+- Explicit spawn-path env precedence test (`ATM_TEAM` over `.atm.toml` default team).
+- Plan updates reflecting Z.1-Z.6 completion and Z.7 review hardening progression.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -164,7 +164,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | S | Runtime Adapters + Hook Installer | Gemini adapter, `atm init` hook installer | COMPLETE |
 | T | Daemon Reliability + Bug Debt | Fix daemon auto-start, config sync, TUI bugs, deferred S work | COMPLETE |
 | X | Team Onboarding + TUI/Doctor Stability | `/team-join`, spawn path normalization, `atm init` one-command setup, and carry-forward bug-debt mapping | PLANNED |
-| Z | Daemon SSoT + Observability Hardening | Canonical daemon-owned member state, session-registry sync closure, and doctor/status observability consistency | IN PROGRESS |
+| Z | Daemon SSoT + Observability Hardening | Canonical daemon-owned member state, session-registry sync closure, and doctor/status observability consistency (Z.1–Z.6 COMPLETE; Z.7 in progress) | IN PROGRESS |
 
 ---
 
@@ -1407,10 +1407,12 @@ the current tranche focused on onboarding contract closure.
 | **Q** | Q.3 | MCP Inspector CI smoke tests for `atm-agent-mcp` standalone tools | COMPLETE | — |
 | **Q** | Q.4 | Manual MCP Inspector testing with live Codex + collaborative watch verification | PLANNED | — |
 | **Z** | Z.1 | Quick Wins: Doctor + Release Fix | COMPLETE | [#423](https://github.com/randlee/agent-team-mail/pull/423) |
-| **Z** | Z.2 | Log Format + Doctor UX | IN REVIEW | [#425](https://github.com/randlee/agent-team-mail/pull/425) |
-| **Z** | Z.3 | SSoT Fast Path (`register-hint`, send-path daemon sync) | IN REVIEW | [#427](https://github.com/randlee/agent-team-mail/pull/427) |
-| **Z** | Z.4 | Canonical Member State Completion | IN REVIEW | [#429](https://github.com/randlee/agent-team-mail/pull/429) |
-| **Z** | Z.5 | Lifecycle Logging + Hook Events | IN REVIEW | [#430](https://github.com/randlee/agent-team-mail/pull/430) |
+| **Z** | Z.2 | Log Format + Doctor UX | COMPLETE | [#425](https://github.com/randlee/agent-team-mail/pull/425) |
+| **Z** | Z.3 | SSoT Fast Path (`register-hint`, send-path daemon sync) | COMPLETE | [#427](https://github.com/randlee/agent-team-mail/pull/427) |
+| **Z** | Z.4 | Canonical Member State Completion | COMPLETE | [#429](https://github.com/randlee/agent-team-mail/pull/429) |
+| **Z** | Z.5 | Lifecycle Logging + Hook Events | COMPLETE | [#430](https://github.com/randlee/agent-team-mail/pull/430) |
+| **Z** | Z.6 | Cross-folder Spawn + QA Blocker Closure | COMPLETE | [#431](https://github.com/randlee/agent-team-mail/pull/431) |
+| **Z** | Z.7 | Review Findings Hardening | IN REVIEW | [#432](https://github.com/randlee/agent-team-mail/pull/432) |
 
 **Completed**: 99+ sprints across 23 phases (CI green)
 **Current version**: v0.33.2
@@ -1435,10 +1437,12 @@ doctor/log observability reliable and diagnosable from structured events.
 | Sprint | Name | PR | Branch | Issues | Status |
 |--------|------|----|--------|--------|--------|
 | Z.1 | Quick Wins: Doctor + Release Fix | [#423](https://github.com/randlee/agent-team-mail/pull/423) | `feature/pZ-s1-quick-wins` | #407, #408, #403, #399 | COMPLETE |
-| Z.2 | Log Format + Doctor UX | [#425](https://github.com/randlee/agent-team-mail/pull/425) | `feature/pZ-s2-log-format` | #410, #411, #412, #419 | IN REVIEW |
-| Z.3 | SSoT Fast Path | [#427](https://github.com/randlee/agent-team-mail/pull/427) | `feature/pZ-s3-ssot-fast-path` | #413, #415, #409 | IN REVIEW |
-| Z.4 | Canonical Member State Completion | [#429](https://github.com/randlee/agent-team-mail/pull/429) | `feature/pZ-s4-canonical-state` | #414, #416, #417, #418, #401, #402 | IN REVIEW |
-| Z.5 | Lifecycle Logging + Hook Events | [#430](https://github.com/randlee/agent-team-mail/pull/430) | `feature/pZ-s5-observability` | #420, #421 | IN REVIEW |
+| Z.2 | Log Format + Doctor UX | [#425](https://github.com/randlee/agent-team-mail/pull/425) | `feature/pZ-s2-log-format` | #410, #411, #412, #419 | COMPLETE |
+| Z.3 | SSoT Fast Path | [#427](https://github.com/randlee/agent-team-mail/pull/427) | `feature/pZ-s3-ssot-fast-path` | #413, #415, #409 | COMPLETE |
+| Z.4 | Canonical Member State Completion | [#429](https://github.com/randlee/agent-team-mail/pull/429) | `feature/pZ-s4-canonical-state` | #414, #416, #417, #418, #401, #402 | COMPLETE |
+| Z.5 | Lifecycle Logging + Hook Events | [#430](https://github.com/randlee/agent-team-mail/pull/430) | `feature/pZ-s5-observability` | #420, #421 | COMPLETE |
+| Z.6 | Cross-folder Spawn + QA Blocker Closure | [#431](https://github.com/randlee/agent-team-mail/pull/431) | `feature/pZ-s6-cross-folder-spawn` | #422, #424, #426, #428 | COMPLETE |
+| Z.7 | Review Findings Hardening | [#432](https://github.com/randlee/agent-team-mail/pull/432) | `feature/pZ-s7-review-hardening` | QA findings closure | IN REVIEW |
 
 ### Z.1 — Quick Wins: Doctor + Release Fix
 **Deliverables**


### PR DESCRIPTION
## Summary

Follow-up to #432 — completes Z.7 deliverables 8–12 (commit b2f04c1):

8. `--override-team` regression tests: fail without flag, pass with flag; assert .atm.toml not modified + WARN logged
9. Register ownership guard fail-closed path: daemon unavailable → non-zero exit + clear error; fail-closed policy comment in teams.rs
10. ATM_TEAM env var precedence integration test: ATM_TEAM overrides .atm.toml default_team in spawn path
11. project-plan.md: Z.1–Z.6 marked COMPLETE in Section 2 overview + sprint tables; Z.7 status updated
12. docs/phase-z-summary.md: Phase Z final summary

## Test plan

- [ ] CI passes (clippy + tests)
- [ ] integration_spawn_folder mismatch tests pass
- [ ] integration_register full suite (11/11) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)