### PR TITLE
fix: merge conflict UX, CALLER doc comments, Dead+hint test coverage (#652 #645 #656)

### DIFF
--- a/crates/atm-daemon/src/daemon/socket.rs
+++ b/crates/atm-daemon/src/daemon/socket.rs
@@ -5727,7 +5727,9 @@ fn bootstrap_session_from_member_hint(
 ) {
     if session_registry
         .query_for_team(team, &member.name)
-        .is_some()
+        .is_some_and(|session| {
+            session.state == crate::daemon::session_registry::SessionState::Active
+        })
     {
         return;
     }
@@ -6991,6 +6993,104 @@ notify_target = "team-lead"
         assert!(
             reg.query_for_team("atm-dev", "arch-ctm").is_none(),
             "bootstrap must not fabricate synthetic session IDs when sessionId hint is missing"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_list_agents_dead_session_without_hint_stays_dead() {
+        let _fixture = setup_hook_auth_fixture("atm-dev", "team-lead", &["team-lead", "arch-ctm"]);
+        let home = std::env::var("ATM_HOME").expect("ATM_HOME set by fixture");
+        let config_path = std::path::Path::new(&home).join(".claude/teams/atm-dev/config.json");
+        let mut cfg: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let members = cfg["members"].as_array_mut().unwrap();
+        let target = members
+            .iter_mut()
+            .find(|m| m["name"].as_str() == Some("arch-ctm"))
+            .expect("arch-ctm in config");
+        target["processId"] = serde_json::json!(std::process::id());
+        target.as_object_mut().unwrap().remove("sessionId");
+        target["externalBackendType"] = serde_json::json!("external");
+        std::fs::write(&config_path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+
+        let store = make_store();
+        let sr = make_sr();
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.upsert_for_team("atm-dev", "arch-ctm", "dead-session-1", std::process::id());
+            let outcome = reg.mark_dead_for_team_session("atm-dev", "arch-ctm", "dead-session-1");
+            assert_eq!(
+                outcome,
+                crate::daemon::session_registry::MarkDeadForSessionOutcome::MarkedDead
+            );
+        }
+
+        let req = make_request("list-agents", serde_json::json!({"team": "atm-dev"}));
+        let resp = handle_list_agents(&req, &store, &sr);
+        assert_eq!(resp.status, "ok");
+
+        let reg = sr.lock().unwrap();
+        let session = reg
+            .query_for_team("atm-dev", "arch-ctm")
+            .expect("dead session should remain present");
+        assert_eq!(session.session_id, "dead-session-1");
+        assert_eq!(
+            session.state,
+            crate::daemon::session_registry::SessionState::Dead
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_list_agents_dead_session_with_valid_hint_reactivates() {
+        let _fixture = setup_hook_auth_fixture("atm-dev", "team-lead", &["team-lead", "arch-ctm"]);
+        let home = std::env::var("ATM_HOME").expect("ATM_HOME set by fixture");
+        let config_path = std::path::Path::new(&home).join(".claude/teams/atm-dev/config.json");
+        let mut cfg: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+        let members = cfg["members"].as_array_mut().unwrap();
+        let target = members
+            .iter_mut()
+            .find(|m| m["name"].as_str() == Some("arch-ctm"))
+            .expect("arch-ctm in config");
+        target["processId"] = serde_json::json!(std::process::id());
+        target["sessionId"] = serde_json::json!("hint-session-2");
+        target["externalBackendType"] = serde_json::json!("external");
+        std::fs::write(&config_path, serde_json::to_string_pretty(&cfg).unwrap()).unwrap();
+
+        let store = make_store();
+        let sr = make_sr();
+        {
+            let mut reg = sr.lock().unwrap();
+            reg.upsert_for_team("atm-dev", "arch-ctm", "dead-session-1", std::process::id());
+            let outcome = reg.mark_dead_for_team_session("atm-dev", "arch-ctm", "dead-session-1");
+            assert_eq!(
+                outcome,
+                crate::daemon::session_registry::MarkDeadForSessionOutcome::MarkedDead
+            );
+        }
+
+        let req = make_request("list-agents", serde_json::json!({"team": "atm-dev"}));
+        let resp = handle_list_agents(&req, &store, &sr);
+        assert_eq!(resp.status, "ok");
+        let arr = resp.payload.unwrap().as_array().unwrap().clone();
+        let member = arr
+            .iter()
+            .find(|a| a["agent"].as_str() == Some("arch-ctm"))
+            .expect("arch-ctm entry missing");
+        assert_eq!(member["state"].as_str(), Some("active"));
+        assert_eq!(member["session_id"].as_str(), Some("hint-session-2"));
+
+        let reg = sr.lock().unwrap();
+        let session = reg
+            .query_for_team("atm-dev", "arch-ctm")
+            .expect("session registry reactivated from member hint");
+        assert_eq!(session.session_id, "hint-session-2");
+        assert_eq!(session.process_id, std::process::id());
+        assert_eq!(
+            session.state,
+            crate::daemon::session_registry::SessionState::Active
         );
     }
 

--- a/crates/atm/src/commands/gh.rs
+++ b/crates/atm/src/commands/gh.rs
@@ -964,15 +964,11 @@ fn print_pr_list_summary(summary: &GhPrListSummary) {
 
     for item in &summary.items {
         let draft = if item.draft { "draft" } else { "ready" };
-        let ci_label = format!(
-            "{} {}/{}",
-            item.ci.state.to_uppercase(),
-            item.ci.pass,
-            ci_effective_total(&item.ci)
-        );
+        let ci_label = render_pr_list_ci_label(&item.ci, &item.merge);
+        let merge_label = render_pr_list_merge_label(&item.merge);
         println!(
             "#{} [{}] [ci:{}] [merge:{}] [review:{}] {}",
-            item.number, draft, ci_label, item.merge, item.review, item.title
+            item.number, draft, ci_label, merge_label, item.review, item.title
         );
     }
 }
@@ -1049,6 +1045,33 @@ fn print_pr_report_summary(report: &GhPrReportSummary) {
 
 fn ci_effective_total(ci: &GhCiRollup) -> u64 {
     ci.total.saturating_sub(ci.skip)
+}
+
+fn is_merge_conflict_status(merge: &str) -> bool {
+    matches!(
+        merge.trim().to_ascii_lowercase().as_str(),
+        "dirty" | "conflicting" | "conflict"
+    )
+}
+
+fn render_pr_list_merge_label(merge: &str) -> String {
+    if is_merge_conflict_status(merge) {
+        "CONFLICT ⚠".to_string()
+    } else {
+        merge.to_string()
+    }
+}
+
+fn render_pr_list_ci_label(ci: &GhCiRollup, merge: &str) -> String {
+    if ci.state == "fail" && is_merge_conflict_status(merge) && ci.fail > 0 && ci.pass == 0 {
+        return "BLOCKED — merge conflict".to_string();
+    }
+    format!(
+        "{} {}/{}",
+        ci.state.to_uppercase(),
+        ci.pass,
+        ci_effective_total(ci)
+    )
 }
 
 fn render_ci_summary(ci: &GhCiRollup) -> String {
@@ -2057,6 +2080,39 @@ mod tests {
                 .iter()
                 .any(|reason| reason.contains("UNKNOWN"))
         );
+    }
+
+    #[test]
+    fn render_pr_list_labels_highlight_merge_conflicts() {
+        let ci = GhCiRollup {
+            state: "fail".to_string(),
+            total: 1,
+            pass: 0,
+            fail: 1,
+            pending: 0,
+            skip: 0,
+            neutral: 0,
+        };
+        assert_eq!(render_pr_list_merge_label("dirty"), "CONFLICT ⚠");
+        assert_eq!(
+            render_pr_list_ci_label(&ci, "dirty"),
+            "BLOCKED — merge conflict"
+        );
+    }
+
+    #[test]
+    fn render_pr_list_labels_preserve_non_conflict_ci_summary() {
+        let ci = GhCiRollup {
+            state: "pending".to_string(),
+            total: 2,
+            pass: 1,
+            fail: 0,
+            pending: 1,
+            skip: 0,
+            neutral: 0,
+        };
+        assert_eq!(render_pr_list_merge_label("clean"), "clean");
+        assert_eq!(render_pr_list_ci_label(&ci, "clean"), "PENDING 1/2");
     }
 
     #[test]

--- a/crates/atm/src/util/caller_identity.rs
+++ b/crates/atm/src/util/caller_identity.rs
@@ -13,7 +13,11 @@ use std::process::Command;
 use crate::util::hook_identity::{read_hook_file, read_session_file};
 use crate::util::settings::get_home_dir;
 
+/// Returned when multiple caller/session resolution candidates remain valid
+/// and ATM cannot choose one canonical caller identity automatically.
 pub const CALLER_AMBIGUOUS: &str = "CALLER_AMBIGUOUS";
+/// Returned when caller/session resolution exhausts all supported sources
+/// without finding a canonical caller identity.
 pub const CALLER_UNRESOLVED: &str = "CALLER_UNRESOLVED";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -1318,7 +1318,9 @@ fn test_gh_monitor_list_human_output_has_one_line_rollups() {
     let text = String::from_utf8(output).unwrap();
     assert!(text.contains("GitHub PR List: atm gh pr list"));
     assert!(text.contains("#101 [ready] [ci:PENDING 1/2] [merge:clean] [review:approved]"));
-    assert!(text.contains("#102 [draft] [ci:FAIL 0/1] [merge:dirty] [review:changes_requested]"));
+    assert!(text.contains(
+        "#102 [draft] [ci:BLOCKED — merge conflict] [merge:CONFLICT ⚠] [review:changes_requested]"
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **#652**: `atm gh pr list` now renders `[merge:CONFLICT ⚠]` and `[ci:BLOCKED — merge conflict]` for visually distinct merge conflict signaling
- **#645**: Added `///` doc comments to `CALLER_AMBIGUOUS` and `CALLER_UNRESOLVED` in `caller_identity.rs`
- **#656**: Fixed member-hint bootstrap so dead records only reactivate on valid session hint; added regression coverage for both cases

## Validation
- `cargo test --workspace` PASS
- `cargo clippy --all-targets --all-features -- -D warnings` PASS

Closes #652, #645, #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)