### PR TITLE
chore(release): bump to 0.43.4 — fix publish-crates Phase 2 sequencing bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,18 +481,9 @@ jobs:
             done
           done < "${publish_plan_path}"
 
-          # Phase 2: after root publish, validate non-root crates can package
-          mapfile -t locked_checks < <(
-            python3 scripts/release_artifacts.py list-preflight \
-              --manifest "${RELEASE_ARTIFACT_MANIFEST}" \
-              --mode locked
-          )
-          for crate in "${locked_checks[@]}"; do
-            [[ -n "$crate" ]] || continue
-            echo "::group::cargo package -p ${crate} --locked (pre-publish validation)"
-            cargo package -p "${crate}" --locked
-            echo "::endgroup::"
-          done
+          # Phase 2 removed: pre-validating locked crates via cargo package before
+          # publishing their dependencies structurally fails (deps not on crates.io yet).
+          # cargo publish --locked in Phase 3 already validates before uploading.
 
           # Phase 3: publish non-core crates
           while IFS='|' read -r crate wait_seconds; do

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -55,7 +55,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -88,7 +88,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1602,7 +1602,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "minijinja",
  "serde",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.43.3"
+version = "0.43.4"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.43.3"
+version = "0.43.4"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.3" }
-sc-composer = { path = "crates/sc-composer", version = "=0.43.3" }
-sc-observability = { path = "crates/sc-observability", version = "=0.43.3" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.43.4" }
+sc-composer = { path = "crates/sc-composer", version = "=0.43.4" }
+sc-observability = { path = "crates/sc-observability", version = "=0.43.4" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.43.3" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.43.4" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.43.3" }
+sc-composer = { path = "../sc-composer", version = "=0.43.4" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/release/release-inventory.json
+++ b/release/release-inventory.json
@@ -1,12 +1,12 @@
 {
-  "releaseVersion": "0.43.3",
+  "releaseVersion": "0.43.4",
   "releaseTag": "v0.42.1",
   "releaseCommit": "c55062769c100f3219b606a9bc08c46621ac04b6",
   "generatedAt": "2026-03-09T04:42:21.212515+00:00",
   "items": [
     {
       "artifact": "sc-composer",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -17,7 +17,7 @@
     },
     {
       "artifact": "agent-team-mail-core",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -28,7 +28,7 @@
     },
     {
       "artifact": "agent-team-mail",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -40,7 +40,7 @@
     },
     {
       "artifact": "agent-team-mail-daemon",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -51,7 +51,7 @@
     },
     {
       "artifact": "agent-team-mail-mcp",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -62,7 +62,7 @@
     },
     {
       "artifact": "agent-team-mail-tui",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,
@@ -73,7 +73,7 @@
     },
     {
       "artifact": "sc-compose",
-      "version": "0.43.3",
+      "version": "0.43.4",
       "sourceRef": "refs/tags/v0.42.1",
       "publishTarget": "crates.io",
       "publish": true,


### PR DESCRIPTION
## Summary
- Remove Phase 2 from `publish-crates` workflow job
- Bump workspace version 0.43.3 → 0.43.4

## Root Cause (Phase 2 bug)
Phase 2 ran `cargo package --locked` on ALL `locked_checks` crates before publishing any of them. This validated `agent-team-mail` before `sc-observability` was published — crates.io couldn't resolve `sc-observability =0.43.3`, causing failure.

`cargo publish --locked` in Phase 3 already validates the package before uploading. Phase 2 was redundant and broke dependency sequencing for chained workspace crates.

## Release failure chain
- v0.43.0 — stale Cargo.lock (#599)
- v0.43.1 — sc-observability missing from manifest (#607)
- v0.43.2 — sc-observability wrong preflight_check (#608)
- v0.43.3 — Phase 2 publish sequencing bug (this PR)

All four failure modes are now gated by PR #609 (release-hardening → develop).

## Test plan
- [ ] CI green
- [ ] User approves + merge to main
- [ ] Trigger: `gh workflow run release.yml -f version=0.43.4`
- [ ] Monitor: all 8 crates publish in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)