### PR TITLE
chore: fix sc-compose frontmatter in codex-orchestration templates

### DIFF
--- a/.claude/skills/codex-orchestration/dev-template.xml.j2
+++ b/.claude/skills/codex-orchestration/dev-template.xml.j2
@@ -1,3 +1,19 @@
+---
+name: dev-task
+version: 1.0.0
+description: arch-ctm sprint assignment template for codex-orchestration phases.
+format: xml
+required_variables:
+  - task_id
+  - sprint
+  - description
+  - worktree_path
+  - branch
+  - pr_target
+  - deliverables
+  - acceptance_criteria
+  - references
+---
 <atm-task id="{{ task_id }}" sprint="{{ sprint }}" assignee="arch-ctm">
   <description>{{ description }}</description>
 
@@ -6,21 +22,15 @@
   <pr-target>{{ pr_target }}</pr-target>
 
   <deliverables>
-    {% for item in deliverables %}
-    <item>{{ item }}</item>
-    {% endfor %}
+{{ deliverables }}
   </deliverables>
 
   <acceptance-criteria>
-    {% for criterion in acceptance_criteria %}
-    <item>{{ criterion }}</item>
-    {% endfor %}
+{{ acceptance_criteria }}
   </acceptance-criteria>
 
   <references>
-    {% for ref in references %}
-    <doc>{{ ref }}</doc>
-    {% endfor %}
+{{ references }}
   </references>
 
   <workflow>

--- a/.claude/skills/codex-orchestration/qa-template.xml.j2
+++ b/.claude/skills/codex-orchestration/qa-template.xml.j2
@@ -1,3 +1,19 @@
+---
+name: qa-task
+version: 1.0.0
+description: quality-mgr QA assignment template for codex-orchestration phases.
+format: xml
+required_variables:
+  - task_id
+  - sprint
+  - description
+  - pr_number
+  - branch
+  - worktree_path
+  - commits
+  - deliverables
+  - references
+---
 <atm-qa-task id="{{ task_id }}" sprint="{{ sprint }}" assignee="quality-mgr">
   <description>{{ description }}</description>
 
@@ -7,15 +23,11 @@
   <commits>{{ commits }}</commits>
 
   <deliverables>
-    {% for item in deliverables %}
-    <item>{{ item }}</item>
-    {% endfor %}
+{{ deliverables }}
   </deliverables>
 
   <references>
-    {% for ref in references %}
-    <doc>{{ ref }}</doc>
-    {% endfor %}
+{{ references }}
   </references>
 
   <workflow>
@@ -37,8 +49,8 @@
         subagent_type: atm-qa-agent
         run_in_background: true
         prompt: Validate sprint {{ sprint }} implementation against requirements and sprint spec.
-                Worktree: {{ worktree_path }}. Deliverables: {{ deliverables | join(', ') }}.
-                Reference docs: {{ references | join(', ') }}.
+                Worktree: {{ worktree_path }}. Deliverables: {{ deliverables }}.
+                Reference docs: {{ references }}.
                 Report findings as BLOCKING or NON-BLOCKING with file:line references.
     </step>
     <step id="c">


### PR DESCRIPTION
## Summary
- Add sc-compose-compatible YAML frontmatter (`name`, `version`, `description`, `format`, `required_variables`) to `dev-template.xml.j2` and `qa-template.xml.j2`
- Replace `{% for item in list %}` Jinja2 loops with flat `{{ variable }}` placeholders — sc-compose only supports `string→string` variables
- Pre-formatted strings are now passed by callers (team-lead) for `deliverables`, `acceptance_criteria`, and `references`
- Pattern matches existing `quality-management-gh` template frontmatter style

## Test plan
- [ ] Verify `sc-compose render dev-template.xml.j2` works with flat variables
- [ ] Verify `sc-compose render qa-template.xml.j2` works with flat variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)