### PR TITLE
chore(release): bump to 0.43.3 — fix sc-observability preflight_check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "minijinja",
  "serde",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.43.2"
+version = "0.43.3"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.43.2"
+version = "0.43.3"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.2" }
-sc-composer = { path = "crates/sc-composer", version = "=0.43.2" }
-sc-observability = { path = "crates/sc-observability", version = "=0.43.2" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.3" }
+sc-composer = { path = "crates/sc-composer", version = "=0.43.3" }
+sc-observability = { path = "crates/sc-observability", version = "=0.43.3" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.43.2" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.43.3" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.43.2" }
+sc-composer = { path = "../sc-composer", version = "=0.43.3" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/release/publish-artifacts.toml
+++ b/release/publish-artifacts.toml
@@ -18,7 +18,7 @@ cargo_toml = "crates/sc-observability/Cargo.toml"
 required = true
 publish = true
 publish_order = 15
-preflight_check = "full"
+preflight_check = "locked"
 wait_after_publish_seconds = 60
 verify_install = false
 

--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -1,12 +1,12 @@
 {
-  "releaseVersion": "0.42.1",
+  "releaseVersion": "0.43.3",
   "releaseTag": "v0.42.1",
   "releaseCommit": "c55062769c100f3219b606a9bc08c46621ac04b6",
   "generatedAt": "2026-03-09T04:42:21.212515+00:00",
   "items": [
     {
       "artifact": "sc-composer",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -17,7 +17,7 @@
     },
     {
       "artifact": "agent-team-mail-core",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -28,7 +28,7 @@
     },
     {
       "artifact": "agent-team-mail",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -40,7 +40,7 @@
     },
     {
       "artifact": "agent-team-mail-daemon",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -51,7 +51,7 @@
     },
     {
       "artifact": "agent-team-mail-mcp",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -62,7 +62,7 @@
     },
     {
       "artifact": "agent-team-mail-tui",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -73,7 +73,7 @@
     },
     {
       "artifact": "sc-compose",
-      "version": "0.43.2",
+      "version": "0.43.3",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,


### PR DESCRIPTION
## Summary
- Fix `sc-observability` `preflight_check` from `"full"` to `"locked"` in `publish-artifacts.toml`
- `"full"` runs `cargo package --locked` which fails because `agent-team-mail-core =0.43.3` is not on crates.io yet (chain-dep structural failure)
- `"locked"` runs `cargo check --locked` which works with local workspace path deps
- Bump workspace version 0.43.2 → 0.43.3
- Regenerate Cargo.lock

## Root Cause
`sc-observability` is NOT a leaf crate — it depends on `agent-team-mail-core`. Only leaf crates (no internal workspace deps) can use `preflight_check = "full"`. Non-leaf crates must use `"locked"`.

## Recovery Context
This is the 3rd recovery bump: v0.43.0 (stale Cargo.lock) → v0.43.1 → v0.43.2 (missing from manifest) → v0.43.3 (wrong preflight_check). Each failure was a configuration bug, not a code bug.

## Test plan
- [ ] CI green on this PR
- [ ] Merge to main
- [ ] Trigger release workflow with version=0.43.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)