### PR TITLE
Release v0.42.1: Phase AG + publish order fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "minijinja",
  "serde",
@@ -2714,18 +2714,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.42.0"
+version = "0.42.1"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -36,5 +36,5 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.42.0" }
-sc-composer = { path = "crates/sc-composer", version = "=0.42.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.42.1" }
+sc-composer = { path = "crates/sc-composer", version = "=0.42.1" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.42.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.42.1" }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -11,7 +11,7 @@ description = "CLI for composing AI prompts with sc-composer"
 
 [dependencies]
 anyhow.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.42.0" }
+sc-composer = { path = "../sc-composer", version = "=0.42.1" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json.workspace = true

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -61,9 +61,9 @@ package = "sc-composer"
 cargo_toml = "crates/sc-composer/Cargo.toml"
 required = true
 publish = true
-publish_order = 60
-preflight_check = "locked"
-wait_after_publish_seconds = 0
+publish_order = 5
+preflight_check = "full"
+wait_after_publish_seconds = 60
 verify_install = false
 
 [[crates]]

--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -1,85 +1,85 @@
 {
-  "releaseVersion": "0.42.0",
-  "releaseTag": "v0.42.0",
-  "releaseCommit": "14ff0b7fca2e785e3dee9e8ed53f4ebcca11ef6b",
-  "generatedAt": "2026-03-09T04:18:55.919385+00:00",
+  "releaseVersion": "0.42.1",
+  "releaseTag": "v0.42.1",
+  "releaseCommit": "c55062769c100f3219b606a9bc08c46621ac04b6",
+  "generatedAt": "2026-03-09T04:42:21.212515+00:00",
   "items": [
     {
-      "artifact": "agent-team-mail-core",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "artifact": "sc-composer",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search agent-team-mail-core --limit 1 | grep -F 'agent-team-mail-core = \"0.42.0\"'"
+        "cargo search sc-composer --limit 1 | grep -F 'sc-composer = \"0.42.1\"'"
+      ]
+    },
+    {
+      "artifact": "agent-team-mail-core",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
+      "publishTarget": "crates.io",
+      "publish": true,
+      "required": true,
+      "verifyCommands": [
+        "cargo search agent-team-mail-core --limit 1 | grep -F 'agent-team-mail-core = \"0.42.1\"'"
       ]
     },
     {
       "artifact": "agent-team-mail",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search agent-team-mail --limit 1 | grep -F 'agent-team-mail = \"0.42.0\"'",
-        "cargo install agent-team-mail --version 0.42.0 --locked --force"
+        "cargo search agent-team-mail --limit 1 | grep -F 'agent-team-mail = \"0.42.1\"'",
+        "cargo install agent-team-mail --version 0.42.1 --locked --force"
       ]
     },
     {
       "artifact": "agent-team-mail-daemon",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search agent-team-mail-daemon --limit 1 | grep -F 'agent-team-mail-daemon = \"0.42.0\"'"
+        "cargo search agent-team-mail-daemon --limit 1 | grep -F 'agent-team-mail-daemon = \"0.42.1\"'"
       ]
     },
     {
       "artifact": "agent-team-mail-mcp",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search agent-team-mail-mcp --limit 1 | grep -F 'agent-team-mail-mcp = \"0.42.0\"'"
+        "cargo search agent-team-mail-mcp --limit 1 | grep -F 'agent-team-mail-mcp = \"0.42.1\"'"
       ]
     },
     {
       "artifact": "agent-team-mail-tui",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search agent-team-mail-tui --limit 1 | grep -F 'agent-team-mail-tui = \"0.42.0\"'"
-      ]
-    },
-    {
-      "artifact": "sc-composer",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
-      "publishTarget": "crates.io",
-      "publish": true,
-      "required": true,
-      "verifyCommands": [
-        "cargo search sc-composer --limit 1 | grep -F 'sc-composer = \"0.42.0\"'"
+        "cargo search agent-team-mail-tui --limit 1 | grep -F 'agent-team-mail-tui = \"0.42.1\"'"
       ]
     },
     {
       "artifact": "sc-compose",
-      "version": "0.42.0",
-      "sourceRef": "refs/tags/v0.42.0",
+      "version": "0.42.1",
+      "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
       "required": true,
       "verifyCommands": [
-        "cargo search sc-compose --limit 1 | grep -F 'sc-compose = \"0.42.0\"'"
+        "cargo search sc-compose --limit 1 | grep -F 'sc-compose = \"0.42.1\"'"
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- Phase AG complete: sc-composer library + sc-compose CLI binary
- Fix: sc-composer publish order moved from 60 to 5 (must publish before agent-team-mail-core due to --locked workspace lockfile resolution)
- Patch bump from v0.42.0 (stuck tag, failed publish) to v0.42.1

## Release
v0.42.1 — merge commit required (no squash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)