### PR TITLE
AD.1: lock Python runtime policy and atm init runtime contract

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1,6 +1,22 @@
 # Known Issues
 
-Last updated: 2026-03-03
+Last updated: 2026-03-07
+
+## Phase AD Dogfood Blockers (GH Monitor Setup Session 2026-03-07)
+
+| Issue | Summary | Type | Status | Priority | Planned Sprint | Notes |
+|---|---|---|---|---|---|---|
+| [#497](https://github.com/randlee/agent-team-mail/issues/497) | DG-001: daemon process leak (multiple concurrent `atm-daemon` processes) | Bug | Open | Critical | Pre-AD hotfix | Must be fixed before AD sprint implementation starts |
+| [#498](https://github.com/randlee/agent-team-mail/issues/498) | DG-002: daemon socket path mismatch between hook context and CLI context | Bug | Open | Critical | Pre-AD hotfix | `ATM_HOME`/socket-path divergence caused false daemon-unreachable errors |
+| [#499](https://github.com/randlee/agent-team-mail/issues/499) | DG-003: repo `.atm.toml` plugin config not visible to daemon | Bug | Open | High | AD.2 | Daemon/CLI config resolution parity gap |
+| [#500](https://github.com/randlee/agent-team-mail/issues/500) | DG-004: missing `atm gh init` guided setup command | Enhancement | Open | High | AD.1 | Required by plugin requirements; currently dead-end setup flow |
+| [#501](https://github.com/randlee/agent-team-mail/issues/501) | DG-005: missing daemon stop/restart/reload command set | Bug | Open | High | Pre-AD hotfix | Operational recovery requires manual PID kill today |
+| [#502](https://github.com/randlee/agent-team-mail/issues/502) | DG-006: monitor restart reloads lifecycle but not updated config | Bug | Open | Medium | AD.4 | Config edits require full daemon restart |
+| [#503](https://github.com/randlee/agent-team-mail/issues/503) | DG-007: `atm gh monitor status` reads cached state instead of live daemon state | Bug | Open | Medium | AD.4 | Can report stale PIDs/health for dead processes |
+| [#504](https://github.com/randlee/agent-team-mail/issues/504) | DG-008: `atm gh monitor status --json` not supported | Bug | Open | Medium | AD.3 | JSON output required for automation |
+| [#505](https://github.com/randlee/agent-team-mail/issues/505) | DG-009: inconsistent daemon reachability across `atm gh` commands | Bug | Open | Medium | AD.4 | Status can show healthy while monitor commands fail unreachable |
+| [#506](https://github.com/randlee/agent-team-mail/issues/506) | DG-010: `disabled_config_error` has no actionable guidance | UX | Open | Low | AD.1 | Must point users to exact init/config remediation |
+| [#507](https://github.com/randlee/agent-team-mail/issues/507) | DG-011: duplicate daemon status output blocks in `atm gh` surfaces | UX | Open | Low | AD.3 | Remove duplicated output and keep single canonical status block |
 
 ## Phase V Issues (Doctor/Lifecycle — arch-ctm's V.0–V.7)
 

--- a/docs/phase-ad-planning.md
+++ b/docs/phase-ad-planning.md
@@ -1,0 +1,178 @@
+# Phase AD Planning: Cross-Platform Script Standardization
+
+## Goal
+
+Eliminate product/runtime dependence on shell scripts (`bash`/`pwsh`) and
+standardize ATM runtime scripting on Python for cross-platform behavior.
+
+## Requirements Lock (Phase AD Scope)
+
+1. Product/runtime script paths are Python-only.
+2. Shell scripts are dev/CI-only exceptions unless explicitly approved.
+3. `atm init` auto-installs runtime hook/config wiring for all detected runtimes:
+   Claude Code, Codex CLI, Gemini CLI.
+4. Runtime install behavior is per-runtime idempotent and reports status per runtime.
+5. Hook/script behavior is covered by pytest and included in required CI checks.
+
+## Requirements Cross-References
+
+1. `docs/requirements.md` §4.9.3a (Python-only runtime scripts; shell exceptions policy).
+2. `docs/requirements.md` §4.9.5 (`atm init` runtime detection + idempotent install contract).
+3. `docs/plugins/ci-monitor/requirements.md` GH-CI-FR-19..24 and GH-CI-TR-7
+   (dogfood gaps discovered during AD planning).
+4. `docs/issues.md` section "Phase AD Dogfood Blockers" (`DG-001..DG-011`).
+
+## Pre-AD Hotfix Scope (Out-of-Phase AD Sprint Work)
+
+These are release-blocking bugs being fixed separately from AD implementation sprints:
+
+1. DG-001 / [#497](https://github.com/randlee/agent-team-mail/issues/497):
+   daemon process leak (multiple daemon instances).
+2. DG-002 / [#498](https://github.com/randlee/agent-team-mail/issues/498):
+   daemon socket-path mismatch across contexts.
+3. DG-005 / [#501](https://github.com/randlee/agent-team-mail/issues/501):
+   missing daemon stop/restart/reload operational controls.
+
+## Violation Inventory (Input to AD Sprints)
+
+### Must Remediate
+
+1. `.claude/settings.json` bash wrapper commands (`bash -c`) in hook wiring paths.
+2. `scripts/atm-hook-relay.sh` (Codex relay) shell runtime dependency.
+3. `scripts/spawn-teammate.sh` shell launcher dependency.
+4. `scripts/launch-worker.sh` shell launcher dependency.
+
+### Review / Absorb (Mapped)
+
+1. `scripts/setup-codex-hooks.sh` must be absorbed into `atm init` runtime install behavior (AD.5).
+2. `.github/workflows/*.yml` shell steps remain CI-only dev exception with explicit policy note (AD.1 docs lock).
+
+## Dogfood Findings to Sprint Mapping
+
+| Finding | GitHub Issue | Planned Sprint | Notes |
+|---|---|---|---|
+| DG-001 | [#497](https://github.com/randlee/agent-team-mail/issues/497) | Pre-AD hotfix | Outside AD sprint scope |
+| DG-002 | [#498](https://github.com/randlee/agent-team-mail/issues/498) | Pre-AD hotfix | Outside AD sprint scope |
+| DG-003 | [#499](https://github.com/randlee/agent-team-mail/issues/499) | AD.2 | Daemon/CLI config discovery parity |
+| DG-004 | [#500](https://github.com/randlee/agent-team-mail/issues/500) | AD.1 | `atm gh init` guided setup contract |
+| DG-005 | [#501](https://github.com/randlee/agent-team-mail/issues/501) | Pre-AD hotfix | Outside AD sprint scope |
+| DG-006 | [#502](https://github.com/randlee/agent-team-mail/issues/502) | AD.4 | Reload must apply updated config |
+| DG-007 | [#503](https://github.com/randlee/agent-team-mail/issues/503) | AD.4 | Status must query live daemon state |
+| DG-008 | [#504](https://github.com/randlee/agent-team-mail/issues/504) | AD.3 | `--json` status support |
+| DG-009 | [#505](https://github.com/randlee/agent-team-mail/issues/505) | AD.4 | Reachability behavior consistency |
+| DG-010 | [#506](https://github.com/randlee/agent-team-mail/issues/506) | AD.1 | Actionable disabled guidance |
+| DG-011 | [#507](https://github.com/randlee/agent-team-mail/issues/507) | AD.3 | Remove duplicate status block output |
+
+## AD.1 — Python Runtime Policy + `atm init` Runtime Auto-Install Contract
+
+### Objective
+
+Lock policy + architecture contract before conversion implementation sprints.
+
+### Deliverables
+
+1. Requirements updates for Python-only runtime policy + shell exception boundaries.
+2. `atm init` runtime detection contract for Claude/Codex/Gemini:
+   - detection criteria (binary reachable OR config location present)
+   - per-runtime status output
+   - idempotent re-run semantics (no duplicate hook entries)
+3. Guided setup requirements for `atm gh init` and actionable disabled-config messaging.
+4. Test-plan coverage matrix for runtime detection/install idempotency and pytest CI lane.
+
+### Acceptance Criteria
+
+1. Requirements explicitly prohibit shell as a product runtime dependency.
+2. `atm init` contract is fully specified for all supported runtimes.
+3. DG-004 and DG-010 requirements are locked with deterministic CLI behavior.
+4. Follow-on AD sprint mapping is complete and traceable to issues.
+
+## AD.2 — Runtime Config Discovery Parity
+
+### Objective
+
+Eliminate daemon/CLI config-path drift for repo-local plugin configuration.
+
+### Deliverables
+
+1. Define and implement daemon/CLI shared config-resolution contract.
+2. Ensure repo `.atm.toml` and global config precedence is deterministic and documented.
+3. Add tests for daemon-start context vs CLI invocation context parity.
+
+### Acceptance Criteria
+
+1. DG-003 is closed: plugin config in repo is visible consistently to daemon + CLI.
+2. Status surfaces effective config source/path for diagnostics.
+3. No regression in team-scoped runtime behavior.
+
+## AD.3 — GH Status Surface Hardening
+
+### Objective
+
+Make `atm gh`/`atm gh monitor status` machine-consumable and non-ambiguous.
+
+### Deliverables
+
+1. Add JSON status mode for monitor status surfaces.
+2. Remove duplicated status blocks and keep one canonical status rendering path.
+3. Add tests for human + JSON output consistency.
+
+### Acceptance Criteria
+
+1. DG-008 is closed: `--json` status is supported and stable.
+2. DG-011 is closed: no duplicate status output blocks.
+3. Status payload fields are deterministic for automation and diagnostics.
+
+## AD.4 — Live State + Reload Reliability
+
+### Objective
+
+Converge monitor runtime behavior on live daemon state and deterministic reload semantics.
+
+### Deliverables
+
+1. Monitor restart/reload must re-apply configuration changes without requiring daemon kill/restart.
+2. Status commands must query daemon live state (not stale cache-only path).
+3. Reachability semantics must be consistent across `atm gh status` and monitor commands.
+4. Add integration tests for reload + live-state + reachability consistency.
+
+### Acceptance Criteria
+
+1. DG-006 is closed: reload path applies config changes.
+2. DG-007 is closed: status reflects live daemon truth.
+3. DG-009 is closed: consistent reachability results across all `atm gh` command paths.
+
+## AD.5 — Runtime Script Conversion + Install Absorption
+
+### Objective
+
+Convert remaining product shell dependencies to Python and absorb legacy setup scripts into `atm init`.
+
+### Deliverables
+
+1. Replace `scripts/atm-hook-relay.sh` with Python equivalent and update installer/deployment paths.
+2. Replace `scripts/spawn-teammate.sh` + `scripts/launch-worker.sh` with Python implementations.
+3. Absorb `scripts/setup-codex-hooks.sh` behavior into `atm init` runtime install flow.
+4. Add migration behavior for already-installed users to replace shell wrappers safely.
+
+### Acceptance Criteria
+
+1. Product runtime no longer depends on shell scripts for supported user paths.
+2. `atm init` is the supported setup entrypoint for hook install across runtimes.
+3. Pytest + CI cover migrated Python scripts and idempotent reinstall behavior.
+
+## AD.6 — Remaining Wrapper Cleanup (Candidate Follow-On)
+
+### Objective
+
+Remove any residual product-facing shell wrappers discovered after AD.5 implementation.
+
+### Deliverables
+
+1. Final repo scan for runtime shell dependencies.
+2. Replace or formally classify any residual scripts as documented dev exceptions.
+3. Close remaining policy/documentation drift.
+
+### Acceptance Criteria
+
+1. No undocumented product runtime shell dependencies remain.
+2. Exceptions are explicitly documented with justification.

--- a/docs/plugins/ci-monitor/requirements.md
+++ b/docs/plugins/ci-monitor/requirements.md
@@ -235,6 +235,58 @@ After a monitored PR run reaches terminal state:
   - `merge_state_status`
   - `run_conclusion`
 
+### GH-CI-FR-19 Daemon/CLI config discovery parity
+
+Daemon and CLI command paths must resolve plugin config from the same effective
+config chain for a given invocation context:
+- repo-local config (`.atm.toml`) when present for the active working scope
+- global config (`$ATM_HOME/.config/atm/config.toml`) fallback
+
+Daemon startup context and CLI invocation context must not diverge on plugin
+enablement due to path-discovery differences.
+
+### GH-CI-FR-20 Guided setup command (`atm gh init`)
+
+`atm gh init` must exist and provide deterministic guided setup:
+- validate prerequisites (`gh` availability, auth prerequisites)
+- write required plugin config keys to the correct config location
+- print exact next-step commands
+- support `--dry-run` preview mode
+
+### GH-CI-FR-21 Reload semantics apply updated config
+
+`atm gh monitor restart`/reload lifecycle actions must re-read and apply latest
+plugin configuration without requiring manual daemon process kill.
+
+If config cannot be reloaded, plugin must surface explicit reload failure state
+with actionable remediation.
+
+### GH-CI-FR-22 Live status source + JSON contract
+
+`atm gh status` and `atm gh monitor status` must source runtime state from live
+daemon state (not stale cache-only files), and both must support `--json` output
+with stable fields for:
+- configured/enabled
+- availability_state
+- plugin process metadata (when applicable)
+- effective config source/path metadata
+
+### GH-CI-FR-23 Reachability consistency
+
+All `atm gh` commands must share a single daemon reachability contract and
+produce consistent outcomes for the same daemon state.
+
+`status` must not report healthy while monitor actions simultaneously report
+"daemon unreachable" for the same target context.
+
+### GH-CI-FR-24 Disabled-state guidance and single status block
+
+When plugin is disabled/unconfigured:
+- output must include explicit reason and precise remediation (`atm gh init`
+  or exact config keys/path)
+- output must not contain duplicated status blocks
+- human output and JSON output must describe the same state
+
 ---
 
 ## 11. Test Requirements
@@ -294,3 +346,16 @@ Test:
 - deterministic drift alert emission for a run exceeding configured threshold
 - baseline/history persistence across plugin restart
 - run dedup persistence across restart (same run ID is not reprocessed)
+
+### GH-CI-TR-7 Dogfood regression coverage
+
+Test:
+- daemon-start context and CLI context resolve identical plugin config visibility
+  (repo-local + global precedence coverage)
+- `atm gh init` creates or previews valid config with actionable output
+- restart/reload applies changed config without manual daemon PID kill
+- `atm gh status` and `atm gh monitor status` read live daemon state and support
+  `--json` with stable schema fields
+- reachability outcomes are consistent across status and monitor commands
+- disabled-state output includes actionable remediation and no duplicate status
+  block rendering

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1442,7 +1442,7 @@ the current tranche focused on onboarding contract closure.
 **Completed**: 123+ sprints across 27 phases (CI green)
 **Current version**: v0.38.0
 **Current phase**: Phase AC COMPLETE
-**Next planned phase**: Phase AD (TBD)
+**Next planned phase**: Phase AD (cross-platform script standardization)
 
 ---
 
@@ -1875,6 +1875,31 @@ for both project-local and global-install paths before Homebrew/global hook roll
 
 ---
 
+## 17.15 Phase AD: Cross-Platform Script Standardization
+
+**Goal**: remove product/runtime shell-script dependencies and standardize runtime
+script behavior on Python across macOS/Linux/Windows.
+
+**Requirements references**:
+- `docs/requirements.md` §4.9.3a (Python-only runtime script policy)
+- `docs/requirements.md` §4.9.5 (`atm init` runtime detection + install contract)
+
+**Integration branch**: `integrate/phase-AD`
+
+**Planning doc**: `docs/phase-ad-planning.md`
+
+### Sprint Summary
+| Sprint | Name | PR | Branch | Issues | Status |
+|--------|------|----|--------|--------|--------|
+| AD.1 | Python Runtime Policy + atm init Auto-Install | — | `feature/pAD-s1-python-policy` | #500, #499 | PLANNED |
+| AD.2 | Gemini Hook Install | — | `feature/pAD-s2-gemini-hook` | #503 | PLANNED |
+| AD.3 | Relay Script Migration | — | `feature/pAD-s3-relay-migration` | #499 | PLANNED |
+| AD.4 | Spawn/Launch Script Python Rewrite | — | `feature/pAD-s4-spawn-python` | — | PLANNED |
+| AD.5 | setup-codex-hooks.sh Absorption | — | `feature/pAD-s5-codex-hooks` | — | PLANNED |
+| AD.6 | Bash Wrapper Removal | — | `feature/pAD-s6-bash-removal` | — | CANDIDATE |
+
+---
+
 ## 20. Phase Integration PRs
 
 | Phase | Integration PR | Status |
@@ -1902,6 +1927,7 @@ for both project-local and global-install paths before Homebrew/global hook roll
 | Phase Z | `integrate/phase-Z` → [#436](https://github.com/randlee/agent-team-mail/pull/436) | Merged |
 | Phase AA | `integrate/phase-AA` | Merged ([#459](https://github.com/randlee/agent-team-mail/pull/459)) |
 | Phase AB | `integrate/phase-AB` | [#469](https://github.com/randlee/agent-team-mail/pull/469) Pending merge |
+| Phase AD | `integrate/phase-AD` | Planned |
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -2293,6 +2293,29 @@ atm init <team> --skip-team
 - Generated hook command paths should use `"$CLAUDE_PROJECT_DIR"` for project-local scripts and absolute per-user script paths for global installs; do not use `${CLAUDE_PLUGIN_ROOT}`.
 - `atm init` success output must include whether hooks were installed globally or locally.
 
+#### 4.9.3a Product Runtime Script Policy (Python-Only)
+
+Runtime scripts executed as part of ATM product behavior MUST be Python-based and
+cross-platform safe.
+
+Policy rules:
+- Product/runtime script execution paths MUST use Python (`python3`/`python`) and
+  repository-shipped `.py` scripts.
+- Shell runtime dependencies (`bash`, `sh`, `zsh`, `pwsh`, `.bat`) are prohibited
+  for product/runtime paths invoked by:
+  - installed hook commands,
+  - `atm init` generated configuration,
+  - runtime launcher/relay flows used by shipped ATM commands.
+- Existing shell scripts may remain only as explicitly documented dev/CI-only
+  exceptions and must not be required for user runtime operation.
+- Hook commands must invoke Python scripts directly; shell wrapper forms such as
+  `bash -c "python ..."` are not allowed in product hook wiring.
+
+Verification requirements:
+- Runtime script behavior must be covered by pytest in `tests/hook-scripts/`.
+- The pytest lane covering runtime scripts is required in CI for changes that
+  modify hook/launcher/relay runtime script paths.
+
 #### 4.9.4 Exit and Result Semantics
 
 - Exit `0` for `installed`, `updated`, and `already-configured`.
@@ -2300,6 +2323,48 @@ atm init <team> --skip-team
 - Exit `1` for malformed config, unsupported environment, or write/permission failures.
 - Idempotent no-op cases (`.atm.toml` exists, team exists, hooks already configured)
   are success states and must be explicitly reported in human output.
+
+#### 4.9.5 Runtime Detection + Auto-Install Contract
+
+`atm init` must detect supported runtimes and apply installation steps in a
+runtime-aware, idempotent manner.
+
+Supported runtimes:
+- Claude Code
+- Codex CLI
+- Gemini CLI
+
+Detection contract:
+- Runtime detection is true when either condition holds:
+  1. Runtime binary is reachable on PATH, or
+  2. Runtime config location exists.
+- Detection precedence and locations:
+  - Claude Code:
+    - project `.claude/settings.json`, then user `~/.claude/settings.json`
+    - binary check (if available in environment) is additive, not required
+  - Codex CLI:
+    - binary `codex` on PATH
+    - config `~/.codex/config.toml` (or equivalent configured home path)
+  - Gemini CLI:
+    - binary `gemini` on PATH
+    - config directory/file under `~/.gemini/`
+
+Install behavior:
+- `atm init` must report per-runtime outcome in human output (and JSON when
+  supported): `installed`, `updated`, `already-configured`, `skipped-not-detected`,
+  or `error`.
+- Runtimes that are not detected are skipped without failing the command.
+- Runtime install actions must be idempotent and must not create duplicate hook
+  entries on re-run.
+- Duplicate detection for hook commands must validate command content (ATM hook
+  relay invocation identity), not only hook key presence.
+- `--dry-run` mode must show per-runtime planned actions with no writes.
+
+Failure behavior:
+- A failure in one runtime install path must not abort installation/reporting for
+  other detected runtimes.
+- Final command result must summarize per-runtime outcomes and include actionable
+  remediation for each error entry.
 
 ### 4.10 Install/Upgrade Daemon Freshness
 
@@ -2358,6 +2423,10 @@ Operator status UX contract:
   - currently available (`healthy` / `degraded` / `disabled_config_error` / `disabled_init_error`).
 - When not enabled, human output must clearly state that monitoring is disabled
   and include next-step guidance to enable/configure `[plugins.gh_monitor]`.
+- Disabled guidance must include both:
+  - the exact command to run: `atm gh init`
+  - the minimum config keys required (team/agent/repo/monitor recipients) and
+    the config file path where those keys are expected.
 - JSON output must expose the same status fields without lossy conversion.
 - When `gh_monitor` is disabled/unconfigured, only the following command paths
   are allowed:

--- a/docs/test-plan-phase-AD.md
+++ b/docs/test-plan-phase-AD.md
@@ -1,0 +1,76 @@
+# Phase AD Test Plan: Python Runtime Policy + Runtime-Aware Init
+
+## Scope
+
+This plan defines deterministic coverage for Phase AD contracts:
+- Python-only product runtime script policy (`docs/requirements.md` §4.9.3a)
+- Runtime detection + auto-install contract (`docs/requirements.md` §4.9.5)
+- GH init and disabled guidance requirements (`docs/requirements.md` §4.11)
+- GH monitor dogfood regressions (`docs/plugins/ci-monitor/requirements.md` GH-CI-FR-19..24, GH-CI-TR-7)
+
+## Sprint Mapping
+
+| Sprint | Focus | Primary Issues |
+|---|---|---|
+| AD.1 | Requirements + policy lock + test matrix | #500, #499 |
+| AD.2 | Runtime config discovery parity | #499 |
+| AD.3 | Status JSON and output consistency | #504, #507 |
+| AD.4 | Reload/live-state/reachability consistency | #502, #503, #505 |
+| AD.5 | Python migration for runtime scripts | #500 |
+| AD.6 | Residual shell-wrapper cleanup (candidate) | #499, #500 |
+
+## AD.1 Verification Matrix (Requirements Lock)
+
+### 1) Python-Only Runtime Policy (§4.9.3a)
+
+| Scenario | Method | Expected Result |
+|---|---|---|
+| Product hook wiring uses Python directly | Static assertion on generated hook command strings | No `bash -c`/`sh -c`/`pwsh` runtime wrappers in product paths |
+| Runtime launcher/relay scripts are Python-based | File/path audit in CI + unit assertions | Product runtime script references resolve to `.py` assets |
+| Dev-only shell exceptions are non-runtime | Documentation + path classification check | Shell scripts only in explicitly documented dev/CI exception sets |
+
+### 2) Runtime Detection + Auto-Install Contract (§4.9.5)
+
+| Scenario | Method | Expected Result |
+|---|---|---|
+| Claude detected via config path | Integration test with mocked project/global config files | Claude runtime marked detected |
+| Codex detected via PATH binary | Integration test with injected PATH fixture | Codex runtime marked detected |
+| Gemini detected via config directory | Integration test with `~/.gemini` fixture | Gemini runtime marked detected |
+| Runtime absent | Integration test with no binary/config | Runtime status `skipped-not-detected`, command succeeds |
+| Re-run idempotency | Execute `atm init` twice in same fixture | No duplicate hook entries; second run `already-configured`/`updated` only where needed |
+| Dry-run semantics | `atm init --dry-run` | Reports per-runtime planned actions with zero writes |
+
+### 3) GH Init + Disabled Guidance (§4.11 / GH-CI-FR-20, FR-24)
+
+| Scenario | Method | Expected Result |
+|---|---|---|
+| Plugin disabled status surface | `atm gh` and `atm gh status` in unconfigured fixture | Explicit disabled reason + `atm gh init` guidance + required key hints |
+| `atm gh init` happy path | Integration test with valid `gh` fixture | Writes required config keys and emits next-step summary |
+| `atm gh init` dry-run | Integration test | Shows target config path/keys; no file mutation |
+| Disabled command gating | `atm gh monitor ...` while disabled | Fast fail with actionable `atm gh init` remediation |
+
+## AD.2-AD.6 Required Regression Coverage
+
+### A) Config Discovery / Path Parity (AD.2)
+- daemon-start context and CLI context resolve identical effective config.
+- Repo-local and global fallback precedence is deterministic and test-verified.
+
+### B) Status / JSON / Output Consistency (AD.3)
+- `atm gh monitor status --json` schema is stable.
+- Human status output has one canonical status block (no duplication).
+
+### C) Reload + Live State + Reachability (AD.4)
+- Restart/reload applies changed config without manual daemon kill.
+- Status commands reflect live daemon state, not stale cache-only state.
+- Reachability outcomes are consistent across status and monitor command paths.
+
+### D) Script Migration (AD.5/AD.6)
+- Migrated runtime scripts execute on macOS/Linux/Windows test fixtures.
+- Hook install and runtime invocation paths remain idempotent after migration.
+- No undocumented shell runtime dependency remains in product execution paths.
+
+## CI Lane Expectations
+
+1. `cargo test` coverage for CLI/daemon command contracts.
+2. `python3 -m pytest tests/hook-scripts/ -q` as required runtime-script lane.
+3. Platform matrix coverage (Linux/macOS/Windows) for cross-platform runtime behavior.


### PR DESCRIPTION
## Summary
- lock Python-only runtime script policy in requirements (`§4.9.3a`)
- add `atm init` runtime detection + per-runtime idempotent auto-install contract (`§4.9.5`)
- tighten `atm gh init`/disabled guidance requirements in `§4.11`
- add GH monitor dogfood requirements `GH-CI-FR-19..24` and `GH-CI-TR-7`
- add Phase AD planning doc + AD test plan matrix + project-plan AD section + issue mapping

## Notes
- Documentation/planning change only
- No code changes or runtime tests executed
