### PR TITLE
fix(daemon): abort timed-out shutdown tasks to resolve SIGTERM stop-path hang (#669)

### DIFF
--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -34,6 +34,17 @@ fn new_reconcile_cycle_state() -> SharedCycleState {
     Arc::new(std::sync::Mutex::new(ReconcileCycleState::default()))
 }
 
+/// Wait for a daemon shutdown task to finish within `timeout`.
+///
+/// Shutdown tasks are expected to honor the shared [`CancellationToken`] and
+/// exit promptly once cancellation is requested. `abort()` is a last-resort
+/// fallback used only after the cooperative timeout has expired.
+///
+/// This helper is intentionally status-agnostic. Non-plugin callers use it for
+/// internal daemon tasks where the only required behavior is bounded shutdown
+/// latency plus best-effort logging. Plugin degraded-state transitions remain
+/// the responsibility of plugin lifecycle/status code, not this generic join
+/// helper.
 async fn wait_for_shutdown_task<T>(task_name: &str, mut handle: JoinHandle<T>, timeout: Duration)
 where
     T: Send + 'static,

--- a/crates/atm-daemon/src/daemon/shutdown.rs
+++ b/crates/atm-daemon/src/daemon/shutdown.rs
@@ -8,8 +8,16 @@ use tracing::{error, info, warn};
 
 /// Perform graceful shutdown of all plugins.
 ///
-/// Calls shutdown() on each plugin with a timeout. If any plugin exceeds the
-/// timeout, it's logged as a warning and shutdown continues for remaining plugins.
+/// Calls `shutdown()` on each plugin sequentially with a per-plugin timeout.
+/// Worst-case shutdown latency for this phase is therefore `plugins.len() *
+/// shutdown_timeout` when every plugin stalls until timeout.
+///
+/// This function intentionally preserves bounded forward progress over perfect
+/// plugin cleanup. If any plugin exceeds the timeout, it is logged as a warning
+/// and shutdown continues for remaining plugins.
+///
+/// TODO(#539): evaluate parallel plugin shutdown so the worst-case latency is
+/// bounded by one timeout window instead of `N * shutdown_timeout`.
 ///
 /// # Arguments
 ///

--- a/docs/adr/issue-539-stale-daemon-fix-plan.md
+++ b/docs/adr/issue-539-stale-daemon-fix-plan.md
@@ -1,0 +1,81 @@
+# Issue #539 Fix Plan: Stale Daemon Shutdown and Recovery
+
+Date: 2026-03-11  
+Status: revised after partial delivery  
+Related Issues: #539, #669
+
+## 1. Problem Statement
+
+Daemon restart reliability work under issue `#539` was originally described as a
+single Layer 2 shutdown-hardening bucket. QA correctly called out that the
+implementation delivered in `#669` only covers part of that scope.
+
+We now split Layer 2 into delivered vs deferred items so the ADR matches the
+actual code in `develop`.
+
+## 2. Layer 2 Scope Split
+
+### 2.1 Delivered in `#669`
+
+Delivered behavior:
+- daemon shutdown waits for internal background tasks with a bounded timeout
+- timed-out tasks are explicitly aborted after the cooperative wait expires
+- plugin `run()` tasks now use the same bounded wait-and-abort behavior during
+  daemon shutdown
+
+Delivered rationale:
+- SIGTERM shutdown was previously allowed to log timeouts and continue without
+  aborting stuck tasks
+- that left hung tasks alive during teardown and contributed to restart flake
+
+Delivered verification:
+- `event_loop::tests::test_wait_for_shutdown_task_aborts_timed_out_task`
+- `event_loop::tests::test_wait_for_shutdown_task_allows_completed_task`
+
+### 2.2 Deferred from original Layer 2
+
+Deferred items:
+- watchdog thread/process that escalates when the main shutdown path wedges
+- explicit double-signal exit flow for repeated termination requests
+
+Deferred status:
+- not implemented by `#669`
+- remain tracked as follow-up work under issue `#539`
+
+Reason for deferral:
+- the immediate blocker was unbounded task lifetime after SIGTERM
+- abort-on-timeout is the smallest change that restores bounded stop-path
+  behavior without mixing in a second supervisor design
+
+## 3. Updated Layer 2 Data Flow
+
+```
+SIGTERM received
+  -> cancel shared CancellationToken
+  -> wait for daemon background tasks (bounded)
+     -> abort timed-out daemon tasks
+  -> graceful_shutdown(plugins, timeout per plugin)
+  -> wait for plugin run() tasks (bounded)
+     -> abort timed-out plugin run() tasks
+  -> final status/log flush best effort
+  -> process exit
+```
+
+The `plugin run()` task wait occurs after `graceful_shutdown(...)` because the
+plugin first gets a cooperative shutdown callback and then its long-running
+task is given a bounded window to observe cancellation and exit.
+
+## 4. Open Items
+
+Still open after `#669`:
+- design watchdog ownership and escalation rules
+- define repeated-signal behavior (`SIGTERM`/second signal/forced exit)
+- decide whether plugin shutdown should become parallel instead of sequential
+
+## 5. Consequences
+
+- The ADR now matches the code that actually shipped.
+- Reviewers can distinguish the delivered bounded-abort work from the deferred
+  watchdog/escalation work.
+- Future shutdown-hardening PRs can target the remaining Layer 2 items without
+  reopening already-delivered task-abort behavior.

--- a/docs/adr/issue-669-sigterm-stop-path.md
+++ b/docs/adr/issue-669-sigterm-stop-path.md
@@ -1,0 +1,84 @@
+# ADR: Issue #669 SIGTERM Stop-Path Fix
+
+- Status: Accepted
+- Date: 2026-03-11
+- Sprint: `fix/issue-669-sigterm-stop-path`
+- Related Issues: #669, #539
+
+## Context
+
+`atm daemon restart` could stop the old daemon with SIGTERM, but shutdown still
+allowed internal daemon tasks and plugin `run()` tasks to outlive the bounded
+wait window. The event loop logged a timeout and then continued, leaving stuck
+tasks alive and making restart behavior flaky.
+
+## Root Cause
+
+The daemon shutdown path had a cooperative timeout but no enforced termination
+for timed-out tasks:
+
+- internal daemon background tasks were waited with `tokio::time::timeout(...)`
+  and then only logged on timeout
+- plugin `run()` tasks were joined after `graceful_shutdown(...)`, but a stuck
+  task could still extend or wedge total shutdown progress
+
+That meant SIGTERM did not guarantee bounded teardown once a task stopped
+observing cancellation.
+
+## Decision
+
+Introduce a shared shutdown helper that:
+- waits for a task to finish within a fixed timeout
+- aborts the task if the timeout expires
+- awaits the post-abort join result for logging/cleanup
+
+Use that helper for:
+- spool task
+- watcher task
+- dispatch task
+- retention task
+- status writer task
+- reconcile task
+- plugin `run()` tasks after `graceful_shutdown(...)`
+
+## Timeout Rationale
+
+The chosen timeout is `5s`.
+
+Why `5s`:
+- long enough for cooperative cancellation and final flush/cleanup on normal
+  shutdown
+- short enough to keep restart and operator recovery bounded when a task wedges
+- already consistent with the stop-path behavior expected by current dogfood
+  restart checks
+
+This is a bounded-shutdown contract, not a promise that every task gets an
+unlimited cleanup window.
+
+## Relationship to Issue #539
+
+`#669` delivers only the task-abort portion of the broader stale-daemon/shutdown
+hardening work described under `#539`.
+
+Delivered here:
+- bounded wait for daemon background tasks
+- bounded wait for plugin `run()` tasks
+- abort-after-timeout when cooperative cancellation is ignored
+
+Still open under `#539`:
+- watchdog thread/process
+- double-signal exit/escalation behavior
+- possible parallel plugin shutdown
+
+## What Remains Open
+
+- sequential plugin `shutdown()` still has worst-case `N * timeout` latency
+- plugin degraded-state reporting still happens in plugin lifecycle/status code,
+  not in the generic shutdown helper
+- final end-to-end restart verification must still be exercised from a normal
+  shell/session because the Codex harness is noisy for detached-child lifetime
+
+## Verification
+
+- `cargo test -p agent-team-mail-daemon event_loop::tests::test_wait_for_shutdown_task_aborts_timed_out_task`
+- `cargo test -p agent-team-mail-daemon event_loop::tests::test_wait_for_shutdown_task_allows_completed_task`


### PR DESCRIPTION
## Summary

- Daemon event loop now aborts background/plugin tasks that miss the shutdown deadline instead of only logging timeout and leaving them running
- This was the primary credible source of the SIGTERM hang observed during dogfood restart testing
- Focused unit tests pass: `test_wait_for_shutdown_task_aborts_timed_out_task` and `test_wait_for_shutdown_allows_completed_task`

## Test Plan

- [x] Unit tests: `cargo test -p agent-team-mail-daemon event_loop::tests`
- [ ] Live restart QA from normal shell/session (not from Codex harness)

## Related

- Closes #669
- Related: #539 (broader stale daemon accumulation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)