### PR TITLE
docs(AH-fix): close post-QA findings — OTel deferral, log path fix, Phase AJ stubs

### DIFF
--- a/docs/observability/architecture.md
+++ b/docs/observability/architecture.md
@@ -69,6 +69,9 @@ Health evaluator is implemented once and reused by `atm doctor` and `atm status`
 
 ## 9. OpenTelemetry Baseline
 
+> **Status**: Deferred to Phase AJ. OTel support is not implemented in Phase AH.
+> The architecture below describes the planned Phase AJ design.
+
 When enabled:
 - Traces: `subagent.run`, `atm.send`, `atm.read`, `daemon.request`.
 - Metrics: `subagent_runs_total`, `subagent_run_duration_ms`,

--- a/docs/observability/requirements.md
+++ b/docs/observability/requirements.md
@@ -133,6 +133,10 @@ Lifecycle and hook coverage:
 
 ## 9. OpenTelemetry Requirements
 
+> **Status**: Deferred to Phase AJ. OTel support is not implemented in Phase AH.
+> Implementation planning will occur in the Phase AJ planning session.
+> The requirements below are the target specification for Phase AJ.
+
 - OTel export support is optional and feature-gated (default off).
 - Local structured file logging remains available regardless of OTel state.
 - Initial OTel baseline must include:

--- a/docs/phase-ah-planning.md
+++ b/docs/phase-ah-planning.md
@@ -211,3 +211,30 @@ OTel rollout in AH is intentionally scoped to a short baseline set:
 DEFERRED to Phase AJ or later. atm_core::logging::init_unified() is ratified as the
 integration surface for ATM binaries in this phase. The sc-observability crate does not
 export init(). No action required for AH.4 merge.
+
+## Phase AH Formal Deferrals (Post-QA)
+
+### AH-OBS-1 deferral: scmux and schook integration
+AH-OBS-1 requires all tools (including `scmux` and `schook`) to use `sc-observability`.
+These binaries are not part of the current workspace. Their `sc-observability` adoption
+is formally deferred to a future phase after v0.43.0 publish.
+Tracking: deferred per user decision post-AH QA review.
+
+### AH-OBS-2 deferral: sc_observability::init() zero-config API
+AH-OBS-2 specifies a canonical zero-config `sc_observability::init("<tool-name>")` entry
+point. This API is not exported in Phase AH. The AJ planning session will define the
+exact API surface and migration path. Tracking: deferred to Phase AJ.
+
+### AH-OBS-5 deferral: OpenTelemetry baseline
+AH-OBS-5 (and AH-OBS-5a/5b) require optional OTel export with feature gate. OTel support
+is entirely absent from the AH implementation. This is formally deferred to Phase AJ.
+The `docs/observability/requirements.md` and `docs/observability/architecture.md` OTel
+sections are stubs — implementation is a Phase AJ deliverable.
+Tracking: deferred per user decision post-AH QA review.
+
+### AJ forward requirement: log injection for library calls
+When ATM calls sc-compose/sc-composer as a library (e.g. `atm teams spawn` calling
+compose APIs), the library's log events must route into the host tool's log file rather
+than the companion tool's default log file. This design contract must be specified in
+Phase AJ requirements before implementation.
+Tracking: added to AJ requirements backlog.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2,7 +2,7 @@
 
 **Version**: 0.7
 **Date**: 2026-03-09
-**Status**: Phase AG complete (v0.42.0). Phase AH planning in progress.
+**Status**: Phases AH and AI complete (v0.43.0). Phase AJ planning next.
 
 ---
 
@@ -171,7 +171,10 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | AD | Cross-Platform Script Standardization | Python-first script conversion and runtime policy hardening across ATM tooling | COMPLETE |
 | AE | GH Monitor Reliability + Daemon Logging | Stabilize gh-monitor status/lifecycle contracts and daemon observability behavior | COMPLETE |
 | AF | External Agent Lifecycle Hardening | Close lifecycle, cleanup, transient registration, and reliability/documentation hardening | COMPLETE |
-| AG | sc-composer Full Implementation + CLI | Deliver `sc-composer` library + `sc-compose` CLI and integrate with `atm teams spawn` via direct library APIs | PLANNED |
+| AG | sc-composer Full Implementation + CLI | Deliver `sc-composer` library + `sc-compose` CLI and integrate with `atm teams spawn` via direct library APIs | COMPLETE |
+| AH | sc-observability Unification + ATM Ecosystem Logging | Shared logging crate, sc-compose migration, ATM ecosystem integration, doctor/status health surfaces | COMPLETE |
+| AI | GH Monitor Dashboard + Detailed PR Reporting | `atm gh monitor list`, `atm gh monitor report`, `--template` rendering, init-report | COMPLETE |
+| AJ | OpenTelemetry Baseline + Observability API Completion | OTel feature gate, sc_observability::init() API, log injection for library calls, scmux/schook integration | PLANNED |
 
 ---
 
@@ -1463,10 +1466,10 @@ the current tranche focused on onboarding contract closure.
 | | AG.3 | `sc-compose` Binary + Logging Baseline | COMPLETE | [#552](https://github.com/randlee/agent-team-mail/pull/552) |
 | | AG.4 | ATM Spawn Integration (`--system-prompt .j2`) | COMPLETE | [#553](https://github.com/randlee/agent-team-mail/pull/553) |
 
-**Completed**: 133+ sprints across 29 phases (CI green)
-**Current version**: v0.42.0
-**Current phase**: Phase AG (COMPLETE)
-**Next planned phase**: Phase AH (observability unification + OTel baseline)
+**Completed**: 138+ sprints across 31 phases (CI green)
+**Current version**: v0.43.0
+**Current phase**: Phase AI (COMPLETE)
+**Next planned phase**: Phase AJ (OTel baseline + observability API completion)
 
 ---
 
@@ -1486,7 +1489,7 @@ optional OpenTelemetry baseline with sub-agent-first trace coverage.
 | AH.1 | Shared crate foundation (`sc-observability`) + spool/size-guard/socket-error/L1a contracts | #556 | COMPLETE |
 | AH.2 | `sc-compose` migration to shared logging | #556 | COMPLETE |
 | AH.3 | Diagnostics + output derivation closure | #555, #557 | COMPLETE |
-| AH.4 | ATM/daemon/tui/mcp/scmux/schook integration + doctor/status health surfaces + OTel baseline | #556 | COMPLETE |
+| AH.4 | ATM/daemon/tui/mcp/scmux/schook integration + doctor/status health surfaces | #556 | COMPLETE |
 | AH.5 | Runbook + install/release docs closeout | #558 | COMPLETE |
 
 ---
@@ -1501,10 +1504,36 @@ observability scope.
 ### Planned Sprint Map
 | Sprint | Focus | Issues | Status |
 |---|---|---|---|
-| AI.0 | `gh_monitor` cold-start init bug fix prerequisite | #564 | PLANNED |
-| AI.1 | `atm gh monitor list` rollup dashboard + `--json` | #560 | PLANNED |
-| AI.2 | `atm gh monitor report <PR>` built-in report + `--json` | #561 | PLANNED |
-| AI.3 | Template customization (`--template`) + optional `init-report` | #561 (follow-up) | PLANNED |
+| AI.0 | `gh_monitor` cold-start init bug fix prerequisite | #564 | COMPLETE |
+| AI.1 | `atm gh monitor list` rollup dashboard + `--json` | #560 | COMPLETE |
+| AI.2 | `atm gh monitor report <PR>` built-in report + `--json` | #561 | COMPLETE |
+| AI.3 | Template customization (`--template`) + optional `init-report` | #561 (follow-up) | COMPLETE |
+
+---
+
+## 17.19 Phase AJ: OpenTelemetry Baseline + Observability API Completion
+
+**Goal**: Deliver the OTel feature gate deferred from AH, complete the `sc_observability::init()`
+zero-config API, define and implement log injection for library calls, and integrate
+`scmux`/`schook` with `sc-observability`.
+
+**Planning doc**: `docs/phase-aj-planning.md` _(planning session pending)_
+**Requirements doc**: `docs/observability/requirements.md` (§9 OTel — deferred from AH)
+**Architecture doc**: `docs/observability/architecture.md` (§9 OTel — deferred from AH)
+
+### Deferred inputs from Phase AH
+- AH-OBS-5/5a/5b: OTel optional feature gate, trace/metric baseline, sub-agent-first instrumentation
+- AH-OBS-1: scmux and schook `sc-observability` adoption
+- AH-OBS-2: `sc_observability::init("<tool>")` zero-config API
+- Log injection contract: library calls from ATM tools must route logs to host tool's log file
+
+### Planned Sprint Map
+| Sprint | Focus | Issues | Status |
+|---|---|---|---|
+| AJ.1 | `sc_observability::init()` API + log injection contract | TBD | PLANNED |
+| AJ.2 | OTel feature gate + trace/metric baseline | TBD | PLANNED |
+| AJ.3 | scmux/schook sc-observability adoption | TBD | PLANNED |
+| AJ.4 | Integration hardening + docs | TBD | PLANNED |
 
 ---
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -150,10 +150,10 @@ file via `--vars-file <path>`.
 |---|---|---|
 | `SC_COMPOSE_LOG_LEVEL` | `info` | Log verbosity: `trace`, `debug`, `info`, `warn`, `error` |
 | `SC_COMPOSE_LOG_FORMAT` | `jsonl` | Output format for log lines: `jsonl` or `human` |
-| `SC_COMPOSE_LOG_FILE` | _(stderr)_ | Redirect sc-compose logs to a file path |
+| `SC_COMPOSE_LOG_FILE` | `~/.config/sc-compose/logs/sc-compose.log` | Override sc-compose log file path (`%APPDATA%\sc-compose\logs\sc-compose.log` on Windows) |
 
-To disable sc-compose structured log emission entirely:
+To suppress most log output, set the level to `error`:
 
 ```bash
-SC_COMPOSE_LOG_LEVEL=off atm compose render <template>
+SC_COMPOSE_LOG_LEVEL=error atm compose render <template>
 ```


### PR DESCRIPTION
## Summary

- **quickstart.md**: Fix `SC_COMPOSE_LOG_FILE` default (was `_(stderr)_`, now shows real platform path `~/.config/sc-compose/logs/sc-compose.log`); replace invalid `SC_COMPOSE_LOG_LEVEL=off` with `error` (no Off variant exists)
- **phase-ah-planning.md**: Add formal Phase AH deferral entries for AH-OBS-1 (scmux/schook post-publish), AH-OBS-2 (init() API → Phase AJ), AH-OBS-5 (OTel → Phase AJ), and log injection forward requirement
- **project-plan.md**: v0.43.0 status, AG/AH/AI→COMPLETE in overview table, Phase AJ row added (PLANNED), Phase 17.19 AJ section added with deferred inputs and sprint map placeholders
- **observability/requirements.md** + **observability/architecture.md**: Mark §9 OTel sections as deferred to Phase AJ

## Addresses QA Findings

- ATM-QA-002: scmux/schook deferral formally documented
- ATM-QA-004: SC_COMPOSE_LOG_FILE default corrected
- ATM-QA-005: SC_COMPOSE_LOG_LEVEL=off removed (invalid value)
- ATM-QA-007: Phase AJ added to project plan overview table
- ATM-QA-008/009: OTel deferral documented in observability stubs and planning doc

## Test plan

- [ ] Docs-only change — no code touched
- [ ] CI will run fmt/clippy/tests on the workspace (all pass from prior sprint work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)