### PR TITLE
AG.5: resolve develop merge conflicts for phase-AG integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,10 @@ jobs:
           set -euo pipefail
           VERSION='${{ needs.gate-and-tag.outputs.release_version }}'
           ARCHIVE="atm_${VERSION}_${{ matrix.target }}.tar.gz"
-          mapfile -t bins < <(python3 scripts/release_artifacts.py list-release-binaries --manifest "${RELEASE_ARTIFACT_MANIFEST}")
+          bins=()
+          while IFS= read -r bin; do
+            [[ -n "$bin" ]] && bins+=("$bin")
+          done < <(python3 scripts/release_artifacts.py list-release-binaries --manifest "${RELEASE_ARTIFACT_MANIFEST}")
           cd target/${{ matrix.target }}/release
           tar czf "../../../${ARCHIVE}" "${bins[@]}"
           cd ../../..

--- a/docs/phase-ag-planning.md
+++ b/docs/phase-ag-planning.md
@@ -1,0 +1,244 @@
+# Phase AG Planning: sc-composer Full Implementation + sc-compose CLI
+
+**Status:** Draft
+**Target version:** v0.42.0
+**Integration branch:** `integrate/phase-AG`
+**Based on:** Phase AF (`integrate/phase-AF` → develop)
+**Canonical docs:** `docs/sc-composer/requirements.md` (requirements) |
+`docs/sc-composer/architecture.md` (design) |
+`docs/test-plan-phase-AG.md` (test plan)
+
+---
+
+## Goal
+
+Deliver a working `sc-composer` library and `sc-compose` CLI published to
+crates.io as v0.42.0. External projects (scmux, others) consume from crates.io
+— no path dependencies.
+
+This plan is an execution plan; detailed product semantics must be sourced from
+the dedicated sc-composer requirements/architecture docs above.
+
+ATM integration in this phase must be library-first:
+- `atm` calls `sc-composer` APIs directly.
+- `atm` must not execute `sc-compose` through shell/subprocess wrappers for
+  core spawn/composition behavior.
+- `atm` composition behavior must match `sc-compose` semantics.
+
+The library skeleton is already in the workspace (v0.41.0) but `compose()` and
+`validate()` return `NotImplemented`. This phase makes them real.
+
+---
+
+## Primary Consumers After Publish
+
+| Consumer | How |
+|----------|-----|
+| **scmux** | `sc-composer = "0.42.0"` in Cargo.toml; `sc-compose` binary via Homebrew |
+| **atm teams spawn** | `sc-composer` workspace dep; renders `.md.j2` templates before passing to runtime |
+| **CI/dev workflows** | `sc-compose render` binary from Homebrew or `cargo install` |
+
+---
+
+## Sprint Plan
+
+### AG.0 — Daemon Stale-Process Hygiene (Issue #539, pre-AG gate)
+
+**Goal:** prevent stale `atm-daemon` processes from test worktrees and ensure
+CLI auto-start/connect does not silently bind to stale/incorrect daemon
+instances.
+
+**Design decision (for implementation):**
+- Do **not** perform broad cross-scope/global process kill on production daemon
+  startup.
+- Enforce correctness in current ATM scope via lock-holder liveness + daemon
+  identity validation (PID/exe/home-scope) during client connect/startup.
+- Add explicit test-harness cleanup behavior for test-scoped daemon processes.
+
+**Deliverables:**
+- `atm-daemon` lock/identity hardening:
+  - lock metadata must include holder PID and executable path (or equivalent
+    process identity metadata) for stale lock recovery in same scope.
+  - startup must reclaim lock only when prior holder is confirmed dead.
+- CLI/daemon connect hardening:
+  - daemon-backed commands must validate that responding daemon matches current
+    expected scope/identity contract before accepting it as healthy.
+  - mismatch/stale daemon response must trigger actionable restart path.
+- Test lifecycle hardening:
+  - `DaemonProcessGuard` cleanup must cover panic/aborted test paths where
+    possible and register best-effort teardown hooks.
+  - add test-only stale-daemon sweep utility/fixture so new tests do not
+    accumulate detached daemon processes across runs.
+
+**Tests:**
+- same-scope stale lock PID dead -> startup recovers and starts one daemon.
+- same-scope stale/identity-mismatch daemon on socket -> CLI detect + restart.
+- test abort/panic paths do not leave unbounded daemon processes.
+- repeated test runs with isolated `ATM_HOME` do not accumulate stale daemons.
+
+---
+
+### AG.1 — Library MVP: Frontmatter + Render (file mode)
+
+**Goal:** Implement working `compose()` and `validate()` for file-mode requests.
+This is the unlock — once this sprint ships, external projects can start using the library.
+
+**Deliverables in `crates/sc-composer/src/`:**
+
+- `frontmatter.rs` — parse optional YAML frontmatter from file text
+  - fields: `required_variables: Vec<String>`, `defaults: BTreeMap<String, String>`
+  - absent frontmatter → validate/render diagnostics must recommend
+    `sc-compose frontmatter-init <file>.j2`
+- `context.rs` — variable merge with precedence `input > env > defaults`
+  - track `VariableSource` per variable
+  - emit `Diagnostic` for missing required vars or unknown/undeclared vars per policy
+- `render.rs` — Jinja2 rendering via `minijinja` (pure Rust)
+  - strict undefined mode — undefined variable → `ComposerError`
+  - context injected from merged variable map
+- `lib.rs` — implement `compose()`: read file → parse frontmatter → merge context → render → return `ComposeResult`
+- `lib.rs` — implement `validate()`: same through context merge, no render, return `ValidationReport`
+- Remove `ComposerError::NotImplemented` variant
+
+**New workspace dep:** `minijinja = "2"` in `Cargo.toml` `[workspace.dependencies]`
+
+**Tests:**
+- plain text (no frontmatter, no vars) → passthrough
+- `.j2` file with `{{ var }}` and `vars_input` → correct substitution
+- missing required var → `ComposerError` with diagnostic code `MISSING_VAR`
+- unknown var, `policy = Error` → error; `policy = Warn` → warning in result; `policy = Ignore` → silent
+- frontmatter defaults apply when input omits the key
+- `validate()` on missing var → `ValidationReport { ok: false, errors: [..] }`
+
+---
+
+### AG.2 — Resolver + Include Expansion
+
+**Goal:** Profile-mode file resolution and `@<path>` include expansion.
+
+**Deliverables in `crates/sc-composer/src/`:**
+
+- `resolver.rs` — resolve profile file by `RuntimeKind` + `kind` (agent/command/skill)
+  - implement FR-5 precedence chains exactly (runtime-specific chain +
+    shared fallback + legacy compatibility fallback)
+  - expose full search trace metadata for profile resolution so `validate` can
+    report attempted locations on failure
+  - explicit `template_path` bypasses probe (root safety check still applies)
+- `include.rs` — expand `@<path>` directives recursively
+  - confined to `policy.allowed_roots`
+  - cycle detection via include stack
+  - max depth guard (`policy.max_include_depth`, default 8)
+  - included files may have their own frontmatter (merged into parent context)
+- Update `compose()` to support `mode = Profile` — run resolver before render
+- `pipeline.rs` — implement deterministic 3-block composition contract:
+  1) resolved profile body, 2) guidance block, 3) user prompt block
+
+**Tests:** probe order, explicit path override, include expansion, cycle detection,
+depth limit, out-of-root escape rejected with `ROOT_ESCAPE` diagnostic, and
+profile-mode search-trace coverage for resolution failures
+
+---
+
+### AG.3 — `sc-compose` Binary
+
+**Goal:** Standalone CLI binary. Thin wrapper over the library. Installable via
+`cargo install sc-compose` and Homebrew.
+
+**Deliverables:**
+
+- New crate `crates/sc-compose/`
+  - `Cargo.toml`: workspace version, description, binary name `sc-compose`
+  - Added to workspace `members`
+  - Added to `release.yml` inventory and `dependency_order`
+  - Added to build step in `release.yml` (`--bin sc-compose`)
+  - Added to Homebrew formula archives
+- Commands:
+  - `sc-compose render [OPTIONS] <template>` — render to stdout
+  - `sc-compose resolve [OPTIONS] <agent>` — print resolved file path
+  - `sc-compose validate [OPTIONS] <template>` — exit 2 on error
+  - `sc-compose frontmatter-init <file>` — write default frontmatter stub
+  - `sc-compose init` — repo bootstrap (`.prompts/`, `.gitignore`, template scan hints)
+- Global flags (FR-7 complete set): `--mode`, `--kind`, `--agent-type`/`--agent`,
+  `--runtime`/`--ai`, `--root`, `--var key=val`, `--var-file`, `--env-prefix`,
+  `--json`, `--dry-run`
+- Exit codes: 0 success, 2 validation/render failure, 3 usage/config error
+- `--json` flag: emit `Diagnostic` list as JSON on stderr, rendered text on stdout
+- `observability.rs` integration: CLI emits structured command start/end,
+  resolver decisions, validate/render outcomes (FR-9)
+- Smoke tests: render round-trip, missing var exits 2, `--json` parses cleanly,
+  `--dry-run` no-write guarantees, and profile-mode `validate` search-trace output
+
+---
+
+### AG.4 — `atm teams spawn` Integration + Full Integration Tests
+
+**Goal:** Wire sc-composer into `atm teams spawn`; comprehensive library integration tests.
+
+**Deliverables in `crates/atm/`:**
+
+- `crates/atm/Cargo.toml`: add `sc-composer.workspace = true` and add to `[workspace.dependencies]`
+- `runtime_adapter.rs` / `spawn.rs`: when `--system-prompt` points to a `.md.j2` file,
+  call `sc_composer::compose()` with spawn vars (`team`, `agent`, `runtime`, `model`, `cwd`),
+  write rendered text to a temp file, pass temp path to runtime adapter
+- Plain `.md` files: passthrough (backwards compat — no rendering)
+- `SpawnSpec` extended with `prompt_vars: BTreeMap<String, String>` for additional caller-supplied vars
+- `atm init` integration: invoke compose-init-equivalent helper so `.prompts/`
+  bootstrap and `.gitignore` enforcement are applied by ATM init contract
+
+**Library integration tests in `crates/sc-composer/tests/integration.rs`:**
+- file-mode end-to-end: `.md.j2` with vars → correct rendered output
+- profile-mode end-to-end: mock runtime dir → resolver finds correct file → renders
+- include expansion end-to-end: base template includes shared file → merged output
+- error paths: missing required var, cycle, out-of-root
+- cross-platform: all paths via `std::env::temp_dir()` or `tempfile::TempDir`
+
+**ATM integration tests in `crates/atm/tests/`:**
+- `atm init` applies compose-init-equivalent bootstrap idempotently
+- spawn composition path uses library APIs directly (no shell/subprocess path)
+
+---
+
+## Sprint Dependency Graph
+
+```
+AG.1 (library MVP — working compose())
+  └── AG.2 (resolver + includes + search trace + pipeline)
+        └── AG.3 (sc-compose binary + FR-7/FR-9 full CLI contract)
+              └── AG.4 (atm teams spawn + atm init integration tests)
+
+AG.0 (stale-daemon hygiene) runs as a pre-AG gate before AG.1.
+```
+
+AG.3 depends on AG.2. No AG.2/AG.3 overlap is planned to avoid profile-mode and
+search-trace contract ambiguity.
+
+---
+
+## Version and Release
+
+- Version: `0.42.0` (bump on integrate/phase-AG before final PR)
+- `sc-composer` and `sc-compose` are version-locked to ATM in this phase and
+  are released together in the same ATM publish cycle.
+- Both `sc-composer` and `sc-compose` publish to crates.io (co-released).
+- `sc-compose` binary added to Homebrew formula and release archives (4 targets)
+- ATM install/upgrade paths must install/upgrade the paired `sc-compose` CLI in
+  the same release step (no separate/manual compose upgrade path).
+- After publish: scmux adds `sc-composer = "0.42.0"` — no ATM sprint needed
+
+---
+
+## Success Criteria
+
+0. AG.0 stale-daemon pre-gate contracts are documented and test-scoped cleanup
+   plan is approved.
+1. `sc_composer::compose()` renders a `.md.j2` template with variable injection. `NotImplemented` is gone.
+2. `sc-compose render --var role=team-lead template.md.j2` prints rendered text.
+3. `sc-compose validate` exits 2 when a required variable is missing.
+4. `atm teams spawn --system-prompt agent.md.j2 --var project=scmux` renders and injects the prompt.
+5. `sc-compose validate --mode profile` includes search-trace output when
+   resolution fails.
+6. `sc-compose --dry-run` paths perform zero writes for write-capable commands.
+7. `atm init` applies compose-init-equivalent bootstrap idempotently.
+8. FR-9 logging events are emitted for CLI command lifecycle and resolver/validate outcomes.
+9. All CI green on ubuntu, macos, windows.
+10. `sc-composer = "0.42.0"` and `sc-compose = "0.42.0"` available on crates.io,
+    and `sc-compose` is present in Homebrew release artifacts.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -171,6 +171,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | AD | Cross-Platform Script Standardization | Python-first script conversion and runtime policy hardening across ATM tooling | COMPLETE |
 | AE | GH Monitor Reliability + Daemon Logging | Stabilize gh-monitor status/lifecycle contracts and daemon observability behavior | COMPLETE |
 | AF | External Agent Lifecycle Hardening | Close lifecycle, cleanup, transient registration, and reliability/documentation hardening | COMPLETE |
+| AG | sc-composer Full Implementation + CLI | Deliver `sc-composer` library + `sc-compose` CLI and integrate with `atm teams spawn` via direct library APIs | PLANNED |
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -701,6 +701,26 @@ team roster (`config.json`) and mailbox (`inboxes/<agent>.json`) do not drift.
 `atm teams spawn` must provide a first-class CLI path equivalent to the current
 `scripts/spawn-teammate.sh` behavior for Claude teammates.
 
+`atm` spawn requirements in this section define ATM integration behavior only.
+Template composition engine behavior (resolver order, frontmatter semantics,
+include expansion, diagnostics, CLI command contracts) is specified in:
+- `docs/sc-composer/requirements.md` (normative requirements)
+- `docs/sc-composer/architecture.md` (normative design)
+
+When ATM consumes `sc-composer`, ATM must not redefine or fork those semantics
+in `docs/requirements.md`; ATM requirements here are limited to call-site
+contracts (inputs passed to composer, error propagation, and spawn fallback UX).
+
+ATM integration parity requirements:
+- `atm teams spawn` composition behavior must match `sc-compose` CLI semantics
+  for resolution, include expansion, variable validation, and diagnostics.
+- ATM must invoke `sc-composer` library APIs directly in-process.
+- ATM must not invoke composition through shell commands or subprocess wrappers
+  (for example, no `bash -> sc-compose` execution path for core spawn behavior).
+- For current ATM packaging mode, `sc-composer` and `sc-compose` are
+  version-locked to ATM and must be installed/upgraded together through ATM
+  distribution channels.
+
 Required baseline behavior:
 - Resolve agent runtime metadata from `.claude/agents/<agent>.md` frontmatter
   (at minimum `model`, `color`; prompt body used for initial instruction delivery).
@@ -1904,6 +1924,23 @@ If daemon is unreachable, CLI attempts auto-start once per command invocation.
 - Daemon MUST NOT remove an existing socket file unless lock ownership has already
   been acquired by the current process.
 
+#### Stale Daemon Recovery and Identity Validation
+
+- Daemon lock ownership metadata must include process identity sufficient to
+  validate staleness in the current ATM scope (at minimum PID and executable
+  identity metadata).
+- If lock ownership metadata references a dead PID, daemon startup may reclaim
+  lock ownership in the same scope.
+- CLI daemon-connect readiness checks must validate that the responding daemon
+  matches expected scope/identity for the current command context before
+  treating it as healthy.
+- If daemon identity validation fails (stale/mismatched daemon), CLI must fail
+  safely with actionable restart guidance and must not silently proceed.
+- Production startup must not perform broad cross-scope daemon kill sweeps; any
+  process reclamation behavior must remain scope-bound and explicit.
+- Test harness paths that spawn daemon processes must provide bounded cleanup so
+  repeated test runs do not accumulate stale daemons.
+
 #### Team/Repo Isolation Contract
 
 Single daemon process does not imply shared team behavior. Runtime behavior must
@@ -2337,6 +2374,8 @@ atm init <team> --skip-team
   1. Create `.atm.toml` in cwd when missing (writes `identity`, `default_team`).
   2. Create team (`~/.claude/teams/<team>/`) when missing, unless `--skip-team`.
   3. Install hooks (global by default, or local with `--local`).
+  4. Apply compose-init-equivalent repo bootstrap (`.prompts/` plus `.gitignore`
+     entry) via the same shared helper semantics used by `sc-compose init`.
 - Default install writes/merges hook entries in `~/.claude/settings.json` (global scope).
 - `--local` install writes/merges hook entries in project `.claude/settings.json`.
 - Installs are idempotent: reruns preserve unrelated settings and avoid duplicate entries.

--- a/docs/sc-composer/architecture.md
+++ b/docs/sc-composer/architecture.md
@@ -16,7 +16,7 @@
 
 Core modules:
 - `frontmatter`: YAML frontmatter parse + typed metadata.
-- `resolver`: runtime-aware profile file search (`.claude`, `.codex`, `.gemini`, `.opencode`, `.agents`).
+- `resolver`: runtime-aware profile file search (`.claude`, `.codex`, `.gemini`, `.opencode`, `.agents/agents` + legacy `.agents`).
 - `include`: `@<path>` expansion with cycle/depth guards.
 - `context`: variable merge + precedence + source tracking.
 - `render`: Jinja2 rendering facade (strict undefined).
@@ -49,6 +49,7 @@ Commands:
 - `resolve`
 - `validate`
 - `frontmatter-init`
+- `init`
 
 CLI uses library APIs directly and only handles argument parsing, output
 formatting, and exit codes.
@@ -96,11 +97,17 @@ All command execution paths emit structured events through `observability`.
    - input > env > defaults
 5. Validate:
    - extract referenced template variables (when frontmatter requirements absent),
+   - emit undeclared-token warnings (or errors in strict mode),
    - required variables,
    - unknown variable policy.
 6. Render template in strict mode.
 7. Compose final output blocks in fixed order.
 8. Return rendered output + diagnostics + trace metadata.
+
+Output target policy:
+- file mode render-to-file defaults to replacing `.j2` suffix beside template.
+- profile mode render-to-file defaults to `.prompts/<name>-<ulid>.md` to avoid
+  polluting version-controlled template directories.
 
 Dry-run path:
 - For write-capable operations, planner computes target paths + diff summary,
@@ -137,3 +144,5 @@ CLI:
 - Keep `sc-composer` runtime-agnostic and ATM-independent.
 - ATM integrates via library API wrappers.
 - Other tools can use `sc-compose` directly in CI/dev workflows.
+- `atm init` should call the same compose-initialization helper used by
+  `sc-compose init` for `.prompts/` and `.gitignore` bootstrap behavior.

--- a/docs/sc-composer/requirements.md
+++ b/docs/sc-composer/requirements.md
@@ -25,6 +25,20 @@ validation.
 
 The library is runtime-agnostic and reusable by ATM and non-ATM tooling.
 
+Current packaging/release mode (required for this phase):
+- `sc-composer` and `sc-compose` are part of the ATM workspace and are
+  version-locked to the ATM release version.
+- They are released together in one ATM publish cycle (no independent versioning
+  during this mode).
+- ATM distribution install/upgrade paths must install/upgrade both the
+  `sc-composer` crate release and `sc-compose` CLI together.
+
+ATM integration contract:
+- ATM is a first-class consumer of `sc-composer` and must use the same
+  composition semantics exposed by `sc-compose`.
+- ATM integration must call `sc-composer` APIs directly; shell/subprocess
+  invocation of `sc-compose` is not an acceptable core integration path.
+
 ## 3. Functional Requirements
 
 ### FR-1: Template Inputs
@@ -63,10 +77,19 @@ The library is runtime-agnostic and reusable by ATM and non-ATM tooling.
   2. environment variables,
   3. frontmatter defaults.
 - Required variables from frontmatter must resolve after merge.
-- If frontmatter is absent, engine must extract referenced template variables
-  from the template/include graph and treat all extracted variables as required.
-- Missing required variables must fail render.
-- Missing referenced template variables must fail render (strict undefined).
+- If frontmatter is absent:
+  - engine must extract referenced template variables from the template/include graph,
+  - `validate` must emit a generated-frontmatter recommendation,
+  - diagnostics must include a fix command:
+    `sc-compose frontmatter-init <file>.j2`.
+- Tokens referenced in template/include graph but not declared in frontmatter must:
+  - be preserved in rendered output by default,
+  - emit warnings in `validate` and `render` diagnostics.
+- Missing frontmatter-declared required variables must fail render.
+- Strict mode (`--strict`) must fail render/validate on undeclared referenced tokens.
+- Undefined-variable render failures (template engine strict undefined) and
+  undeclared-token validation warnings/errors are distinct diagnostics and must
+  use distinct stable diagnostic codes.
 - Missing-variable errors must include:
   - full list of missing variable names,
   - the template/include file where each variable was referenced,
@@ -87,6 +110,9 @@ The library is runtime-agnostic and reusable by ATM and non-ATM tooling.
   - cycle detection,
   - bounded max depth,
   - deterministic expansion order.
+- Included files ending in `.j2` must be rendered using the same context/policy
+  pipeline as the parent template.
+- Include expansion must run in both file-output and stdout/stream render modes.
 - Include failures must return actionable diagnostics with include chain.
 
 ### FR-4: Safety Constraints
@@ -111,21 +137,36 @@ Resolution precedence applies only in `profile` mode.
 
 In `profile` mode, resolver must support runtime-specific search paths.
 Default order:
-- `claude`: `.claude/agents/<agent>.md` -> `.agents/<agent>.md`
-- `codex`: `.codex/agents/<agent>.md` -> `.agents/<agent>.md` -> `.claude/agents/<agent>.md`
-- `gemini`: `.gemini/agents/<agent>.md` -> `.agents/<agent>.md` -> `.claude/agents/<agent>.md`
-- `opencode`: `.opencode/agents/<agent>.md` -> `.agents/<agent>.md` -> `.claude/agents/<agent>.md`
+- `claude`: `.claude/agents/<agent>.md` -> `.agents/agents/<agent>.md` -> `.agents/<agent>.md`
+- `codex`: `.codex/agents/<agent>.md` -> `.agents/agents/<agent>.md` -> `.claude/agents/<agent>.md` -> `.agents/<agent>.md`
+- `gemini`: `.gemini/agents/<agent>.md` -> `.agents/agents/<agent>.md` -> `.claude/agents/<agent>.md` -> `.agents/<agent>.md`
+- `opencode`: `.opencode/agents/<agent>.md` -> `.agents/agents/<agent>.md` -> `.claude/agents/<agent>.md` -> `.agents/<agent>.md`
+
+Ambiguity contract:
+- When `--ai` (runtime selector) is provided, only that runtime precedence chain
+  is used.
+- When `--ai` is omitted, resolver must scan all runtime/shared roots; if more
+  than one candidate matches, command must fail with actionable ambiguity error
+  requiring `--ai`.
+- If exactly one candidate is found across all roots, it may be selected without
+  `--ai`.
 
 Profile-kind path conventions:
 - `kind=agent`:
-  - runtime-specific `<runtime>/agents/<name>.md` then shared `.agents/<name>.md`
+  - runtime-specific `<runtime>/agents/<name>.md` then shared `.agents/agents/<name>.md`
 - `kind=command`:
-  - runtime-specific `<runtime>/commands/<name>.md` then shared `.commands/<name>.md`
+  - runtime-specific `<runtime>/commands/<name>.md` then shared `.agents/commands/<name>.md`
 - `kind=skill`:
-  - runtime-specific `<runtime>/skills/<name>/SKILL.md` then shared `.skills/<name>/SKILL.md`
+  - runtime-specific `<runtime>/skills/<name>/` probe order:
+    1. `SKILL.md.j2`
+    2. `SKILL.md`
+    3. `SKILL.j2`
+  - then shared `.agents/skills/<name>/` with the same probe order.
 
 For ATM repository compatibility, `.claude/<kind>/...` remains a valid fallback
 for all runtimes when runtime-specific/shared paths are absent.
+For backwards compatibility with older shared layouts, resolver may also check
+legacy `.agents/<name>.md` for `kind=agent` after `.agents/agents/<name>.md`.
 
 The path policy must be configurable by callers.
 
@@ -145,10 +186,13 @@ Each block may be empty; output order is fixed.
 - `resolve`: print winning profile path and search trace.
 - `validate`: validate variables/includes without emitting full output.
 - `frontmatter-init`: generate default YAML frontmatter for a template/profile file.
+- `init`: repository bootstrap (`.prompts/`, `.gitignore` entry, template scan + recommendations).
 
 CLI must support:
 - `--mode <profile|file>` (default: `file`),
 - `--kind <agent|command|skill>` (required when `--mode profile`),
+- `--agent-type <name>` (profile-mode selector; alias to `--agent`),
+- `--ai <claude|codex|gemini|opencode>` (runtime selector; alias to `--runtime`),
 - `--var key=value` (repeatable),
 - `--var-file <json|yaml>`,
 - `--env-prefix <PREFIX_>`,
@@ -177,11 +221,14 @@ CLI must support:
 Render output path rules:
 - If `render` writes to stdout (default), no output filename transform is applied.
 - If `render` writes to a file without explicit `--output`, default output path is
-  derived from template filename:
-  - `<name>.xml.j2` -> `<name>.xml`
-  - `<name>.md.j2` -> `<name>.md`
-  - `<name>.txt.j2` -> `<name>.txt`
-  - `<name>.j2` -> `<name>`
+  mode-dependent:
+  - file mode: derived from template filename:
+    - `<name>.xml.j2` -> `<name>.xml`
+    - `<name>.md.j2` -> `<name>.md`
+    - `<name>.txt.j2` -> `<name>.txt`
+    - `<name>.j2` -> `<name>`
+  - profile mode (`kind=agent|command|skill`): `.prompts/<prompt-name>-<ulid>.md`
+    to avoid writing generated prompts beside version-controlled templates.
 - If `--output <path>` is provided, it overrides derived output path.
 
 `frontmatter-init` behavior:
@@ -191,6 +238,20 @@ Render output path rules:
   - `metadata` (empty map).
 - Must preserve existing body content and prepend frontmatter at file start.
 - Must fail unless `--force` is provided when frontmatter already exists.
+
+`init` behavior:
+- Create `.prompts/` at repo root.
+- Ensure `.prompts/` is present in `.gitignore` (idempotent).
+- Scan repository for `*.j2` templates and run validation.
+- Print recommendations for missing/weak frontmatter with direct fix commands.
+- CLI help for `validate` and `frontmatter-init` must include frontmatter edit
+  guidance and the direct fix command form:
+  `sc-compose frontmatter-init <file>.j2`.
+
+ATM init integration:
+- `atm init` must run compose-init-equivalent setup automatically (or call the
+  same underlying library helper) so `.prompts/` + `.gitignore` policy is
+  enforced without extra user steps.
 
 ### FR-8: Determinism and Diagnostics
 

--- a/docs/test-plan-phase-AG.md
+++ b/docs/test-plan-phase-AG.md
@@ -1,0 +1,34 @@
+# Phase AG Test Plan: sc-composer + sc-compose
+
+Last updated: 2026-03-08
+
+## Goal
+
+Define required automated coverage for Phase AG deliverables so implementation
+review can verify requirement-to-test traceability before merge.
+
+## Coverage Matrix
+
+| Sprint | Scope | Requirement Source | Required Automated Coverage |
+|---|---|---|---|
+| AG.0 | Stale daemon process hygiene (pre-AG gate) | `docs/requirements.md` §4.7 (single-instance + auto-start), issue #539 planning contract | Integration tests for stale lock-holder PID recovery, daemon identity mismatch detection on CLI connect, and bounded stale-daemon cleanup in test harnesses using isolated `ATM_HOME` scopes |
+| AG.1 | Library MVP (`compose`/`validate`, frontmatter/context/render) | `docs/sc-composer/requirements.md` FR-1, FR-2, FR-8 | Unit tests for frontmatter parse (present/absent), variable precedence (`input > env > defaults`), required-var failures, unknown-var policy (`error|warn|ignore`), strict undefined render behavior, and deterministic output snapshots |
+| AG.2 | Resolver + include expansion | FR-3, FR-4, FR-5, FR-6 | Unit/integration tests for runtime precedence resolution (`claude/codex/gemini/opencode`), profile-mode search-trace output on resolution failure, explicit-path bypass, include recursion/cycle detection, max-depth guard, root-escape rejection, rendered include output parity in stdout + file-output modes, and deterministic three-block pipeline composition order |
+| AG.3 | `sc-compose` CLI (`render/resolve/validate/frontmatter-init/init`) | FR-7, FR-8, FR-9 | CLI integration tests for exit codes (`0/2/3`), `--json` diagnostics schema stability, `frontmatter-init` write + `--dry-run`, `init` idempotency (`.prompts` and `.gitignore`), help output including fix command guidance, and observability event emission for command lifecycle + resolver/validate outcomes |
+| AG.4 | ATM integration (`atm teams spawn` + composer API wiring) | `docs/requirements.md` §4.3.2 + sc-composer FR-6/FR-7 integration contract | Integration tests verifying ATM calls library APIs directly (no subprocess composition path), `.md.j2` prompt rendering into spawn flow, plain `.md` passthrough, generated launch command emitted on success/failure, and prompt var forwarding (`team/agent/runtime/model/cwd`) |
+
+## Cross-Platform and Reliability Requirements
+
+- Run AG test matrix on ubuntu, macos, and windows.
+- Use deterministic temp paths (`tempfile::TempDir`/`std::env::temp_dir`) only.
+- No shell-dependent test harnesses for product/runtime behavior.
+- Any flaky test must be redesigned before phase closeout (no retry-only masking).
+
+## Validation Commands (Minimum)
+
+```bash
+cargo test -p sc-composer
+cargo test -p sc-compose
+cargo test -p agent-team-mail --test integration_spawn
+cargo clippy --workspace --all-targets -- -D warnings
+```


### PR DESCRIPTION
## Summary\n- merge origin/develop into feature/pAG-s5-merge-fix (branched from integrate/phase-AG)\n- resolve conflicts while preserving AG state: workspace version 0.42.0, atm-tui core pin =0.42.0, and Phase AG status entries in docs/project-plan.md\n- regenerate Cargo.lock via cargo generate-lockfile\n\n## Validation\n- cargo fmt --check --all\n- cargo clippy -- -D warnings\n\n## Notes\n- clippy needless_return fix in sc-compose observability was already present in merge base (1d18adf) and is included via branch ancestry.