### PR TITLE
fix(release): POSIX-compatible packaging for macOS bash 3.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,10 @@ jobs:
           set -euo pipefail
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
-          mapfile -t bins < <(python3 scripts/release_artifacts.py list-release-binaries --manifest "${RELEASE_ARTIFACT_MANIFEST}")
+          bins=()
+          while IFS= read -r bin; do
+            [[ -n "$bin" ]] && bins+=("$bin")
+          done < <(python3 scripts/release_artifacts.py list-release-binaries --manifest "${RELEASE_ARTIFACT_MANIFEST}")
           cd target/${{ matrix.target }}/release
           tar czf "../../../${ARCHIVE}" "${bins[@]}"
           cd ../../..


### PR DESCRIPTION
## Summary

- `mapfile` builtin is bash 4+; macOS runners use bash 3.2 — causes Package step failure on all macOS targets
- Replace with POSIX-compatible `while IFS= read -r` loop
- Commit: 06978e8

## Impact

v0.41.0 release run 22832055583: crates.io publish succeeded, linux/windows artifacts built, macOS packaging failed. After this merges, re-run release workflow to produce macOS archives and complete GitHub Release + Homebrew update.

**Merge method: Create a merge commit** (not squash — release gate requires develop ⊆ main ancestry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)