### PR TITLE
feat(dev): dev-install/use/rollback scripts for dogfood environment

### DIFF
--- a/.env
+++ b/.env
@@ -6,5 +6,5 @@ CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 # Dev environment (dogfood channel)
 ATM_DEV_ROOT=/Users/randlee/.local/atm-dev
 ATM_HOME=/Users/randlee/.local/share/atm-dev/home
-ATM_DAEMON_BIN=/Users/randlee/.local/atm-dev/current/bin/atm-daemon
+ATM_DAEMON_BIN=/Users/randlee/.local/atm-dev/bin/atm-daemon
 ATM_CHANNEL=dev

--- a/scripts/dev-install
+++ b/scripts/dev-install
@@ -1,16 +1,20 @@
 #!/usr/bin/env python3
 """dev-install: Build and install ATM binaries to the dev channel.
 
-Builds all ATM binaries from source, creates a versioned immutable install
-prefix, atomically switches the active version, restarts the daemon, and
-runs post-install verification.
+Builds all ATM binaries from source, saves a versioned backup, overwrites the
+active ~/.local/atm-dev/bin/ in place, restarts the daemon, and runs
+post-install verification.
+
+No symlinks. PATH always points to ~/.local/atm-dev/bin/ — files swap
+underneath without requiring session restarts.
 
 Usage:
-    dev-install [--repo <path>] [--allow-dirty]
+    dev-install [--repo <path>] [--allow-dirty] [--skip-build]
 
 Options:
     --repo <path>     Path to the repository root (default: parent of scripts/)
     --allow-dirty     Skip the dirty-worktree check
+    --skip-build      Skip cargo build; use existing target/release/ binaries
     -h, --help        Show this help message
 """
 
@@ -47,6 +51,7 @@ CARGO_PACKAGES = [
 
 ATM_DEV_ROOT = Path.home() / ".local" / "atm-dev"
 ATM_HOME = Path.home() / ".local" / "share" / "atm-dev" / "home"
+BIN_DIR = ATM_DEV_ROOT / "bin"
 
 
 # ---------------------------------------------------------------------------
@@ -54,24 +59,18 @@ ATM_HOME = Path.home() / ".local" / "share" / "atm-dev" / "home"
 # ---------------------------------------------------------------------------
 
 def die(msg: str) -> None:
-    """Print an error message and exit with code 1."""
     print(f"error: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
-def run(cmd: list[str], *, cwd: Path | None = None, capture: bool = False,
-        env: dict | None = None) -> subprocess.CompletedProcess:
-    """Run a command, printing it first. Raise on non-zero exit."""
+def run(cmd: list, *, cwd: Path = None, capture: bool = False,
+        env: dict = None) -> subprocess.CompletedProcess:
     display = " ".join(str(c) for c in cmd)
     print(f"  $ {display}")
     try:
         return subprocess.run(
-            cmd,
-            check=True,
-            cwd=cwd,
-            capture_output=capture,
-            text=True,
-            env=env,
+            cmd, check=True, cwd=cwd,
+            capture_output=capture, text=True, env=env,
         )
     except subprocess.CalledProcessError as exc:
         msg = f"command failed (exit {exc.returncode}): {display}"
@@ -80,14 +79,11 @@ def run(cmd: list[str], *, cwd: Path | None = None, capture: bool = False,
         die(msg)
 
 
-def run_capture(cmd: list[str], *, cwd: Path | None = None) -> str:
-    """Run a command and return stdout, stripped."""
-    result = run(cmd, cwd=cwd, capture=True)
-    return result.stdout.strip()
+def run_capture(cmd: list, *, cwd: Path = None) -> str:
+    return run(cmd, cwd=cwd, capture=True).stdout.strip()
 
 
 def sha256_file(path: Path) -> str:
-    """Return the hex SHA-256 digest of a file."""
     h = hashlib.sha256()
     with open(path, "rb") as f:
         for chunk in iter(lambda: f.read(65536), b""):
@@ -95,13 +91,13 @@ def sha256_file(path: Path) -> str:
     return h.hexdigest()
 
 
-def dev_env(path_prefix: Path) -> dict:
-    """Build the subprocess environment for ATM dev channel commands."""
+def dev_env() -> dict:
+    """Build subprocess environment pointing at the active bin/ dir."""
     env = os.environ.copy()
     env["ATM_HOME"] = str(ATM_HOME)
-    env["ATM_DAEMON_BIN"] = str(path_prefix / "bin" / "atm-daemon")
+    env["ATM_DAEMON_BIN"] = str(BIN_DIR / "atm-daemon")
     env["ATM_CHANNEL"] = "dev"
-    env["PATH"] = str(path_prefix / "bin") + os.pathsep + env.get("PATH", "")
+    env["PATH"] = str(BIN_DIR) + os.pathsep + env.get("PATH", "")
     return env
 
 
@@ -110,57 +106,65 @@ def write_env_sh() -> None:
     ATM_DEV_ROOT.mkdir(parents=True, exist_ok=True)
     env_sh = ATM_DEV_ROOT / "env.sh"
     content = (
-        '# ATM dev channel environment — source this file or add to your shell profile\n'
+        "# ATM dev channel environment\n"
+        "# Add to ~/.zshrc: source ~/.local/atm-dev/env.sh\n"
         'export ATM_DEV_ROOT="$HOME/.local/atm-dev"\n'
         'export ATM_HOME="$HOME/.local/share/atm-dev/home"\n'
-        'export PATH="$ATM_DEV_ROOT/current/bin:$PATH"\n'
-        'export ATM_DAEMON_BIN="$ATM_DEV_ROOT/current/bin/atm-daemon"\n'
+        'export PATH="$ATM_DEV_ROOT/bin:$PATH"\n'
+        'export ATM_DAEMON_BIN="$ATM_DEV_ROOT/bin/atm-daemon"\n'
         'export ATM_CHANNEL=dev\n'
     )
     env_sh.write_text(content)
     print(f"  wrote {env_sh}")
 
 
-def switch_current(new_prefix: Path) -> None:
-    """Atomically move current -> previous, then set current -> new_prefix."""
-    current = ATM_DEV_ROOT / "current"
-    previous = ATM_DEV_ROOT / "previous"
+def save_backup(label: str, binary_entries: list, git_sha: str,
+                git_branch: str, rust_toolchain: str, dirty: bool,
+                repo: Path) -> Path:
+    """Copy current bin/ to <label>/ as a versioned backup."""
+    backup_dir = ATM_DEV_ROOT / label / "bin"
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    for name in BINARIES:
+        src = BIN_DIR / name
+        if src.exists():
+            shutil.copy2(src, backup_dir / name)
+    manifest = {
+        "label": label,
+        "git_sha": git_sha,
+        "git_branch": git_branch,
+        "build_timestamp": datetime.now(timezone.utc).isoformat(),
+        "dirty": dirty,
+        "rust_toolchain": rust_toolchain,
+        "binaries": binary_entries,
+    }
+    (ATM_DEV_ROOT / label / "manifest.json").write_text(
+        json.dumps(manifest, indent=2) + "\n"
+    )
+    (ATM_DEV_ROOT / label / "source.txt").write_text(str(repo) + "\n")
+    return ATM_DEV_ROOT / label
 
-    if current.is_symlink() or current.exists():
-        if previous.is_symlink() or previous.exists():
-            previous.unlink()
-        # Rename resolves as rename of the symlink itself on macOS/Linux.
-        os.rename(current, previous)
-        print(f"  moved current -> previous ({os.readlink(previous)})")
 
-    os.symlink(new_prefix, current)
-    print(f"  current -> {new_prefix}")
-
-
-def restart_daemon(current_prefix: Path) -> None:
-    """Restart the ATM daemon using the dev environment."""
+def restart_daemon() -> None:
     print("\n[restart daemon]")
-    atm_bin = current_prefix / "bin" / "atm"
+    atm_bin = BIN_DIR / "atm"
     if not atm_bin.exists():
         die(f"atm binary not found at {atm_bin}")
-    env = dev_env(current_prefix)
+    env = dev_env()
     try:
         run([str(atm_bin), "daemon", "restart"], env=env)
     except SystemExit:
-        # daemon restart may report non-zero if no daemon was running; continue.
-        print("  note: daemon restart returned non-zero (may be first-time start)")
+        print("  note: daemon restart returned non-zero (first-time start ok)")
 
 
-def verify_install(current_prefix: Path) -> bool:
-    """Run post-install verification checks. Returns True if all pass."""
+def verify_install() -> bool:
     print("\n[post-install verification]")
-    atm_bin = current_prefix / "bin" / "atm"
-    env = dev_env(current_prefix)
+    atm_bin = BIN_DIR / "atm"
+    env = dev_env()
     checks = [
         ([str(atm_bin), "daemon", "status"], "daemon status"),
         ([str(atm_bin), "--version"], "atm --version"),
-        ([str(current_prefix / "bin" / "atm-daemon"), "--version"], "atm-daemon --version"),
-        ([str(current_prefix / "bin" / "sc-compose"), "--version"], "sc-compose --version"),
+        ([str(BIN_DIR / "atm-daemon"), "--version"], "atm-daemon --version"),
+        ([str(BIN_DIR / "sc-compose"), "--version"], "sc-compose --version"),
     ]
     all_pass = True
     for cmd, label in checks:
@@ -168,8 +172,8 @@ def verify_install(current_prefix: Path) -> bool:
             result = subprocess.run(
                 cmd, check=True, capture_output=True, text=True, env=env
             )
-            version_line = (result.stdout or result.stderr).strip().splitlines()[0]
-            print(f"  [PASS] {label}: {version_line}")
+            line = (result.stdout or result.stderr).strip().splitlines()[0]
+            print(f"  [PASS] {label}: {line}")
         except (subprocess.CalledProcessError, FileNotFoundError, IndexError) as exc:
             print(f"  [FAIL] {label}: {exc}")
             all_pass = False
@@ -186,19 +190,12 @@ def parse_args() -> argparse.Namespace:
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     scripts_dir = Path(__file__).resolve().parent
-    default_repo = scripts_dir.parent
-    parser.add_argument(
-        "--repo",
-        type=Path,
-        default=default_repo,
-        metavar="PATH",
-        help=f"repository root (default: {default_repo})",
-    )
-    parser.add_argument(
-        "--allow-dirty",
-        action="store_true",
-        help="skip the dirty-worktree check",
-    )
+    parser.add_argument("--repo", type=Path, default=scripts_dir.parent,
+                        metavar="PATH", help="repository root")
+    parser.add_argument("--allow-dirty", action="store_true",
+                        help="skip the dirty-worktree check")
+    parser.add_argument("--skip-build", action="store_true",
+                        help="skip cargo build; use existing target/release/ binaries")
     return parser.parse_args()
 
 
@@ -211,154 +208,125 @@ def main() -> None:
 
     print(f"[dev-install] repo: {repo}")
 
-    # ------------------------------------------------------------------
-    # 1. Dirty check (before any build work)
-    # ------------------------------------------------------------------
+    # 1. Dirty check
     print("\n[dirty check]")
     if args.allow_dirty:
-        print("  --allow-dirty passed, skipping dirty check")
         dirty = True
+        print("  --allow-dirty passed, skipping")
     else:
         status_output = run_capture(["git", "status", "--porcelain"], cwd=repo)
         if status_output:
-            die(
-                "working tree is dirty. Commit or stash changes, or pass --allow-dirty.\n"
-                + status_output
-            )
+            die("working tree is dirty. Commit or stash changes, or pass --allow-dirty.\n"
+                + status_output)
         dirty = False
-        print("  working tree is clean")
+        print("  clean")
 
-    # ------------------------------------------------------------------
-    # 2. Gather git metadata
-    # ------------------------------------------------------------------
+    # 2. Git metadata
     print("\n[git metadata]")
     git_sha = run_capture(["git", "rev-parse", "HEAD"], cwd=repo)
     short_sha = git_sha[:7]
-    git_branch = run_capture(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo
-    )
+    git_branch = run_capture(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=repo)
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     label = f"{today}-{short_sha}"
     print(f"  label:  {label}")
     print(f"  branch: {git_branch}")
-    print(f"  sha:    {git_sha}")
 
-    # ------------------------------------------------------------------
-    # 3. Build
-    # ------------------------------------------------------------------
-    print("\n[cargo build --release]")
-    cargo_args = ["cargo", "build", "--release"]
-    for pkg in CARGO_PACKAGES:
-        cargo_args += ["-p", pkg]
-    run(cargo_args, cwd=repo)
+    # 3. Build (unless --skip-build)
+    if args.skip_build:
+        print("\n[skipping build — using existing target/release/]")
+    else:
+        print("\n[cargo build --release]")
+        cargo_args = ["cargo", "build", "--release"]
+        for pkg in CARGO_PACKAGES:
+            cargo_args += ["-p", pkg]
+        run(cargo_args, cwd=repo)
 
-    # ------------------------------------------------------------------
-    # 4. Verify built binaries exist
-    # ------------------------------------------------------------------
-    print("\n[verify binaries]")
+    # 4. Verify built binaries exist before touching anything
+    print("\n[verify source binaries]")
     release_dir = repo / "target" / "release"
     for name in BINARIES:
-        binary = release_dir / name
-        if not binary.exists():
-            die(f"expected binary not found after build: {binary}")
+        if not (release_dir / name).exists():
+            die(f"expected binary not found: {release_dir / name}")
         print(f"  found {name}")
 
-    # ------------------------------------------------------------------
-    # 5. Gather toolchain info
-    # ------------------------------------------------------------------
     rust_toolchain = run_capture(["rustc", "--version"], cwd=repo)
 
-    # ------------------------------------------------------------------
-    # 6. Create immutable prefix and copy binaries
-    # ------------------------------------------------------------------
-    print("\n[install binaries]")
-    prefix = ATM_DEV_ROOT / "installs" / label
-    bin_dir = prefix / "bin"
-    bin_dir.mkdir(parents=True, exist_ok=True)
-
+    # 5. Compute checksums from source
     binary_entries = []
     for name in BINARIES:
-        src = release_dir / name
-        dst = bin_dir / name
-        shutil.copy2(src, dst)
-        # Make executable
-        dst.chmod(0o755)
-        checksum = sha256_file(dst)
+        checksum = sha256_file(release_dir / name)
         binary_entries.append({"name": name, "sha256": checksum})
-        print(f"  installed {name}  ({checksum[:16]}...)")
 
-    # ------------------------------------------------------------------
-    # 7. Write manifest.json
-    # ------------------------------------------------------------------
-    print("\n[write manifest]")
-    build_timestamp = datetime.now(timezone.utc).isoformat()
+    # 6. Save backup of current bin/ before overwriting
+    if BIN_DIR.exists() and any((BIN_DIR / b).exists() for b in BINARIES):
+        # Read current manifest to get its label for the backup dir name
+        current_manifest = ATM_DEV_ROOT / "manifest.json"
+        if current_manifest.exists():
+            try:
+                cur = json.loads(current_manifest.read_text())
+                prev_label = cur.get("label", "unknown")
+            except (json.JSONDecodeError, OSError):
+                prev_label = "unknown"
+        else:
+            prev_label = f"pre-{label}"
+
+        if not (ATM_DEV_ROOT / prev_label).exists():
+            print(f"\n[backup current -> {prev_label}/]")
+            backup_dir = ATM_DEV_ROOT / prev_label / "bin"
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            for name in BINARIES:
+                src = BIN_DIR / name
+                if src.exists():
+                    shutil.copy2(src, backup_dir / name)
+            if current_manifest.exists():
+                shutil.copy2(current_manifest, ATM_DEV_ROOT / prev_label / "manifest.json")
+            print(f"  saved to {ATM_DEV_ROOT / prev_label}/")
+            # Record previous label for rollback
+            (ATM_DEV_ROOT / "previous.txt").write_text(prev_label + "\n")
+
+    # 7. Install binaries to bin/ (overwrite in place)
+    print("\n[install binaries -> ~/.local/atm-dev/bin/]")
+    BIN_DIR.mkdir(parents=True, exist_ok=True)
+    for name in BINARIES:
+        src = release_dir / name
+        dst = BIN_DIR / name
+        shutil.copy2(src, dst)
+        dst.chmod(0o755)
+        print(f"  installed {name}")
+
+    # 8. Write root manifest.json for current install
     manifest = {
         "label": label,
         "git_sha": git_sha,
         "git_branch": git_branch,
-        "build_timestamp": build_timestamp,
+        "build_timestamp": datetime.now(timezone.utc).isoformat(),
         "dirty": dirty,
         "rust_toolchain": rust_toolchain,
         "binaries": binary_entries,
     }
-    manifest_path = prefix / "manifest.json"
-    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
-    print(f"  wrote {manifest_path}")
+    (ATM_DEV_ROOT / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    (ATM_DEV_ROOT / "current.txt").write_text(label + "\n")
 
-    # ------------------------------------------------------------------
-    # 8. Write source.txt
-    # ------------------------------------------------------------------
-    source_path = prefix / "source.txt"
-    source_path.write_text(str(repo) + "\n")
-    print(f"  wrote {source_path}")
-
-    # ------------------------------------------------------------------
-    # 9. Create ATM_HOME directory
-    # ------------------------------------------------------------------
+    # 9. Ensure ATM_HOME and env.sh exist
     ATM_HOME.mkdir(parents=True, exist_ok=True)
     print(f"\n[ATM_HOME] {ATM_HOME}")
-
-    # ------------------------------------------------------------------
-    # 10. Write env.sh
-    # ------------------------------------------------------------------
-    print("\n[write env.sh]")
     write_env_sh()
 
-    # ------------------------------------------------------------------
-    # 11. Switch current -> new prefix (atomic)
-    # ------------------------------------------------------------------
-    print("\n[switch current]")
-    switch_current(prefix)
+    # 10. Restart daemon
+    restart_daemon()
 
-    # Resolve the live current symlink for subsequent operations
-    current_prefix = ATM_DEV_ROOT / "current"
+    # 11. Post-install verification
+    all_pass = verify_install()
 
-    # ------------------------------------------------------------------
-    # 12. Restart daemon
-    # ------------------------------------------------------------------
-    restart_daemon(prefix)
-
-    # ------------------------------------------------------------------
-    # 13. Post-install verification
-    # ------------------------------------------------------------------
-    all_pass = verify_install(prefix)
-
-    # ------------------------------------------------------------------
-    # 14. Summary
-    # ------------------------------------------------------------------
+    # 12. Summary
     print("\n" + "=" * 60)
-    print(f"dev-install complete")
-    print(f"  label:   {label}")
-    print(f"  prefix:  {prefix}")
-    print(f"  current: {current_prefix} -> {prefix}")
+    print("dev-install complete")
+    print(f"  label:    {label}")
+    print(f"  bin:      {BIN_DIR}")
     print(f"  ATM_HOME: {ATM_HOME}")
-    binaries_list = ", ".join(BINARIES)
-    print(f"  binaries: {binaries_list}")
     print(f"  verification: {'ALL PASS' if all_pass else 'SOME CHECKS FAILED'}")
-    print()
     if not all_pass:
-        print("One or more verification checks failed.")
-        print(f"To rollback: scripts/dev-rollback")
+        print("\nTo rollback:  scripts/dev-rollback")
         sys.exit(1)
 
 

--- a/scripts/dev-rollback
+++ b/scripts/dev-rollback
@@ -1,168 +1,142 @@
 #!/usr/bin/env python3
-"""dev-rollback: Roll back to the previous ATM dev install.
+"""dev-rollback: Roll back the active ATM dev binaries to the previous version.
 
-Swaps current <-> previous, restarts the daemon, and verifies the install.
+Reads ~/.local/atm-dev/previous.txt to find the previous version label,
+copies those binaries into the active bin/, and restarts the daemon.
+No symlinks. PATH never changes.
 
 Usage:
-    dev-rollback [-h]
+    dev-rollback
 
 Options:
     -h, --help    Show this help message
 """
 
+import argparse
+import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
-# ---------------------------------------------------------------------------
-# Constants (mirrored from dev-install)
-# ---------------------------------------------------------------------------
-
 ATM_DEV_ROOT = Path.home() / ".local" / "atm-dev"
 ATM_HOME = Path.home() / ".local" / "share" / "atm-dev" / "home"
+BIN_DIR = ATM_DEV_ROOT / "bin"
 
+BINARIES = ["atm", "atm-daemon", "atm-agent-mcp", "atm-tui", "sc-compose"]
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def die(msg: str) -> None:
-    """Print an error message and exit with code 1."""
     print(f"error: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
-def dev_env(path_prefix: Path) -> dict:
-    """Build the subprocess environment for ATM dev channel commands."""
+def run(cmd: list, *, env: dict = None) -> subprocess.CompletedProcess:
+    display = " ".join(str(c) for c in cmd)
+    print(f"  $ {display}")
+    try:
+        return subprocess.run(cmd, check=True, text=True, env=env)
+    except subprocess.CalledProcessError as exc:
+        die(f"command failed (exit {exc.returncode}): {display}")
+
+
+def dev_env() -> dict:
     env = os.environ.copy()
     env["ATM_HOME"] = str(ATM_HOME)
-    env["ATM_DAEMON_BIN"] = str(path_prefix / "bin" / "atm-daemon")
+    env["ATM_DAEMON_BIN"] = str(BIN_DIR / "atm-daemon")
     env["ATM_CHANNEL"] = "dev"
-    env["PATH"] = str(path_prefix / "bin") + os.pathsep + env.get("PATH", "")
+    env["PATH"] = str(BIN_DIR) + os.pathsep + env.get("PATH", "")
     return env
 
 
-def restart_daemon(prefix: Path) -> None:
-    """Restart the ATM daemon using the dev environment."""
+def restart_daemon() -> None:
     print("\n[restart daemon]")
-    atm_bin = prefix / "bin" / "atm"
+    atm_bin = BIN_DIR / "atm"
     if not atm_bin.exists():
         die(f"atm binary not found at {atm_bin}")
-    env = dev_env(prefix)
-    display = f"ATM_HOME=... atm daemon restart"
-    print(f"  $ {display}")
     try:
-        subprocess.run(
-            [str(atm_bin), "daemon", "restart"],
-            check=True,
-            text=True,
-            env=env,
-        )
-    except subprocess.CalledProcessError:
-        print("  note: daemon restart returned non-zero (may be first-time start)")
+        run([str(atm_bin), "daemon", "restart"], env=dev_env())
+    except SystemExit:
+        print("  note: daemon restart returned non-zero (ok)")
 
 
-def verify_install(prefix: Path) -> bool:
-    """Run post-install verification checks. Returns True if all pass."""
-    print("\n[post-install verification]")
-    atm_bin = prefix / "bin" / "atm"
-    env = dev_env(prefix)
+def verify_install() -> bool:
+    print("\n[post-rollback verification]")
+    env = dev_env()
     checks = [
-        ([str(atm_bin), "daemon", "status"], "daemon status"),
-        ([str(atm_bin), "--version"], "atm --version"),
-        ([str(prefix / "bin" / "atm-daemon"), "--version"], "atm-daemon --version"),
-        ([str(prefix / "bin" / "sc-compose"), "--version"], "sc-compose --version"),
+        ([str(BIN_DIR / "atm"), "daemon", "status"], "daemon status"),
+        ([str(BIN_DIR / "atm"), "--version"], "atm --version"),
+        ([str(BIN_DIR / "atm-daemon"), "--version"], "atm-daemon --version"),
     ]
     all_pass = True
     for cmd, label in checks:
         try:
-            result = subprocess.run(
-                cmd, check=True, capture_output=True, text=True, env=env
-            )
-            version_line = (result.stdout or result.stderr).strip().splitlines()[0]
-            print(f"  [PASS] {label}: {version_line}")
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+            line = (result.stdout or result.stderr).strip().splitlines()[0]
+            print(f"  [PASS] {label}: {line}")
         except (subprocess.CalledProcessError, FileNotFoundError, IndexError) as exc:
             print(f"  [FAIL] {label}: {exc}")
             all_pass = False
     return all_pass
 
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
 def main() -> None:
-    # Simple help check without argparse overhead
-    if "--help" in sys.argv or "-h" in sys.argv:
-        print(__doc__.strip())
-        return
+    argparse.ArgumentParser(
+        description="Roll back ATM dev binaries to previous version."
+    ).parse_args()
 
-    current = ATM_DEV_ROOT / "current"
-    previous = ATM_DEV_ROOT / "previous"
+    prev_txt = ATM_DEV_ROOT / "previous.txt"
+    if not prev_txt.exists():
+        die("no previous version recorded — cannot rollback\n"
+            "Use 'scripts/dev-use --list' to see available versions.")
 
-    # ------------------------------------------------------------------
-    # 1. Validate that previous exists
-    # ------------------------------------------------------------------
-    if not (previous.is_symlink() or previous.exists()):
-        die("no previous install found — cannot rollback")
+    prev_label = prev_txt.read_text().strip()
+    src_dir = ATM_DEV_ROOT / prev_label / "bin"
 
-    previous_target = Path(os.readlink(previous)).resolve()
-    current_target = None
-    if current.is_symlink():
-        current_target = Path(os.readlink(current)).resolve()
+    if not src_dir.is_dir():
+        die(f"previous version backup not found: {ATM_DEV_ROOT / prev_label}\n"
+            "Use 'scripts/dev-use --list' to see available versions.")
 
-    from_label = previous_target.name
-    to_label = current_target.name if current_target else "(none)"
+    cur_txt = ATM_DEV_ROOT / "current.txt"
+    cur_label = cur_txt.read_text().strip() if cur_txt.exists() else "(unknown)"
 
-    print(f"[dev-rollback] rolling back")
-    print(f"  from current: {to_label}")
-    print(f"  to previous:  {from_label}")
+    print(f"[dev-rollback] {cur_label} -> {prev_label}")
 
-    # ------------------------------------------------------------------
-    # 2. Swap current <-> previous
-    # ------------------------------------------------------------------
-    print("\n[swap symlinks]")
+    # Verify source binaries exist
+    print("\n[verify rollback binaries]")
+    for name in BINARIES:
+        if not (src_dir / name).exists():
+            die(f"binary missing from rollback version: {src_dir / name}")
+        print(f"  found {name}")
 
-    # Remove current
-    if current.is_symlink() or current.exists():
-        current.unlink()
+    # Swap current/previous labels before touching bin/
+    (ATM_DEV_ROOT / "previous.txt").write_text(cur_label + "\n")
 
-    # Move previous -> current
-    os.symlink(previous_target, current)
-    print(f"  current -> {previous_target}")
+    # Overwrite active bin/ with rollback binaries
+    print("\n[restore binaries -> ~/.local/atm-dev/bin/]")
+    BIN_DIR.mkdir(parents=True, exist_ok=True)
+    for name in BINARIES:
+        shutil.copy2(src_dir / name, BIN_DIR / name)
+        (BIN_DIR / name).chmod(0o755)
+        print(f"  restored {name}")
 
-    # Point previous at what was current (if it existed)
-    previous.unlink()
-    if current_target and current_target.exists():
-        os.symlink(current_target, previous)
-        print(f"  previous -> {current_target}")
-    else:
-        print("  previous: (removed — no previous current to restore)")
+    # Update current.txt and manifest
+    (ATM_DEV_ROOT / "current.txt").write_text(prev_label + "\n")
+    src_manifest = ATM_DEV_ROOT / prev_label / "manifest.json"
+    if src_manifest.exists():
+        shutil.copy2(src_manifest, ATM_DEV_ROOT / "manifest.json")
 
-    # ------------------------------------------------------------------
-    # 3. Restart daemon
-    # ------------------------------------------------------------------
-    restart_daemon(previous_target)
+    restart_daemon()
+    all_pass = verify_install()
 
-    # ------------------------------------------------------------------
-    # 4. Post-rollback verification
-    # ------------------------------------------------------------------
-    all_pass = verify_install(previous_target)
-
-    # ------------------------------------------------------------------
-    # 5. Summary
-    # ------------------------------------------------------------------
     print("\n" + "=" * 60)
-    print(f"dev-rollback complete")
-    print(f"  rolled back to: {from_label}")
-    print(f"  prefix:         {previous_target}")
-    print(f"  ATM_HOME:       {ATM_HOME}")
-    print(f"  verification:   {'ALL PASS' if all_pass else 'SOME CHECKS FAILED'}")
-    print()
+    print("dev-rollback complete")
+    print(f"  rolled back to: {prev_label}")
+    print(f"  previous was:   {cur_label}")
+    print(f"  verification: {'ALL PASS' if all_pass else 'SOME CHECKS FAILED'}")
     if not all_pass:
-        print("One or more verification checks failed after rollback.")
         sys.exit(1)
 
 

--- a/scripts/dev-use
+++ b/scripts/dev-use
@@ -1,54 +1,41 @@
 #!/usr/bin/env python3
-"""dev-use: Switch the active ATM dev install to an existing versioned prefix.
+"""dev-use: Switch the active ATM dev install to a saved backup version.
 
-Does not rebuild. Repoints the current symlink to the named install, restarts
-the daemon, and runs post-install verification.
+Copies binaries from ~/.local/atm-dev/<label>/bin/ into the active
+~/.local/atm-dev/bin/, restarts the daemon, and runs verification.
+No symlinks. PATH never changes.
 
 Usage:
     dev-use <label>
     dev-use --list
 
 Options:
-    --list        List available installs
+    --list        List available saved versions
     -h, --help    Show this help message
 """
 
 import argparse
 import json
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
-# ---------------------------------------------------------------------------
-# Constants (mirrored from dev-install)
-# ---------------------------------------------------------------------------
-
 ATM_DEV_ROOT = Path.home() / ".local" / "atm-dev"
 ATM_HOME = Path.home() / ".local" / "share" / "atm-dev" / "home"
+BIN_DIR = ATM_DEV_ROOT / "bin"
 
-BINARIES = [
-    "atm",
-    "atm-daemon",
-    "atm-agent-mcp",
-    "atm-tui",
-    "sc-compose",
-]
+BINARIES = ["atm", "atm-daemon", "atm-agent-mcp", "atm-tui", "sc-compose"]
 
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 def die(msg: str) -> None:
-    """Print an error message and exit with code 1."""
     print(f"error: {msg}", file=sys.stderr)
     sys.exit(1)
 
 
-def run(cmd: list[str], *, env: dict | None = None) -> subprocess.CompletedProcess:
-    """Run a command, printing it first. Raise on non-zero exit."""
+def run(cmd: list, *, env: dict = None) -> subprocess.CompletedProcess:
     display = " ".join(str(c) for c in cmd)
     print(f"  $ {display}")
     try:
@@ -57,136 +44,97 @@ def run(cmd: list[str], *, env: dict | None = None) -> subprocess.CompletedProce
         die(f"command failed (exit {exc.returncode}): {display}")
 
 
-def dev_env(path_prefix: Path) -> dict:
-    """Build the subprocess environment for ATM dev channel commands."""
+def dev_env() -> dict:
     env = os.environ.copy()
     env["ATM_HOME"] = str(ATM_HOME)
-    env["ATM_DAEMON_BIN"] = str(path_prefix / "bin" / "atm-daemon")
+    env["ATM_DAEMON_BIN"] = str(BIN_DIR / "atm-daemon")
     env["ATM_CHANNEL"] = "dev"
-    env["PATH"] = str(path_prefix / "bin") + os.pathsep + env.get("PATH", "")
+    env["PATH"] = str(BIN_DIR) + os.pathsep + env.get("PATH", "")
     return env
 
 
-def list_installs() -> list[str]:
-    """Return sorted list of available install labels."""
-    installs_dir = ATM_DEV_ROOT / "installs"
-    if not installs_dir.exists():
-        return []
-    labels = sorted(
-        d.name for d in installs_dir.iterdir() if d.is_dir()
-    )
-    return labels
+def list_versions() -> list:
+    """Return sorted list of available backup version labels."""
+    versions = []
+    for d in ATM_DEV_ROOT.iterdir():
+        if d.is_dir() and (d / "bin").is_dir():
+            versions.append(d.name)
+    return sorted(versions)
+
+
+def current_label() -> str:
+    txt = ATM_DEV_ROOT / "current.txt"
+    return txt.read_text().strip() if txt.exists() else "(unknown)"
 
 
 def show_list() -> None:
-    """Print available installs, marking current and previous."""
-    labels = list_installs()
-    if not labels:
-        print("No installs found under ~/.local/atm-dev/installs/")
+    versions = list_versions()
+    if not versions:
+        print("No saved versions found under ~/.local/atm-dev/")
         return
-
-    current_target = None
-    previous_target = None
-    current_link = ATM_DEV_ROOT / "current"
-    previous_link = ATM_DEV_ROOT / "previous"
-
-    if current_link.is_symlink():
-        current_target = Path(os.readlink(current_link)).name
-    if previous_link.is_symlink():
-        previous_target = Path(os.readlink(previous_link)).name
-
-    print("Available installs:")
-    for label in reversed(labels):  # newest first
+    cur = current_label()
+    prev_txt = ATM_DEV_ROOT / "previous.txt"
+    prev = prev_txt.read_text().strip() if prev_txt.exists() else None
+    print("Saved versions:")
+    for v in reversed(versions):
         markers = []
-        if label == current_target:
-            markers.append("current")
-        if label == previous_target:
+        if v == cur:
+            markers.append("active")
+        if v == prev:
             markers.append("previous")
-        suffix = f"  [{', '.join(markers)}]" if markers else ""
-        manifest_path = ATM_DEV_ROOT / "installs" / label / "manifest.json"
+        manifest_path = ATM_DEV_ROOT / v / "manifest.json"
         branch_info = ""
         if manifest_path.exists():
             try:
                 data = json.loads(manifest_path.read_text())
-                branch_info = f"  branch={data.get('git_branch', '?')}"
+                branch_info = f"  branch={data.get('git_branch','?')}  sha={data.get('git_sha','?')[:7]}"
             except (json.JSONDecodeError, OSError):
                 pass
-        print(f"  {label}{branch_info}{suffix}")
+        suffix = f"  [{', '.join(markers)}]" if markers else ""
+        print(f"  {v}{branch_info}{suffix}")
 
 
-def switch_current(new_prefix: Path) -> None:
-    """Atomically move current -> previous, then set current -> new_prefix."""
-    current = ATM_DEV_ROOT / "current"
-    previous = ATM_DEV_ROOT / "previous"
-
-    if current.is_symlink() or current.exists():
-        if previous.is_symlink() or previous.exists():
-            previous.unlink()
-        os.rename(current, previous)
-        print(f"  moved current -> previous ({os.readlink(previous)})")
-
-    os.symlink(new_prefix, current)
-    print(f"  current -> {new_prefix}")
-
-
-def restart_daemon(prefix: Path) -> None:
-    """Restart the ATM daemon using the dev environment."""
+def restart_daemon() -> None:
     print("\n[restart daemon]")
-    atm_bin = prefix / "bin" / "atm"
+    atm_bin = BIN_DIR / "atm"
     if not atm_bin.exists():
         die(f"atm binary not found at {atm_bin}")
-    env = dev_env(prefix)
     try:
-        run([str(atm_bin), "daemon", "restart"], env=env)
+        run([str(atm_bin), "daemon", "restart"], env=dev_env())
     except SystemExit:
-        print("  note: daemon restart returned non-zero (may be first-time start)")
+        print("  note: daemon restart returned non-zero (ok)")
 
 
-def verify_install(prefix: Path) -> bool:
-    """Run post-install verification checks. Returns True if all pass."""
+def verify_install() -> bool:
     print("\n[post-install verification]")
-    atm_bin = prefix / "bin" / "atm"
-    env = dev_env(prefix)
+    env = dev_env()
     checks = [
-        ([str(atm_bin), "daemon", "status"], "daemon status"),
-        ([str(atm_bin), "--version"], "atm --version"),
-        ([str(prefix / "bin" / "atm-daemon"), "--version"], "atm-daemon --version"),
-        ([str(prefix / "bin" / "sc-compose"), "--version"], "sc-compose --version"),
+        ([str(BIN_DIR / "atm"), "daemon", "status"], "daemon status"),
+        ([str(BIN_DIR / "atm"), "--version"], "atm --version"),
+        ([str(BIN_DIR / "atm-daemon"), "--version"], "atm-daemon --version"),
+        ([str(BIN_DIR / "sc-compose"), "--version"], "sc-compose --version"),
     ]
     all_pass = True
     for cmd, label in checks:
         try:
-            result = subprocess.run(
-                cmd, check=True, capture_output=True, text=True, env=env
-            )
-            version_line = (result.stdout or result.stderr).strip().splitlines()[0]
-            print(f"  [PASS] {label}: {version_line}")
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+            line = (result.stdout or result.stderr).strip().splitlines()[0]
+            print(f"  [PASS] {label}: {line}")
         except (subprocess.CalledProcessError, FileNotFoundError, IndexError) as exc:
             print(f"  [FAIL] {label}: {exc}")
             all_pass = False
     return all_pass
 
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Switch the active ATM dev install without rebuilding.",
+        description="Switch active ATM dev binaries to a saved backup version.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument(
-        "label",
-        nargs="?",
-        metavar="LABEL",
-        help="install label to activate (e.g. 2026-03-10-6ed6420)",
-    )
-    parser.add_argument(
-        "--list",
-        action="store_true",
-        help="list available installs and exit",
-    )
+    parser.add_argument("label", nargs="?", metavar="LABEL",
+                        help="version label to activate")
+    parser.add_argument("--list", action="store_true",
+                        help="list available versions and exit")
     return parser.parse_args()
 
 
@@ -202,55 +150,52 @@ def main() -> None:
         sys.exit(1)
 
     label = args.label
-    prefix = ATM_DEV_ROOT / "installs" / label
+    src_dir = ATM_DEV_ROOT / label / "bin"
 
-    # ------------------------------------------------------------------
-    # 1. Verify install exists
-    # ------------------------------------------------------------------
     print(f"[dev-use] activating: {label}")
-    if not prefix.is_dir():
-        print(f"error: install not found: {prefix}", file=sys.stderr)
-        print("\nAvailable installs:")
+
+    if not src_dir.is_dir():
+        print(f"error: version not found: {ATM_DEV_ROOT / label}", file=sys.stderr)
+        print()
         show_list()
         sys.exit(1)
 
-    # Verify all binaries are present in the target prefix
-    print("\n[verify binaries]")
+    # Verify source binaries exist
+    print("\n[verify source binaries]")
     for name in BINARIES:
-        binary = prefix / "bin" / name
-        if not binary.exists():
-            die(f"binary missing from install prefix: {binary}")
+        if not (src_dir / name).exists():
+            die(f"binary missing from version backup: {src_dir / name}")
         print(f"  found {name}")
 
-    # ------------------------------------------------------------------
-    # 2. Switch current
-    # ------------------------------------------------------------------
-    print("\n[switch current]")
-    switch_current(prefix)
+    # Save current as previous before switching
+    cur = current_label()
+    if cur != label:
+        (ATM_DEV_ROOT / "previous.txt").write_text(cur + "\n")
 
-    # ------------------------------------------------------------------
-    # 3. Restart daemon
-    # ------------------------------------------------------------------
-    restart_daemon(prefix)
+    # Overwrite active bin/
+    print("\n[install binaries -> ~/.local/atm-dev/bin/]")
+    BIN_DIR.mkdir(parents=True, exist_ok=True)
+    for name in BINARIES:
+        shutil.copy2(src_dir / name, BIN_DIR / name)
+        (BIN_DIR / name).chmod(0o755)
+        print(f"  installed {name}")
 
-    # ------------------------------------------------------------------
-    # 4. Post-install verification
-    # ------------------------------------------------------------------
-    all_pass = verify_install(prefix)
+    # Update current.txt and manifest
+    (ATM_DEV_ROOT / "current.txt").write_text(label + "\n")
+    src_manifest = ATM_DEV_ROOT / label / "manifest.json"
+    if src_manifest.exists():
+        shutil.copy2(src_manifest, ATM_DEV_ROOT / "manifest.json")
 
-    # ------------------------------------------------------------------
-    # 5. Summary
-    # ------------------------------------------------------------------
+    restart_daemon()
+    all_pass = verify_install()
+
     print("\n" + "=" * 60)
-    print(f"dev-use complete")
+    print("dev-use complete")
     print(f"  label:    {label}")
-    print(f"  prefix:   {prefix}")
-    print(f"  ATM_HOME: {ATM_HOME}")
+    print(f"  bin:      {BIN_DIR}")
     print(f"  verification: {'ALL PASS' if all_pass else 'SOME CHECKS FAILED'}")
-    print()
     if not all_pass:
-        print("One or more verification checks failed.")
-        print("To rollback: scripts/dev-rollback")
+        print("\nTo rollback:  scripts/dev-rollback")
         sys.exit(1)
 
 


### PR DESCRIPTION
## Summary

- Adds `scripts/dev-install` — builds ATM from source, saves versioned backup, overwrites `~/.local/atm-dev/bin/` in place, restarts daemon, runs verification
- Adds `scripts/dev-use` — switches active install to a saved backup version (no session restart needed)
- Adds `scripts/dev-rollback` — rolls back to previous version using `previous.txt`
- Updates `.env` with `ATM_DEV_ROOT`, `ATM_HOME`, `ATM_DAEMON_BIN`, `ATM_CHANNEL=dev`

## Design

Flat `~/.local/atm-dev/bin/` layout — always on PATH, files overwritten in place on upgrade. Versioned backups stored under `~/.local/atm-dev/<label>/bin/` for rollback without PATH changes. Only a daemon restart is needed to switch versions.

No symlinks. No session/tmux restarts required.

## Scripts

| Script | Purpose |
|--------|---------|
| `dev-install` | Build + install to `~/.local/atm-dev/bin/`, backup previous |
| `dev-use <label>` | Switch to a saved backup version |
| `dev-rollback` | Roll back to previous version |

## Test plan
- [ ] Run `scripts/dev-install --allow-dirty --skip-build` (uses existing `target/release/` binaries)
- [ ] Verify `~/.local/atm-dev/bin/atm --version` shows installed version
- [ ] Run `scripts/dev-use --list` to see saved versions
- [ ] Add `source ~/.local/atm-dev/env.sh` to `~/.zshrc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)