### PR TITLE
chore(release): bump to 0.43.2 — add sc-observability to publish manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "minijinja",
  "serde",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.43.1"
+version = "0.43.2"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.1" }
-sc-composer = { path = "crates/sc-composer", version = "=0.43.1" }
-sc-observability = { path = "crates/sc-observability", version = "=0.43.1" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.2" }
+sc-composer = { path = "crates/sc-composer", version = "=0.43.2" }
+sc-observability = { path = "crates/sc-observability", version = "=0.43.2" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.43.1" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.43.2" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.43.1" }
+sc-composer = { path = "../sc-composer", version = "=0.43.2" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -12,6 +12,17 @@ wait_after_publish_seconds = 60
 verify_install = false
 
 [[crates]]
+artifact = "sc-observability"
+package = "sc-observability"
+cargo_toml = "crates/sc-observability/Cargo.toml"
+required = true
+publish = true
+publish_order = 15
+preflight_check = "full"
+wait_after_publish_seconds = 60
+verify_install = false
+
+[[crates]]
 artifact = "agent-team-mail"
 package = "agent-team-mail"
 cargo_toml = "crates/atm/Cargo.toml"

--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -6,7 +6,7 @@
   "items": [
     {
       "artifact": "sc-composer",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -17,7 +17,7 @@
     },
     {
       "artifact": "agent-team-mail-core",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -28,7 +28,7 @@
     },
     {
       "artifact": "agent-team-mail",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -40,7 +40,7 @@
     },
     {
       "artifact": "agent-team-mail-daemon",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -51,7 +51,7 @@
     },
     {
       "artifact": "agent-team-mail-mcp",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -62,7 +62,7 @@
     },
     {
       "artifact": "agent-team-mail-tui",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -73,7 +73,7 @@
     },
     {
       "artifact": "sc-compose",
-      "version": "0.43.1",
+      "version": "0.43.2",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,


### PR DESCRIPTION
## Summary

Recovery from v0.43.1 partial publish failure. `sc-observability` (added in Phase AH) was missing from `release/publish-artifacts.toml`, causing `agent-team-mail` crates.io publish to fail.

**State**: `agent-team-mail-core 0.43.1` published. All other crates not published.

**Changes**:
- Add `sc-observability` to `publish-artifacts.toml` at `publish_order=15` (after `atm-core`, before `agent-team-mail`)
- Bump workspace version 0.43.1 → 0.43.2
- Update all pinned internal deps to `=0.43.2`
- Regenerate `Cargo.lock`
- Update `release-inventory.json` to 0.43.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)