### PR TITLE
chore: bump workspace version 0.44.0 → 0.44.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "anyhow",
  "blake3",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -224,9 +224,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert_cmd"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5bcfa8749ac45dd12cb11055aeeb6b27a3895560d60d71e3c23bf979e60514"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
 dependencies = [
  "anstyle",
  "bstr",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "minijinja",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.44.0"
+version = "0.44.5"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.44.0"
+version = "0.44.5"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.0" }
-sc-composer = { path = "crates/sc-composer", version = "=0.44.0" }
-sc-observability = { path = "crates/sc-observability", version = "=0.44.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.5" }
+sc-composer = { path = "crates/sc-composer", version = "=0.44.5" }
+sc-observability = { path = "crates/sc-observability", version = "=0.44.5" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.44.0" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.44.5" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.44.0" }
+sc-composer = { path = "../sc-composer", version = "=0.44.5" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bumps workspace version from 0.44.0 to 0.44.5 to match dev-install milestone
- Updates pinned dependency versions in `crates/atm-tui/Cargo.toml` and `crates/sc-compose/Cargo.toml`
- Regenerates `Cargo.lock`

## Motivation
Version SSoT: `atm --version` must match the active dev-install milestone (0.44.5) to prevent mistakes during dogfood testing. Without this bump, `atm --version` reports 0.44.0 while the milestone tracker shows 0.44.4/0.44.5.

## Test plan
- [ ] CI green
- [ ] `atm --version` reports `0.44.5` after dev-install
- [ ] `atm doctor` shows `Install milestone: 0.44.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)