### PR TITLE
chore(release): bump to v0.41.1 + mapfile fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -30,7 +30,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -52,7 +52,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.41.0"
+version = "0.41.1"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -34,4 +34,4 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.41.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.41.1" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.41.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.41.1" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }


### PR DESCRIPTION
## Summary

- v0.41.0 tag points to old main (pre PRs #535/#537) — gate rejects retag
- Bumps workspace version to 0.41.1
- Includes mapfile→while-read fix for macOS bash 3.2

## Merge method: Create a merge commit (NOT squash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)