### PR TITLE
AG.1: implement sc-composer file-mode frontmatter + render MVP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,6 +1126,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minijinja"
+version = "2.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ea5ea1e90055f200af6b8e52a4a34e05e77e7fee953a9fb40c631efdc43cab1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,6 +1532,10 @@ dependencies = [
 name = "sc-composer"
 version = "0.41.0"
 dependencies = [
+ "minijinja",
+ "serde",
+ "serde_yaml",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 
@@ -1604,6 +1617,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2061,6 +2087,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rust-version = "1.85"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 toml = { version = "0.8", features = ["parse"] }
+minijinja = "2"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/crates/sc-composer/Cargo.toml
+++ b/crates/sc-composer/Cargo.toml
@@ -11,3 +11,9 @@ description = "Prompt/template composition engine for AI agent pipelines"
 
 [dependencies]
 thiserror.workspace = true
+minijinja.workspace = true
+serde.workspace = true
+serde_yaml = "0.9"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/sc-composer/src/context.rs
+++ b/crates/sc-composer/src/context.rs
@@ -1,0 +1,119 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::{Diagnostic, UnknownVariablePolicy, VariableSource};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextMergeReport {
+    pub context: BTreeMap<String, String>,
+    pub variable_sources: BTreeMap<String, VariableSource>,
+    pub warnings: Vec<Diagnostic>,
+    pub errors: Vec<Diagnostic>,
+}
+
+pub fn merge_context(
+    template_path: &Path,
+    required_variables: &[String],
+    declared_variables: &BTreeSet<String>,
+    defaults: &BTreeMap<String, String>,
+    vars_env: &BTreeMap<String, String>,
+    vars_input: &BTreeMap<String, String>,
+    unknown_policy: UnknownVariablePolicy,
+) -> ContextMergeReport {
+    let mut context = BTreeMap::new();
+    let mut variable_sources = BTreeMap::new();
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    for (key, value) in defaults {
+        context.insert(key.clone(), value.clone());
+        variable_sources.insert(key.clone(), VariableSource::Default);
+    }
+
+    for (key, value) in vars_env {
+        context.insert(key.clone(), value.clone());
+        variable_sources.insert(key.clone(), VariableSource::Env);
+    }
+
+    for (key, value) in vars_input {
+        context.insert(key.clone(), value.clone());
+        variable_sources.insert(key.clone(), VariableSource::Input);
+    }
+
+    for required in required_variables {
+        if !context.contains_key(required) {
+            errors.push(Diagnostic {
+                code: "MISSING_VAR".to_string(),
+                message: format!("Required variable '{required}' is missing"),
+                path: Some(template_path.to_path_buf()),
+            });
+        }
+    }
+
+    if !declared_variables.is_empty() {
+        for key in vars_input.keys() {
+            if declared_variables.contains(key) {
+                continue;
+            }
+
+            let diagnostic = Diagnostic {
+                code: "UNKNOWN_VAR".to_string(),
+                message: format!("Input variable '{key}' is not declared by template/frontmatter"),
+                path: Some(template_path.to_path_buf()),
+            };
+
+            match unknown_policy {
+                UnknownVariablePolicy::Error => errors.push(diagnostic),
+                UnknownVariablePolicy::Warn => warnings.push(diagnostic),
+                UnknownVariablePolicy::Ignore => {}
+            }
+        }
+    }
+
+    ContextMergeReport {
+        context,
+        variable_sources,
+        warnings,
+        errors,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_context_applies_precedence() {
+        let path = Path::new("template.md.j2");
+        let required = vec!["name".to_string(), "role".to_string()];
+        let declared = BTreeSet::from(["name".to_string(), "role".to_string()]);
+        let defaults = BTreeMap::from([
+            ("name".to_string(), "default".to_string()),
+            ("role".to_string(), "reader".to_string()),
+        ]);
+        let env = BTreeMap::from([("name".to_string(), "env".to_string())]);
+        let input = BTreeMap::from([("name".to_string(), "input".to_string())]);
+
+        let report = merge_context(
+            path,
+            &required,
+            &declared,
+            &defaults,
+            &env,
+            &input,
+            UnknownVariablePolicy::Error,
+        );
+
+        assert!(report.errors.is_empty());
+        assert_eq!(report.context.get("name"), Some(&"input".to_string()));
+        assert_eq!(report.context.get("role"), Some(&"reader".to_string()));
+        assert_eq!(
+            report.variable_sources.get("name"),
+            Some(&VariableSource::Input)
+        );
+        assert_eq!(
+            report.variable_sources.get("role"),
+            Some(&VariableSource::Default)
+        );
+    }
+}

--- a/crates/sc-composer/src/frontmatter.rs
+++ b/crates/sc-composer/src/frontmatter.rs
@@ -1,0 +1,186 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::{ComposerError, Diagnostic};
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Frontmatter {
+    pub required_variables: Vec<String>,
+    pub defaults: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedDocument {
+    pub frontmatter: Option<Frontmatter>,
+    pub body: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct FrontmatterYaml {
+    #[serde(default)]
+    required_variables: Vec<String>,
+    #[serde(default)]
+    defaults: BTreeMap<String, String>,
+}
+
+pub fn parse_document(path: &Path, text: &str) -> Result<ParsedDocument, ComposerError> {
+    let mut segments = text.split_inclusive('\n');
+    let Some(first) = segments.next() else {
+        return Ok(ParsedDocument {
+            frontmatter: None,
+            body: String::new(),
+        });
+    };
+
+    if normalize_line(first) != "---" {
+        return Ok(ParsedDocument {
+            frontmatter: None,
+            body: text.to_string(),
+        });
+    }
+
+    let mut yaml = String::new();
+    let mut offset = first.len();
+    let mut closing_found = false;
+
+    for segment in segments {
+        let normalized = normalize_line(segment);
+        offset += segment.len();
+        if normalized == "---" {
+            closing_found = true;
+            break;
+        }
+        yaml.push_str(segment);
+    }
+
+    if !closing_found {
+        return Err(ComposerError::FrontmatterParse {
+            path: path.to_path_buf(),
+            message: "missing closing frontmatter delimiter '---'".to_string(),
+        });
+    }
+
+    let fm: FrontmatterYaml =
+        serde_yaml::from_str(&yaml).map_err(|err| ComposerError::FrontmatterParse {
+            path: path.to_path_buf(),
+            message: err.to_string(),
+        })?;
+
+    let body = text[offset..].to_string();
+    Ok(ParsedDocument {
+        frontmatter: Some(Frontmatter {
+            required_variables: fm.required_variables,
+            defaults: fm.defaults,
+        }),
+        body,
+    })
+}
+
+pub fn is_template_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".j2"))
+}
+
+pub fn frontmatter_missing_warning(path: &Path) -> Diagnostic {
+    Diagnostic {
+        code: "MISSING_FRONTMATTER".to_string(),
+        message: format!(
+            "Template has no frontmatter. Run: sc-compose frontmatter-init {}",
+            path.display()
+        ),
+        path: Some(path.to_path_buf()),
+    }
+}
+
+pub fn extract_template_variables(body: &str) -> BTreeSet<String> {
+    let mut vars = BTreeSet::new();
+    let mut remaining = body;
+    while let Some(start) = remaining.find("{{") {
+        let after_start = &remaining[start + 2..];
+        let Some(end) = after_start.find("}}") else {
+            break;
+        };
+        let expr = after_start[..end].trim();
+        if let Some(name) = extract_identifier(expr) {
+            vars.insert(name.to_string());
+        }
+        remaining = &after_start[end + 2..];
+    }
+    vars
+}
+
+fn normalize_line(line: &str) -> &str {
+    line.trim_end_matches('\n').trim_end_matches('\r')
+}
+
+fn extract_identifier(expr: &str) -> Option<&str> {
+    let first = expr
+        .split(['|', ' ', '.', '(', ')', '[', ']', ',', ':'])
+        .find(|token| !token.is_empty())?;
+
+    if is_identifier(first) {
+        Some(first)
+    } else {
+        None
+    }
+}
+
+fn is_identifier(token: &str) -> bool {
+    let mut chars = token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+    chars.all(|c| c == '_' || c.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_document_without_frontmatter() {
+        let path = Path::new("example.md.j2");
+        let parsed = parse_document(path, "hello {{name}}").expect("parse should succeed");
+        assert!(parsed.frontmatter.is_none());
+        assert_eq!(parsed.body, "hello {{name}}");
+    }
+
+    #[test]
+    fn parse_document_with_frontmatter() {
+        let path = Path::new("example.md.j2");
+        let parsed = parse_document(
+            path,
+            "---\nrequired_variables:\n  - name\ndefaults:\n  role: dev\n---\nhello {{name}}",
+        )
+        .expect("parse should succeed");
+        let fm = parsed.frontmatter.expect("frontmatter should be present");
+        assert_eq!(fm.required_variables, vec!["name".to_string()]);
+        assert_eq!(fm.defaults.get("role"), Some(&"dev".to_string()));
+        assert_eq!(parsed.body, "hello {{name}}");
+    }
+
+    #[test]
+    fn parse_document_missing_closing_delimiter_errors() {
+        let path = Path::new("example.md.j2");
+        let err = parse_document(path, "---\nrequired_variables:\n  - name\nhello")
+            .expect_err("must fail");
+        match err {
+            ComposerError::FrontmatterParse { .. } => {}
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn extract_template_variables_finds_identifiers() {
+        let vars = extract_template_variables("a {{ name }} {{_role|upper}} {{user.id}}");
+        assert!(vars.contains("name"));
+        assert!(vars.contains("_role"));
+        assert!(vars.contains("user"));
+    }
+}

--- a/crates/sc-composer/src/lib.rs
+++ b/crates/sc-composer/src/lib.rs
@@ -3,8 +3,16 @@
 //! This crate intentionally stays runtime-agnostic so it can be reused by ATM
 //! and non-ATM tools.
 
-use std::collections::BTreeMap;
-use std::path::PathBuf;
+mod context;
+mod frontmatter;
+mod render;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use context::merge_context;
+use frontmatter::{extract_template_variables, frontmatter_missing_warning, parse_document};
+use render::render_template;
 
 /// Supported runtime profiles for default agent file resolution policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,22 +98,278 @@ pub struct ValidationReport {
 }
 
 /// Stable error surface for composition failures.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum ComposerError {
-    #[error("not implemented: {0}")]
-    NotImplemented(&'static str),
+    #[error("template path is required for compose/validate in file mode")]
+    MissingTemplatePath,
+    #[error("failed to read template at {path}: {source}")]
+    TemplateRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("invalid frontmatter in {path}: {message}")]
+    FrontmatterParse { path: PathBuf, message: String },
+    #[error("template parse/render failed in {path}: {message}")]
+    TemplateRender { path: PathBuf, message: String },
+    #[error("validation failed with {error_count} error(s)")]
+    ValidationFailed {
+        errors: Vec<Diagnostic>,
+        warnings: Vec<Diagnostic>,
+        error_count: usize,
+    },
 }
 
 /// Compose a final prompt output.
-///
-/// Placeholder API surface for upcoming implementation.
-pub fn compose(_request: &ComposeRequest) -> Result<ComposeResult, ComposerError> {
-    Err(ComposerError::NotImplemented("compose"))
+pub fn compose(request: &ComposeRequest) -> Result<ComposeResult, ComposerError> {
+    let template_path = resolve_template_path(request)?;
+    let raw =
+        std::fs::read_to_string(&template_path).map_err(|source| ComposerError::TemplateRead {
+            path: template_path.clone(),
+            source,
+        })?;
+
+    let parsed = parse_document(&template_path, &raw)?;
+    let (required_variables, declared_variables, defaults, mut warnings) =
+        effective_schema(&template_path, &parsed.frontmatter, &parsed.body);
+
+    let merge = merge_context(
+        &template_path,
+        &required_variables,
+        &declared_variables,
+        &defaults,
+        &request.vars_env,
+        &request.vars_input,
+        request.policy.unknown_variable_policy,
+    );
+    warnings.extend(merge.warnings);
+
+    if !merge.errors.is_empty() {
+        return Err(ComposerError::ValidationFailed {
+            error_count: merge.errors.len(),
+            errors: merge.errors,
+            warnings,
+        });
+    }
+
+    let rendered_text = if frontmatter::is_template_file(&template_path) {
+        render_template(&template_path, &parsed.body, &merge.context)?
+    } else {
+        parsed.body
+    };
+
+    Ok(ComposeResult {
+        rendered_text,
+        resolved_files: vec![template_path],
+        variable_sources: merge.variable_sources,
+        warnings,
+    })
 }
 
 /// Validate a compose request without producing output.
-///
-/// Placeholder API surface for upcoming implementation.
-pub fn validate(_request: &ComposeRequest) -> Result<ValidationReport, ComposerError> {
-    Err(ComposerError::NotImplemented("validate"))
+pub fn validate(request: &ComposeRequest) -> Result<ValidationReport, ComposerError> {
+    let template_path = resolve_template_path(request)?;
+    let raw =
+        std::fs::read_to_string(&template_path).map_err(|source| ComposerError::TemplateRead {
+            path: template_path.clone(),
+            source,
+        })?;
+
+    let parsed = parse_document(&template_path, &raw)?;
+    let (required_variables, declared_variables, defaults, mut warnings) =
+        effective_schema(&template_path, &parsed.frontmatter, &parsed.body);
+
+    let merge = merge_context(
+        &template_path,
+        &required_variables,
+        &declared_variables,
+        &defaults,
+        &request.vars_env,
+        &request.vars_input,
+        request.policy.unknown_variable_policy,
+    );
+    warnings.extend(merge.warnings);
+
+    Ok(ValidationReport {
+        ok: merge.errors.is_empty(),
+        warnings,
+        errors: merge.errors,
+    })
+}
+
+fn resolve_template_path(request: &ComposeRequest) -> Result<PathBuf, ComposerError> {
+    let template_path = request
+        .template_path
+        .as_ref()
+        .ok_or(ComposerError::MissingTemplatePath)?;
+    if template_path.is_absolute() {
+        Ok(template_path.clone())
+    } else {
+        Ok(request.root.join(template_path))
+    }
+}
+
+fn effective_schema(
+    template_path: &Path,
+    frontmatter: &Option<frontmatter::Frontmatter>,
+    body: &str,
+) -> (
+    Vec<String>,
+    BTreeSet<String>,
+    BTreeMap<String, String>,
+    Vec<Diagnostic>,
+) {
+    if let Some(fm) = frontmatter {
+        let mut declared = BTreeSet::new();
+        declared.extend(fm.required_variables.iter().cloned());
+        declared.extend(fm.defaults.keys().cloned());
+        return (
+            fm.required_variables.clone(),
+            declared,
+            fm.defaults.clone(),
+            Vec::new(),
+        );
+    }
+
+    if frontmatter::is_template_file(template_path) {
+        let discovered = extract_template_variables(body);
+        let required = discovered.iter().cloned().collect::<Vec<_>>();
+        let warning = frontmatter_missing_warning(template_path);
+        return (required, discovered, BTreeMap::new(), vec![warning]);
+    }
+
+    (Vec::new(), BTreeSet::new(), BTreeMap::new(), Vec::new())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    use super::{
+        ComposePolicy, ComposeRequest, ComposerError, RuntimeKind, UnknownVariablePolicy, compose,
+        validate,
+    };
+
+    fn write_file(root: &TempDir, rel_path: &str, content: &str) -> PathBuf {
+        let path = root.path().join(rel_path);
+        std::fs::write(&path, content).expect("write file");
+        path
+    }
+
+    fn request(root: &TempDir, rel_path: &str) -> ComposeRequest {
+        ComposeRequest {
+            runtime: RuntimeKind::Claude,
+            root: root.path().to_path_buf(),
+            agent: None,
+            template_path: Some(PathBuf::from(rel_path)),
+            vars_input: BTreeMap::new(),
+            vars_env: BTreeMap::new(),
+            guidance_block: None,
+            user_prompt: None,
+            policy: ComposePolicy::default(),
+        }
+    }
+
+    #[test]
+    fn compose_plain_text_passthrough() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(&tmp, "plain.txt", "hello world");
+
+        let result = compose(&request(&tmp, "plain.txt")).expect("compose");
+        assert_eq!(result.rendered_text, "hello world");
+    }
+
+    #[test]
+    fn compose_template_substitutes_vars() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(&tmp, "template.md.j2", "hello {{ name }}");
+
+        let mut req = request(&tmp, "template.md.j2");
+        req.vars_input
+            .insert("name".to_string(), "alex".to_string());
+        let result = compose(&req).expect("compose");
+        assert_eq!(result.rendered_text, "hello alex");
+    }
+
+    #[test]
+    fn compose_missing_required_var_returns_missing_var_diagnostic() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(
+            &tmp,
+            "template.md.j2",
+            "---\nrequired_variables:\n  - name\n---\nhello {{ name }}",
+        );
+
+        let err = compose(&request(&tmp, "template.md.j2")).expect_err("missing var must fail");
+        match err {
+            ComposerError::ValidationFailed { errors, .. } => {
+                assert!(
+                    errors.iter().any(|d| d.code == "MISSING_VAR"),
+                    "expected MISSING_VAR, got: {errors:?}"
+                );
+            }
+            other => panic!("unexpected error type: {other}"),
+        }
+    }
+
+    #[test]
+    fn compose_unknown_var_policy_error_warn_ignore() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(
+            &tmp,
+            "template.md.j2",
+            "---\nrequired_variables:\n  - name\n---\nhello {{ name }}",
+        );
+
+        let mut req = request(&tmp, "template.md.j2");
+        req.vars_input
+            .insert("name".to_string(), "alex".to_string());
+        req.vars_input.insert("extra".to_string(), "x".to_string());
+        req.policy.unknown_variable_policy = UnknownVariablePolicy::Error;
+
+        let err = compose(&req).expect_err("unknown must fail for Error policy");
+        match err {
+            ComposerError::ValidationFailed { errors, .. } => {
+                assert!(errors.iter().any(|d| d.code == "UNKNOWN_VAR"));
+            }
+            other => panic!("unexpected error type: {other}"),
+        }
+
+        req.policy.unknown_variable_policy = UnknownVariablePolicy::Warn;
+        let ok = compose(&req).expect("warn policy should pass");
+        assert!(ok.warnings.iter().any(|d| d.code == "UNKNOWN_VAR"));
+
+        req.policy.unknown_variable_policy = UnknownVariablePolicy::Ignore;
+        let ok = compose(&req).expect("ignore policy should pass");
+        assert!(!ok.warnings.iter().any(|d| d.code == "UNKNOWN_VAR"));
+    }
+
+    #[test]
+    fn compose_frontmatter_defaults_are_applied() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(
+            &tmp,
+            "template.md.j2",
+            "---\ndefaults:\n  role: engineer\nrequired_variables:\n  - role\n---\nrole={{ role }}",
+        );
+        let result = compose(&request(&tmp, "template.md.j2")).expect("compose");
+        assert_eq!(result.rendered_text, "role=engineer");
+    }
+
+    #[test]
+    fn validate_reports_missing_vars_without_rendering() {
+        let tmp = TempDir::new().expect("tempdir");
+        write_file(
+            &tmp,
+            "template.md.j2",
+            "---\nrequired_variables:\n  - name\n---\nhello {{ name }}",
+        );
+
+        let report = validate(&request(&tmp, "template.md.j2")).expect("validate");
+        assert!(!report.ok);
+        assert!(report.errors.iter().any(|d| d.code == "MISSING_VAR"));
+    }
 }

--- a/crates/sc-composer/src/render.rs
+++ b/crates/sc-composer/src/render.rs
@@ -1,0 +1,29 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use minijinja::{Environment, UndefinedBehavior};
+
+use crate::ComposerError;
+
+pub fn render_template(
+    template_path: &Path,
+    template_body: &str,
+    context: &BTreeMap<String, String>,
+) -> Result<String, ComposerError> {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+
+    let template =
+        env.template_from_str(template_body)
+            .map_err(|err| ComposerError::TemplateRender {
+                path: template_path.to_path_buf(),
+                message: err.to_string(),
+            })?;
+
+    template
+        .render(context)
+        .map_err(|err| ComposerError::TemplateRender {
+            path: template_path.to_path_buf(),
+            message: err.to_string(),
+        })
+}


### PR DESCRIPTION
## Summary
- implement AG.1 library MVP in `sc-composer` for file-mode `compose`/`validate`
- add optional YAML frontmatter parsing (`required_variables`, `defaults`) and missing-frontmatter guidance diagnostics
- add context merge precedence (`input > env > defaults`) with variable source tracking and unknown variable policy handling
- add strict minijinja rendering path and replace `NotImplemented` compose/validate APIs
- add AG.1 unit tests for passthrough, substitution, required vars, unknown-var policy, defaults, and validate failure contract

## Validation
- `cargo fmt -p sc-composer`
- `cargo test -p sc-composer`
- `cargo clippy -p sc-composer -- -D warnings`
