### PR TITLE
chore(release): merge develop → main for v0.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -18,6 +18,7 @@ dependencies = [
  "notify",
  "predicates",
  "sc-composer",
+ "sc-observability",
  "serde",
  "serde_json",
  "serial_test",
@@ -32,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -54,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -67,7 +68,7 @@ dependencies = [
  "libc",
  "libloading",
  "notify",
- "rand",
+ "rand 0.8.5",
  "sc-observability",
  "serde",
  "serde_json",
@@ -87,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -96,6 +97,7 @@ dependencies = [
  "clap",
  "dirs",
  "libc",
+ "sc-observability",
  "serde",
  "serde_json",
  "serial_test",
@@ -109,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -117,6 +119,7 @@ dependencies = [
  "clap",
  "crossterm",
  "ratatui",
+ "sc-observability",
  "serde",
  "serde_json",
  "serial_test",
@@ -704,13 +707,25 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1371,6 +1386,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1382,8 +1403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1393,7 +1424,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1403,6 +1444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1533,23 +1583,26 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
+ "agent-team-mail-core",
  "anyhow",
  "assert_cmd",
  "chrono",
  "clap",
  "predicates",
  "sc-composer",
+ "sc-observability",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
+ "ulid",
 ]
 
 [[package]]
 name = "sc-composer"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "minijinja",
  "serde",
@@ -1560,10 +1613,11 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
+ "chrono",
  "serde_json",
  "serial_test",
  "tempfile",
@@ -2079,6 +2133,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2362,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.43.1"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.0" }
-sc-composer = { path = "crates/sc-composer", version = "=0.43.0" }
-sc-observability = { path = "crates/sc-observability", version = "=0.43.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.1" }
+sc-composer = { path = "crates/sc-composer", version = "=0.43.1" }
+sc-observability = { path = "crates/sc-observability", version = "=0.43.1" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.43.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.43.1" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.43.0" }
+sc-composer = { path = "../sc-composer", version = "=0.43.1" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -6,7 +6,7 @@
   "items": [
     {
       "artifact": "sc-composer",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -17,7 +17,7 @@
     },
     {
       "artifact": "agent-team-mail-core",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -28,7 +28,7 @@
     },
     {
       "artifact": "agent-team-mail",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -40,7 +40,7 @@
     },
     {
       "artifact": "agent-team-mail-daemon",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -51,7 +51,7 @@
     },
     {
       "artifact": "agent-team-mail-mcp",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -62,7 +62,7 @@
     },
     {
       "artifact": "agent-team-mail-tui",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -73,7 +73,7 @@
     },
     {
       "artifact": "sc-compose",
-      "version": "0.42.1",
+      "version": "0.43.1",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,


### PR DESCRIPTION
## Summary

Recovery patch for v0.43.0 release failure (stale Cargo.lock).

- Bump workspace version 0.43.0 → 0.43.1
- Update all pinned internal deps to `=0.43.1`
- Regenerate Cargo.lock
- Update release-inventory.json to 0.43.1

## Test plan
- [ ] CI green on develop before merge
- [ ] Publisher triggers release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)