### PR TITLE
Fix degraded spooling canonical log path

### DIFF
--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -1467,6 +1467,13 @@ fn spool_metrics(spool_path: &Path) -> std::io::Result<(u64, Option<u64>)> {
         if !file_type.is_file() {
             continue;
         }
+        if !entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| name.ends_with(".jsonl"))
+        {
+            continue;
+        }
 
         spool_count += 1;
 
@@ -1655,6 +1662,20 @@ mod tests {
         assert_eq!(snapshot.state, "degraded_spooling");
         assert!(snapshot.spool_count >= 1);
         assert!(snapshot.oldest_spool_age.is_some());
+    }
+
+    #[test]
+    fn test_build_logging_health_snapshot_ignores_claiming_files() {
+        let tmp = TempDir::new().expect("temp dir");
+        let spool_dir = agent_team_mail_core::logging_event::configured_spool_dir(tmp.path());
+        stdfs::create_dir_all(&spool_dir).expect("mkdir spool");
+        stdfs::write(spool_dir.join("atm-1-1.jsonl"), "{\"v\":1}\n").expect("write spool file");
+        stdfs::write(spool_dir.join("atm-1-1.claiming"), "{\"v\":1}\n")
+            .expect("write claiming file");
+
+        let snapshot = build_logging_health_snapshot(tmp.path(), 0, false);
+        assert_eq!(snapshot.state, "degraded_spooling");
+        assert_eq!(snapshot.spool_count, 1);
     }
 
     #[test]

--- a/crates/atm-daemon/src/daemon/log_writer.rs
+++ b/crates/atm-daemon/src/daemon/log_writer.rs
@@ -21,7 +21,7 @@
 //! renames existing rotated files (`base.1` → `base.2` → … → `base.N`) and
 //! starts a fresh base file. The oldest rotation file (`.N`) is removed.
 
-use agent_team_mail_core::logging_event::LogEventV1;
+use agent_team_mail_core::logging_event::{LogEventV1, configured_log_path};
 use sc_observability::{DEFAULT_QUEUE_CAPACITY, export_otel_best_effort_from_path};
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};
@@ -120,7 +120,7 @@ pub fn new_log_event_queue() -> LogEventQueue {
 
 /// Configuration for the [`run_log_writer_task`] async writer.
 pub struct LogWriterConfig {
-    /// Path to the base JSONL log file (e.g. `~/.config/atm/atm.log.jsonl`).
+    /// Path to the base JSONL log file (e.g. `~/.config/atm/logs/atm/atm.log.jsonl`).
     pub log_path: PathBuf,
     /// Rotate when the file reaches this size in bytes (default: 50 MiB).
     pub max_bytes: u64,
@@ -135,20 +135,20 @@ impl LogWriterConfig {
     ///
     /// | Variable              | Default                                  |
     /// |-----------------------|------------------------------------------|
-    /// | `ATM_LOG_FILE`        | `{home_dir}/.config/atm/atm.log.jsonl`  |
+    /// | `ATM_LOG_FILE`        | `{home_dir}/.config/atm/logs/atm/atm.log.jsonl` |
     /// | `ATM_LOG_PATH`        | alias for `ATM_LOG_FILE` (compat)        |
     /// | `ATM_LOG_MAX_BYTES`   | 52428800 (50 MiB)                        |
     /// | `ATM_LOG_MAX_FILES`   | 5                                        |
     /// | `ATM_LOG_FLUSH_MS`    | 100                                      |
     ///
     /// `ATM_LOG_FILE` takes precedence over `ATM_LOG_PATH`. When neither is
-    /// set the log is written to `{home_dir}/.config/atm/atm.log.jsonl`.
+    /// set the log is written to `{home_dir}/.config/atm/logs/atm/atm.log.jsonl`.
     pub fn from_env(home_dir: &Path) -> Self {
         // Check ATM_LOG_FILE first (canonical), then ATM_LOG_PATH (compat alias).
         let log_path = std::env::var("ATM_LOG_FILE")
             .or_else(|_| std::env::var("ATM_LOG_PATH"))
             .map(PathBuf::from)
-            .unwrap_or_else(|_| home_dir.join(".config/atm/atm.log.jsonl"));
+            .unwrap_or_else(|_| configured_log_path(home_dir));
 
         let max_bytes = std::env::var("ATM_LOG_MAX_BYTES")
             .ok()
@@ -487,10 +487,7 @@ mod tests {
         // Use a temp dir as the home dir.
         let dir = TempDir::new().expect("temp dir");
         let config = LogWriterConfig::from_env(dir.path());
-        assert_eq!(
-            config.log_path,
-            dir.path().join(".config/atm/atm.log.jsonl")
-        );
+        assert_eq!(config.log_path, configured_log_path(dir.path()));
         assert_eq!(config.max_bytes, 50 * 1024 * 1024);
         assert_eq!(config.max_files, 5);
         assert_eq!(config.flush_interval_ms, 100);

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<()> {
     // This runs before the socket server starts so no new spool files can arrive
     // from this daemon instance during the merge window.
     {
-        let spool_dir = agent_team_mail_core::logging_event::spool_dir(&home_dir);
+        let spool_dir = agent_team_mail_core::logging_event::configured_spool_dir(&home_dir);
         match agent_team_mail_daemon::daemon::spool_merge::merge_spool_on_startup(
             &spool_dir, &log_file,
         ) {

--- a/crates/atm-daemon/tests/test_spool_merge.rs
+++ b/crates/atm-daemon/tests/test_spool_merge.rs
@@ -222,6 +222,25 @@ fn test_merge_skips_unparseable_lines() {
 }
 
 #[test]
+fn test_merge_writes_to_configured_canonical_log_path() {
+    let tmp = TempDir::new().unwrap();
+    let spool_dir = agent_team_mail_core::logging_event::configured_spool_dir(tmp.path());
+    fs::create_dir_all(&spool_dir).unwrap();
+    let log_path = agent_team_mail_core::logging_event::configured_log_path(tmp.path());
+
+    let event = new_log_event("atm", "daemon_start", "atm_daemon::main", "info");
+    write_spool_file(&spool_dir, "atm-1-100.jsonl", &[event]);
+
+    let merged = merge_spool_on_startup(&spool_dir, &log_path).unwrap();
+    assert_eq!(merged, 1);
+    assert!(log_path.exists(), "configured canonical log should be created");
+    assert!(
+        spool_jsonl_files(&spool_dir).is_empty(),
+        "configured spool directory should be drained after merge"
+    );
+}
+
+#[test]
 fn test_merge_events_sorted_by_timestamp() {
     let tmp = TempDir::new().unwrap();
     let spool_dir = tmp.path().join("spool");

--- a/docs/adr/issue-679-logging-spool-merge-root-cause.md
+++ b/docs/adr/issue-679-logging-spool-merge-root-cause.md
@@ -1,0 +1,101 @@
+---
+issue: 679
+title: "degraded_spooling: LogWriterConfig default path diverges from configured_log_path SSoT"
+date: 2026-03-12
+worktree: fix/issue-679-spool-merge
+status: ready-to-implement
+---
+
+# Issue #679: degraded_spooling Root Cause & Fix Blueprint
+
+## Root Cause
+
+**Path mismatch** between two independent defaults for the canonical log location:
+
+| Location | Default path produced |
+|----------|-----------------------|
+| `log_writer.rs:148-151` (`LogWriterConfig::from_env`) | `{home}/.config/atm/atm.log.jsonl` |
+| `logging_event.rs:620` (`configured_log_path`) | `{home}/.config/atm/logs/atm/atm.log.jsonl` |
+
+`merge_spool_on_startup` and `run_log_writer_task` use `LogWriterConfig` → write to the **wrong path**. The health check (`build_logging_health_snapshot`) uses `configured_log_path` → reads from the **correct path** and finds no file.
+
+Secondary: `spool_metrics` counts ALL files in the spool directory including `.claiming` transient lock files, inflating the pending count.
+
+## Failure Sequence
+
+1. Producer writes spool files to `~/.config/atm/logs/atm/spool/*.jsonl` while daemon offline.
+2. Daemon starts. `merge_spool_on_startup` claims files (→ `.claiming`), reads events.
+3. `append_events_to_log` writes to wrong path `~/.config/atm/atm.log.jsonl` — succeeds but misplaced.
+4. `.claiming` files deleted. Spool dir empty briefly.
+5. Any new producer activity → new spool files. No periodic merge → accumulate indefinitely.
+6. `spool_metrics` sees pending files → `degraded_spooling` forever.
+
+## Fixes
+
+### Change 1 (Primary) — `log_writer.rs:148`
+
+```rust
+// BEFORE:
+.unwrap_or_else(|_| home_dir.join(".config/atm/atm.log.jsonl"));
+
+// AFTER:
+.unwrap_or_else(|_| {
+    agent_team_mail_core::logging_event::configured_log_path(home_dir)
+});
+```
+
+No `Cargo.toml` changes needed — `agent_team_mail_core` already a dependency of `atm-daemon`.
+
+### Change 2 (Secondary) — `event_loop.rs:1467` in `spool_metrics`
+
+After the `is_file()` check, add `.jsonl` extension filter:
+
+```rust
+if !entry.file_name().to_str().map(|n| n.ends_with(".jsonl")).unwrap_or(false) {
+    continue;
+}
+```
+
+### Change 3 (Defensive) — `main.rs:112`
+
+Use `configured_spool_dir` instead of `spool_dir` for explicit SSoT alignment (functionally equivalent when no env vars set, but makes intent clear).
+
+## Tests to Add
+
+**Test 1** (`log_writer.rs` test module):
+```rust
+fn log_writer_config_default_matches_configured_log_path()
+// Assert: LogWriterConfig::from_env(home).log_path == configured_log_path(home)
+```
+
+**Test 2** (`event_loop.rs` test module):
+```rust
+fn test_spool_metrics_ignores_claiming_files()
+// Setup: 1 .jsonl + 1 .claiming in spool dir
+// Assert: snapshot.spool_count == 1
+```
+
+**Test 3** (`tests/test_spool_merge.rs`):
+```rust
+fn test_merge_clears_degraded_spooling_state()
+// Full end-to-end: write spool file → merge → assert canonical log at configured_log_path → spool empty
+```
+
+## Implementation Checklist
+
+- [ ] Change 1: `log_writer.rs:148` — use `configured_log_path(home_dir)`
+- [ ] Change 2: `event_loop.rs` `spool_metrics` — filter `.jsonl` only
+- [ ] Change 3: `main.rs:112` — use `configured_spool_dir`
+- [ ] Test 1: path alignment unit test
+- [ ] Test 2: `.claiming` filter unit test
+- [ ] Test 3: end-to-end integration test
+- [ ] `cargo test --workspace` — no regressions
+- [ ] Manual verify: `atm doctor --json | jq '.logging_health.state'` → `"healthy"`
+
+## Backward Compatibility
+
+Old canonical log at `~/.config/atm/atm.log.jsonl` is orphaned (no tool ever read it via `configured_log_path`). Harmless. Changelog note recommended.
+
+## Self-Healing
+
+`degraded_spooling` state is derived on every 5s status tick. Once spool files are cleared, state self-heals on the next tick — no explicit reset needed.


### PR DESCRIPTION
## Summary
- align daemon log writer defaults with the canonical logging path helper
- ignore transient .claiming files in spool health metrics
- add ADR and regression coverage for configured spool/log merge behavior

## Testing
- cargo test -p agent-team-mail-daemon --lib test_log_writer_config_from_env -- --nocapture
- cargo test -p agent-team-mail-daemon --lib test_build_logging_health_snapshot_ignores_claiming_files -- --nocapture
- cargo test -p agent-team-mail-daemon --test test_spool_merge -- --nocapture
- cargo test -p agent-team-mail-daemon --lib --tests
- cargo clippy --all-targets --all-features -- -D warnings

## Notes
- 
running 342 tests
test commands::broadcast::tests::test_generate_summary_whitespace ... ok
test commands::broadcast::tests::test_generate_summary_short ... ok
test commands::daemon::tests::test_is_status_stale_invalid ... ok
test commands::daemon::tests::test_format_duration ... ok
test commands::broadcast::tests::test_generate_summary_long ... ok
test commands::daemon::tests::test_is_status_stale_fresh ... ok
test commands::daemon::tests::test_is_status_stale_old ... ok
test commands::doctor::tests::build_recommendations_routes_active_without_session_to_cleanup_with_context ... ok
test commands::doctor::tests::build_recommendations_includes_daemon_start_for_unreachable ... ok
test commands::doctor::tests::build_recommendations_includes_daemon_start ... ok
test commands::doctor::tests::build_recommendations_routes_active_without_session_to_cleanup ... ok
test commands::doctor::tests::build_recommendations_routes_active_without_session_to_cleanup_without_context ... ok
test commands::doctor::tests::build_recommendations_routes_lead_recovery_to_register_only ... ok
test commands::doctor::tests::build_recommendations_routes_non_lead_teardown_to_cleanup ... ok
test commands::doctor::tests::check_config_runtime_drift_flags_env_mismatch ... ok
test commands::doctor::tests::check_pid_session_reconciliation_detects_ghost_session_for_inactive_hint ... ok
test commands::doctor::tests::check_pid_session_reconciliation_ignores_foreign_state_entries ... ok
test commands::doctor::tests::check_pid_session_reconciliation_query_error_maps_to_active_without_session ... ok
test commands::doctor::tests::build_member_snapshot_includes_daemon_only_members_as_unregistered ... ok
test commands::doctor::tests::check_pid_session_reconciliation_query_none_maps_to_daemon_unreachable ... ok
test commands::doctor::tests::check_pid_session_reconciliation_reports_pid_mismatch_for_daemon_only_state ... ok
test commands::doctor::tests::check_roster_session_integrity_excludes_other_teams_when_scoped ... ok
test commands::doctor::tests::check_roster_session_integrity_ignores_foreign_team_name_collision ... ok
test commands::doctor::tests::count_findings_counts_all_levels ... ok
test commands::doctor::tests::format_session_short_always_uses_8_char_prefix ... ok
test commands::doctor::tests::doctor_json_schema_includes_members_and_excludes_member_snapshot ... ok
test commands::doctor::tests::check_mailbox_integrity_classifies_dead_team_lead_as_recovery_warning ... ok
test commands::doctor::tests::format_session_short_returns_unchanged_when_shorter_than_8_chars ... ok
test commands::doctor::tests::parse_pid_backend_mismatch_reason_extracts_expected_fields ... ok
test commands::doctor::tests::parse_since_input_accepts_positive_durations ... ok
test commands::doctor::tests::parse_since_input_rejects_negative_duration ... ok
test commands::doctor::tests::check_mailbox_integrity_keeps_dead_non_lead_as_critical_cleanup_finding ... ok
test commands::doctor::tests::parse_since_input_rejects_zero_duration ... ok
test commands::doctor::tests::parse_since_input_supports_rfc3339 ... ok
test commands::doctor::tests::parse_since_input_supports_duration ... ok
test commands::doctor::tests::render_human_includes_active_env_overrides ... ok
test commands::doctor::tests::compute_log_window_since_timestamp_sets_timestamp_mode ... ok
test commands::doctor::tests::render_human_members_mixed_session_formats_display_consistent_short_values ... ok
test commands::doctor::tests::render_human_members_use_short_session_ids_while_snapshot_keeps_full ... ok
test commands::doctor::tests::render_human_places_member_snapshot_before_findings ... ok
test commands::doctor::tests::render_log_window_human_uses_elapsed_labels ... ok
test commands::doctor::tests::snapshot_status_from_canonical_state_maps_active_offline_unknown ... ok
test commands::doctor::tests::check_log_diagnostics_non_errors_only_emits_no_events_info ... ok
test commands::gh::tests::build_merge_report_unknown_mergeability_is_indeterminate_not_blocking ... ok
test commands::gh::tests::extract_check_reports_maps_check_run_and_context_fields ... ok
test commands::gh::tests::normalize_merge_status_maps_unknown_to_pending ... ok
test commands::gh::tests::extract_review_reports_maps_reviewer_state_and_timestamp ... ok
test commands::gh::tests::normalize_report_review_decision_maps_empty_to_none_when_no_reviews ... ok
test commands::gh::tests::render_pr_list_labels_highlight_merge_conflicts ... ok
test commands::gh::tests::render_pr_list_labels_preserve_non_conflict_ci_summary ... ok
test commands::doctor::tests::compute_log_window_since_duration_sets_duration_mode ... ok
test commands::doctor::tests::check_log_diagnostics_errors_only_suppresses_no_events_info ... ok
test commands::gh::tests::resolve_repo_coordinates_accepts_owner_repo ... ok
test commands::doctor::tests::logging_health_contract_matches_canonical_schema ... ok
test commands::gh::tests::resolve_repo_coordinates_defaults_to_detected_owner_repo ... ok
test commands::gh::tests::resolve_repo_coordinates_uses_detected_owner_for_repo_only ... ok
test commands::gh::tests::summarize_ci_rollup_marks_fail_when_any_check_fails ... ok
test commands::gh::tests::summarize_ci_rollup_marks_pass_when_all_success ... ok
test commands::gh::tests::summarize_ci_rollup_marks_pending_without_failures ... ok
test commands::gh::tests::validate_status_args_accepts_no_target_form ... ok
test commands::gh::tests::summarize_ci_rollup_marks_pass_when_neutral_skipped_checks_present ... ok
test commands::gh::tests::validate_status_args_rejects_partial_target_form ... ok
test commands::init::tests::test_hook_command_present_true_and_false ... ok
test commands::init::tests::test_merge_report_all_added ... ok
test commands::init::tests::test_merge_report_partial_update ... ok
test commands::init::tests::test_migrates_legacy_catch_all_hook_entries_to_matcher_schema ... ok
test commands::init::tests::test_normalize_catch_all_hook_entries_preserves_non_catch_all_matcher ... ok
test commands::doctor::tests::check_mailbox_integrity_detects_orphan_mailbox ... ok
test commands::init::tests::test_global_hook_commands_use_absolute_script_paths ... ok
test commands::doctor::tests::compute_log_window_prefers_max_of_team_start_and_last_call ... ok
test commands::init::tests::test_session_start_script_supports_env_fallback_without_atm_toml ... ok
test commands::gh::tests::render_pr_report_template_renders_report_payload ... ok
test commands::launch::tests::test_launch_config_builds_correctly ... ok
test commands::gh::tests::execute_pr_init_report_writes_default_template_file ... ok
test commands::launch::tests::test_launch_result_json_output ... ok
test commands::launch::tests::test_launch_result_with_warning ... ok
test commands::cleanup::tests::test_execute_agent_cleanup_refuses_without_daemon_or_force ... ok
test commands::launch::tests::test_parse_env_vars_empty ... ok
test commands::launch::tests::test_parse_env_vars_empty_key ... ok
test commands::launch::tests::test_parse_env_vars_missing_equals ... ok
test commands::launch::tests::test_parse_env_vars_empty_value ... ok
test commands::launch::tests::test_parse_env_vars_multiple ... ok
test commands::launch::tests::test_parse_env_vars_single ... ok
test commands::launch::tests::test_parse_env_vars_value_with_equals ... ok
test commands::init::tests::test_fresh_file_install ... ok
test commands::init::tests::test_preserves_existing_non_atm_hooks ... ok
test commands::init::tests::test_idempotent_double_install ... ok
test commands::init::tests::test_write_settings_atomic_creates_parents_and_ends_with_newline ... ok
test commands::init::tests::test_materialize_scripts_creates_all_files ... ok
test commands::init::tests::test_materialize_scripts_idempotent ... ok
test commands::cleanup::tests::test_execute_agent_cleanup_force_removes_roster_and_mailbox ... ok
test commands::doctor::tests::active_env_overrides_ignores_empty_values ... ok
test commands::mcp::tests::test_check_cross_scope_skip_true_when_global_configured ... ok
test commands::mcp::tests::test_find_mcp_binary_override_missing_file_errors ... ok
test commands::cleanup::tests::test_execute_agent_cleanup_refuses_active_without_kill ... ok
test commands::doctor::tests::check_plugin_init_failures_reports_disabled_init_error ... ok
test commands::init::tests::test_execute_creates_atm_toml_team_and_global_hooks ... ok
test commands::mcp::tests::test_install_codex_local_scope_errors ... ok
test commands::init::tests::test_resolve_settings_path_global_uses_atm_home ... ok
test commands::init::tests::test_resolve_settings_path_local ... ok
test commands::logs::tests::test_agent_filter_via_execute ... ok
test commands::mcp::tests::test_is_codex_atm_configured_true_and_false ... ok
test commands::mcp::tests::test_is_json_atm_configured_true_and_false ... ok
test commands::mcp::tests::test_json_server_entry_matches_claude_requires_stdio_type ... ok
test commands::mcp::tests::test_json_server_entry_matches_gemini_allows_extra_type_field ... ok
test commands::mcp::tests::test_json_server_entry_matches_requires_serve_arg ... ok
test commands::mcp::tests::test_scope_label_values ... ok
test commands::members::tests::render_members_human_shows_short_session_ids ... ok
test commands::members::tests::build_member_rows_includes_daemon_only_member ... ok
test commands::monitor::tests::test_alert_tracker_dedup_window ... ok
test commands::monitor::tests::test_alert_tracker_reintroduced_finding_emits_immediately ... ok
test commands::read::tests::test_format_relative_time_days ... ok
test commands::monitor::tests::test_extract_critical_findings_filters_non_critical ... ok
test commands::read::tests::test_format_relative_time_hours ... ok
test commands::read::tests::test_format_relative_time_invalid ... ok
test commands::read::tests::test_format_relative_time_minutes ... ok
test commands::read::tests::test_format_relative_time_seconds ... ok
test commands::request::tests::test_generate_summary_101_chars_unicode_safe ... ok
test commands::request::tests::test_generate_summary_emoji_unicode_safe ... ok
test commands::request::tests::test_generate_summary_empty ... ok
test commands::request::tests::test_generate_summary_exactly_100_chars ... ok
test commands::request::tests::test_generate_summary_long_ascii ... ok
test commands::request::tests::test_generate_summary_short ... ok
test commands::request::tests::test_one_line_all_emoji_truncated ... ok
test commands::request::tests::test_one_line_cjk_string_truncated ... ok
test commands::request::tests::test_one_line_exact_120_chars_no_truncation ... ok
test commands::logs::tests::test_human_readable_output ... ok
test commands::request::tests::test_one_line_multibyte_at_boundary ... ok
test commands::request::tests::test_one_line_replaces_newlines ... ok
test commands::request::tests::test_one_line_short_text ... ok
test commands::request::tests::test_one_line_truncates_ascii_at_120 ... ok
test commands::runtime_adapter::tests::claude_build_command_includes_agent_team_flags ... ok
test commands::runtime_adapter::tests::codex_build_command_prefixes_cd ... ok
test commands::runtime_adapter::tests::gemini_build_command_uses_baseline_flags ... ok
test commands::runtime_adapter::tests::gemini_build_env_sets_runtime_home_and_system_prompt ... ok
test commands::mcp::tests::test_write_json_creates_parent_and_trailing_newline ... ok
test commands::runtime_adapter::tests::opencode_build_command_prefixes_cd ... ok
test commands::runtime_adapter::tests::gemini_resume_uses_explicit_session_when_present ... ok
test commands::send::tests::test_backend_expected_rule_defaults_team_lead_to_claude ... ok
test commands::send::tests::test_backend_expected_rule_prefers_backend_type ... ok
test commands::send::tests::test_backend_expected_rule_uses_legacy_agent_type_for_codex ... ok
test commands::send::tests::test_destination_target_formats_agent_at_team ... ok
test commands::send::tests::test_generate_summary_long ... ok
test commands::send::tests::test_generate_summary_short ... ok
test commands::send::tests::test_generate_summary_whitespace ... ok
test commands::logs::tests::test_json_output_mode ... ok
test commands::send::tests::test_is_self_send_different_name_same_team_no_warning ... ok
test commands::send::tests::test_is_self_send_same_name_different_teams_no_warning ... ok
test commands::send::tests::test_is_self_send_same_name_same_team_warns ... ok
test commands::send::tests::test_process_matches_rule_matches_basename_for_path_commands ... ok
test commands::send::tests::test_recipient_has_dead_session_false_for_alive_session ... ok
test commands::send::tests::test_recipient_has_dead_session_false_on_query_error ... ok
test commands::send::tests::test_recipient_has_dead_session_false_when_session_unknown ... ok
test commands::send::tests::test_recipient_has_dead_session_true_for_dead_session ... ok
test commands::send::tests::test_resolve_offline_action_cli_flag ... ok
test commands::send::tests::test_resolve_offline_action_cli_overrides_config ... ok
test commands::send::tests::test_resolve_offline_action_config ... ok
test commands::send::tests::test_resolve_offline_action_default ... ok
test commands::send::tests::test_resolve_offline_action_empty_string_opt_out ... ok
test commands::logs::tests::test_limit_zero_means_unlimited ... ok
test commands::request::tests::test_read_and_mark_response_matches_unknown_field_request_id ... ok
test commands::logs::tests::test_missing_log_file_exits_ok ... ok
test commands::logs::tests::test_resolve_log_path_default_uses_atm_home ... ok
test commands::send::tests::test_self_send_warning_not_added_for_cross_team_same_name ... ok
test commands::send::tests::test_self_send_warning_not_added_for_different_recipient ... ok
test commands::send::tests::test_should_warn_self_send_false_when_different_active_session_owns_identity ... ok
test commands::send::tests::test_should_warn_self_send_true_when_same_session_owned ... ok
test commands::logs::tests::test_resolve_log_path_from_compat_env ... ok
test commands::send::tests::test_should_warn_self_send_true_when_sender_session_unknown ... ok
test commands::send::tests::test_touch_sender_session_heartbeat_invokes_query ... ok
test commands::send::tests::test_touch_sender_session_heartbeat_propagates_query_error ... ok
test commands::spawn::tests::test_apply_panel_edits_accepts_existing_pane_selection ... ok
test commands::spawn::tests::test_spawn_apply_edits_parses_comma_separated ... ok
test commands::spawn::tests::test_spawn_dry_run_output ... ok
test commands::spawn::tests::test_spawn_non_interactive_with_yes_flag ... ok
test commands::spawn::tests::test_spawn_tty_guard_rejects_non_tty_stdin ... ok
test commands::spawn::tests::test_spawn_pane_mode_validation ... ok
test commands::spawn::tests::test_validate_spawn_request_blocks_new_pane_without_tmux ... ok
test commands::spawn::tests::test_validate_spawn_request_existing_pane_requires_selection ... ok
test commands::status::tests::build_status_member_rows_includes_daemon_only_member ... ok
test commands::status::tests::logging_remediation_returns_messages_for_degraded_and_unavailable ... ok
test commands::request::tests::test_read_and_mark_response_matches_message_id ... ok
test commands::status::tests::logging_health_contract_contains_required_json_keys ... ok
test commands::logs::tests::test_resolve_log_path_from_env ... ok
test commands::tail::tests::test_last_n_lines_empty_file ... ok
test commands::logs::tests::test_resolve_log_path_from_flag ... ok
test commands::tail::tests::test_last_n_lines_nonexistent_file ... ok
test commands::tail::tests::test_last_n_lines_fewer_than_requested ... ok
test commands::tail::tests::test_last_n_lines_zero_requested ... ok
test commands::tail::tests::test_last_n_lines_exact_count ... ok
test commands::tail::tests::test_tmux_capture_pane_args_zero_lines ... ok
test commands::tail::tests::test_tmux_capture_pane_command_construction ... ok
test commands::teams::tests::test_apply_spawn_contract_env_omits_optional_session_when_unknown ... ok
test commands::teams::tests::test_apply_spawn_contract_env_sets_required_fields ... ok
test commands::mcp::tests::test_find_in_path_prefers_executable_file ... ok
test commands::tail::tests::test_last_n_lines_from_file ... ok
test commands::mcp::tests::test_install_and_uninstall_claude_global_round_trip ... ok
test commands::mcp::tests::test_install_and_uninstall_codex_global_round_trip ... ok
test commands::mcp::tests::test_install_and_uninstall_gemini_local_round_trip ... ok
test commands::mcp::tests::test_install_gemini_idempotent_with_extra_type_field ... ok
test commands::send::tests::test_detect_sender_process_pid_does_not_fall_back_to_atm_subprocess_pid ... ok
test commands::send::tests::test_resolve_sender_session_id_errors_on_ambiguous_session_files_without_env ... ok
test commands::send::tests::test_resolve_sender_session_id_prefers_env_when_hook_missing ... ok
test commands::send::tests::test_resolve_sender_session_id_prefers_hook_file_over_session_and_env ... ok
test commands::send::tests::test_resolve_sender_session_id_uses_env_when_hook_and_session_missing ... ok
test commands::send::tests::test_resolve_sender_session_id_uses_session_file_when_hook_and_env_missing ... ok
test commands::teams::tests::test_canonicalize_directory_rejects_file_path ... ok
test commands::status::tests::read_daemon_logging_health_parses_extended_fields ... ok
test commands::tail::tests::test_resolve_log_path_no_daemon_returns_none ... ok
test commands::teams::tests::test_add_member_creates_valid_inbox_json ... ok
test commands::teams::tests::test_backup_creates_timestamped_dir ... ok
test commands::teams::tests::test_cleanup_preview_output_includes_external_agent_no_state_reason ... ok
test commands::teams::tests::test_backup_includes_project_tasks_when_requested ... ok
test commands::teams::tests::test_backup_includes_tasks ... ok
test commands::teams::tests::test_backup_no_team_returns_err ... ok
test commands::teams::tests::test_backup_project_tasks_omitted_when_project_scope_missing ... ok
test commands::teams::tests::test_backup_twice_creates_distinct_dirs ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_absent_toml_defaults_to_leaders_only ... ok
test commands::teams::tests::test_ensure_daemon_ready_for_spawn_accepts_available_daemon ... ok
test commands::teams::tests::test_ensure_daemon_ready_for_spawn_reports_unavailable_daemon ... ok
test commands::teams::tests::test_ensure_daemon_ready_for_spawn_wraps_query_errors ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_any_member_policy_bypasses_gate ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_co_leader_allowed ... ok
test commands::teams::tests::test_format_age ... ok
test commands::teams::tests::test_format_spawn_launch_command_claude_includes_required_flags ... ok
test commands::teams::tests::test_format_spawn_launch_command_non_claude_passthrough ... ok
test commands::teams::tests::test_load_spawn_policy_defaults_to_leaders_only_when_toml_missing ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_member_blocked ... ok
test commands::teams::tests::test_parse_env_vars_empty_key_errors ... ok
test commands::teams::tests::test_parse_env_vars_missing_delimiter_errors ... ok
test commands::teams::tests::test_parse_env_vars_valid_pair ... ok
test commands::teams::tests::test_parse_env_vars_value_with_equals ... ok
test commands::teams::tests::test_parse_template_vars_empty_key_errors ... ok
test commands::teams::tests::test_parse_template_vars_missing_delimiter_errors ... ok
test commands::teams::tests::test_parse_template_vars_valid_pair ... ok
test commands::teams::tests::test_parse_template_vars_value_with_equals ... ok
test commands::teams::tests::test_load_spawn_policy_reads_any_member_config ... ok
test commands::teams::tests::test_prune_no_backups_is_noop ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_team_lead_allowed ... ok
test commands::teams::tests::test_build_spawn_authorization_decision_unknown_blocked ... ok
test commands::teams::tests::test_cleanup_force_removes_when_daemon_unreachable_single_agent ... ok
test commands::teams::tests::test_cleanup_full_team_purges_orphan_mailbox_artifacts ... ok
test commands::teams::tests::test_resolve_continue_session_id_rejects_active_session ... ok
test commands::teams::tests::test_resolve_session_id_prefix_accepts_exact_match ... ok
test commands::teams::tests::test_resolve_session_id_prefix_accepts_unique_prefix ... ok
test commands::teams::tests::test_resolve_session_id_prefix_rejects_ambiguous_prefix ... ok
test commands::teams::tests::test_resolve_session_id_prefix_rejects_unknown_prefix ... ok
test commands::teams::tests::test_cleanup_keeps_external_agent_without_state_when_last_seen_recent ... ok
test commands::teams::tests::test_cleanup_no_team_returns_err ... ok
test commands::teams::tests::test_cleanup_removes_external_agent_without_state_when_last_seen_missing ... ok
test commands::teams::tests::test_cleanup_removes_member_when_daemon_reports_dead ... ok
test commands::teams::tests::test_resolve_spawn_folder_accepts_matching_folder_and_cwd ... ok
test commands::teams::tests::test_resolve_spawn_folder_defaults_to_current_dir ... ok
test commands::teams::tests::test_resolve_spawn_folder_rejects_mismatched_folder_and_cwd ... ok
test commands::teams::tests::test_resolve_spawn_folder_rejects_nonexistent_folder ... ok
test commands::teams::tests::test_cleanup_removes_member_with_no_daemon ... ok
test commands::teams::tests::test_cleanup_removes_multiple_dead_members ... ok
test commands::teams::tests::test_cleanup_single_agent_removes_member_mailbox_directory ... ok
test commands::teams::tests::test_cleanup_skips_and_errors_when_daemon_unreachable_no_force ... ok
test commands::teams::tests::test_ensure_spawn_member_metadata_creates_missing_member ... ok
test commands::teams::tests::test_ensure_spawn_member_metadata_updates_existing_member_backend_and_model ... ok
test commands::teams::tests::test_prune_old_backups_keeps_last_5 ... ok
test commands::teams::tests::test_remove_member_force_archives_inbox_and_removes_roster_entry ... ok
test commands::teams::tests::test_remove_member_refuses_external_member_without_session_id_without_force ... ok
test commands::teams::tests::test_remove_member_refuses_team_lead ... ok
test commands::teams::tests::test_remove_member_refuses_when_liveness_cannot_be_confirmed_without_force ... ok
test commands::teams::tests::test_resolve_spawn_caller_identity_prefers_atm_identity_env ... ok
test commands::teams::tests::test_resolve_spawn_caller_identity_uses_claude_session_id_for_member ... ok
test commands::teams::tests::test_resolve_spawn_caller_identity_uses_claude_session_id_for_team_lead ... ok
test commands::teams::tests::test_resolve_spawn_caller_identity_uses_resolved_identity_when_not_human ... ok
test commands::teams::tests::test_restore_clears_restored_tmux_pane_id ... ok
test commands::teams::tests::test_restore_dry_run_makes_no_changes ... ok
test commands::teams::tests::test_restore_from_backup ... ok
test commands::teams::tests::test_restore_includes_project_tasks_when_requested ... ok
test commands::teams::tests::test_restore_includes_tasks_by_default ... ok
test commands::teams::tests::test_runtime_name_all_variants ... ok
test commands::teams::tests::test_spawn_unauthorized_error_includes_context ... ok
test commands::teams::tests::test_write_team_config_roundtrip ... ok
test commands::wait::tests::test_count_messages_empty ... ok
test commands::wait::tests::test_count_messages_single_inbox ... ok
test commands::wait::tests::test_count_messages_with_origins ... ok
test commands::teams::tests::test_restore_preserves_lead_session_id ... ok
test commands::teams::tests::test_restore_recomputes_team_task_highwatermark_to_max_numeric_id ... ok
test util::addressing::tests::test_parse_address_empty_agent ... ok
test util::addressing::tests::test_parse_address_empty_team ... ok
test util::addressing::tests::test_parse_address_team_flag_overrides_at ... ok
test util::addressing::tests::test_parse_address_with_at ... ok
test util::addressing::tests::test_parse_address_with_team_flag ... ok
test util::addressing::tests::test_parse_simple_address ... ok
test commands::teams::tests::test_restore_sets_highwatermark_to_zero_when_no_numeric_task_files_exist ... ok
test commands::teams::tests::test_restore_skip_tasks_flag ... ok
test commands::teams::tests::test_restore_skip_tasks_suppresses_project_tasks ... ok
test commands::teams::tests::test_restore_skips_team_lead ... ok
test commands::teams::tests::test_resume_explicit_session_id_succeeds_without_config_mutation ... ok
test commands::teams::tests::test_resume_force_flag_bypasses_alive_check ... ok
test commands::teams::tests::test_resume_identity_from_atm_identity_env ... ok
test commands::teams::tests::test_resume_no_session_id_archives_team_when_daemon_unreachable ... ok
test commands::teams::tests::test_resume_no_team_returns_err ... ok
test util::caller_identity::tests::gemini_file_fallback_reports_ambiguity_when_multiple_chats_and_no_logs ... ok
test commands::teams::tests::test_resume_removes_team_directory_instead_of_mutating_members ... ok
test util::caller_identity::tests::normalize_runtime_aliases_to_canonical_session_id ... ok
test commands::teams::tests::test_resume_with_project_backs_up_project_tasks ... ok
test util::caller_identity::tests::parse_gemini_list_sessions_extracts_uuid_first ... ok
test commands::teams::tests::test_resume_without_explicit_session_id_succeeds_when_daemon_unreachable ... ok
test commands::teams::tests::test_resume_wrong_caller_identity ... ok
test util::caller_identity::tests::claude_runtime_env_wins_over_live_daemon_session ... ok
test util::caller_identity::tests::codex_runtime_env_wins_over_live_daemon_session ... ok
test util::file_policy::tests::test_file_matches_rule_read_pattern ... ok
test util::caller_identity::tests::codex_runtime_uses_codex_thread_id_only ... ok
test util::caller_identity::tests::codex_thread_id_implies_codex_runtime_without_atm_runtime ... ok
test util::caller_identity::tests::codex_thread_id_precedence_holds_even_when_live_daemon_session_exists ... ok
test util::file_policy::tests::test_check_file_reference_allowed ... ok
test util::file_policy::tests::test_find_git_root_at_root ... ok
test util::file_policy::tests::test_find_git_root_no_git ... ok
test util::file_policy::tests::test_file_policy_from_subdirectory ... ok
test util::file_policy::tests::test_find_git_root_from_subdirectory ... ok
test util::file_policy::tests::test_is_file_in_repo ... ok
test util::file_policy::tests::test_is_file_outside_repo ... ok
test util::file_policy::tests::test_check_file_reference_not_allowed_copies ... ok
test util::file_policy::tests::test_file_policy_unknown_destination_fallback ... ok
test util::caller_identity::tests::daemon_ambiguity_surfaces_stable_code ... ok
test util::caller_identity::tests::daemon_session_is_authoritative_when_alive ... ok
test util::caller_identity::tests::explicit_atm_session_override_wins ... ok
test util::caller_identity::tests::gemini_file_fallback_prefers_logs_json ... ok
test util::caller_identity::tests::implicit_claude_session_resolved_from_env_when_no_runtime_or_codex_thread_id ... FAILED
test util::caller_identity::tests::opencode_runtime_is_explicitly_unresolved ... ok
test util::state::tests::test_update_and_get_last_seen ... ok
test util::caller_identity::tests::required_ambiguous_returns_stable_code ... ok
test util::caller_identity::tests::required_unresolved_returns_stable_code ... ok
test util::hook_identity::tests::test_read_hook_file_identity_none_when_missing ... ok
test util::hook_identity::tests::test_read_hook_file_malformed_json ... ok
test util::hook_identity::tests::test_read_hook_file_missing ... ok
test util::hook_identity::tests::test_read_hook_file_stale ... ok
test util::hook_identity::tests::test_read_hook_file_valid ... ok
test util::hook_identity::tests::test_read_session_file_ambiguous_returns_err ... ok
test util::hook_identity::tests::test_read_session_file_missing_directory_returns_none ... ok
test util::hook_identity::tests::test_read_session_file_single_match_returns_session_id ... ok
test util::hook_identity::tests::test_read_session_file_stale_file_returns_none ... ok
test util::hook_identity::tests::test_read_session_file_updated_at_refreshes_ttl ... ok
test util::hook_identity::tests::test_read_session_file_wrong_identity_returns_none ... ok
test commands::wait::tests::test_polling_wait_timeout ... ok
test commands::wait::tests::test_polling_wait_message_received ... ok

failures:

---- util::caller_identity::tests::implicit_claude_session_resolved_from_env_when_no_runtime_or_codex_thread_id stdout ----

thread 'util::caller_identity::tests::implicit_claude_session_resolved_from_env_when_no_runtime_or_codex_thread_id' (11576301) panicked at crates/atm/src/util/caller_identity.rs:1079:9:
assertion `left == right` failed: CLAUDE_SESSION_ID must resolve when it is the only session signal
  left: Some("09ab30b4-a04f-42cf-a8a8-de1434bec38c")
 right: Some("claude-implicit-session-abc")
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    util::caller_identity::tests::implicit_claude_session_resolved_from_env_when_no_runtime_or_codex_thread_id

test result: FAILED. 341 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.29s still hits the pre-existing  failure in , outside this branch's write set.