### PR TITLE
feat(AB.3): monitor progress cadence + terminal/failure payload reporting

### DIFF
--- a/crates/atm-daemon/src/daemon/socket.rs
+++ b/crates/atm-daemon/src/daemon/socket.rs
@@ -5467,7 +5467,7 @@ exit 1
         assert_eq!(payload["target_kind"].as_str(), Some("run"));
         assert_eq!(payload["target"].as_str(), Some("456789"));
         assert_eq!(payload["run_id"].as_u64(), Some(456789));
-        assert_eq!(payload["state"].as_str(), Some("tracking"));
+        assert_eq!(payload["state"].as_str(), Some("monitoring"));
 
         let status_req = r#"{"version":1,"request_id":"r-gh-run-status","command":"gh-status","payload":{"team":"atm-dev","target_kind":"run","target":"456789"}}"#;
         let status_resp = handle_gh_status_command(status_req, temp.path()).await;
@@ -5475,7 +5475,7 @@ exit 1
         let status = status_resp.payload.unwrap();
         assert_eq!(status["target_kind"].as_str(), Some("run"));
         assert_eq!(status["run_id"].as_u64(), Some(456789));
-        assert_eq!(status["state"].as_str(), Some("tracking"));
+        assert_eq!(status["state"].as_str(), Some("monitoring"));
     }
 
     #[tokio::test]
@@ -5502,7 +5502,7 @@ exit 1
         assert_eq!(payload["target"].as_str(), Some("ci"));
         assert_eq!(payload["reference"].as_str(), Some("develop"));
         assert_eq!(payload["run_id"].as_u64(), Some(987654));
-        assert_eq!(payload["state"].as_str(), Some("tracking"));
+        assert_eq!(payload["state"].as_str(), Some("monitoring"));
 
         let status_req = r#"{"version":1,"request_id":"r-gh-workflow-status","command":"gh-status","payload":{"team":"atm-dev","target_kind":"workflow","target":"ci"}}"#;
         let status_resp = handle_gh_status_command(status_req, temp.path()).await;
@@ -5512,7 +5512,7 @@ exit 1
         assert_eq!(status["target"].as_str(), Some("ci"));
         assert_eq!(status["reference"].as_str(), Some("develop"));
         assert_eq!(status["run_id"].as_u64(), Some(987654));
-        assert_eq!(status["state"].as_str(), Some("tracking"));
+        assert_eq!(status["state"].as_str(), Some("monitoring"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- add daemon-side background `gh-monitor` run tracking loop with:
  - progress cadence enforcement (max one progress update per minute)
  - immediate terminal update on run completion/failure
- add terminal summary table formatting (`job/test`, `status`, `runtime`)
- add failure payload builder enforcing GH-CI-FR-12 fields:
  - run URL, failed job URL(s), PR URL
  - workflow/job names, run id/attempt
  - branch + short/full SHA
  - classification, first failing step, bounded log excerpt
  - correlation id + next action hint
- persist monitor state transitions in daemon state file for `atm gh status`

## Notes
- AB.3 branch currently includes AB.2 baseline by fast-forwarding from `origin/feature/pAB-s2-gh-monitor-command` so AB.3 implementation can compile/test against the monitor command surface.

## Validation
- `cargo fmt -p agent-team-mail-daemon`
- `cargo test -p agent-team-mail-daemon socket::tests::test_gh_ -- --nocapture`
- `cargo test -p agent-team-mail-daemon socket::tests::test_should_emit_progress_rate_limited_to_one_minute -- --nocapture`
- `cargo test -p agent-team-mail-daemon socket::tests::test_format_summary_table_contains_required_columns -- --nocapture`
- `cargo test -p agent-team-mail-daemon socket::tests::test_build_failure_payload_contains_required_fields -- --nocapture`
- `cargo clippy -p agent-team-mail-daemon --all-targets -- -D warnings`
