### PR TITLE
fix(socket): gate teammate_idle state transitions on session ownership outcome

### DIFF
--- a/crates/atm-daemon/src/daemon/socket.rs
+++ b/crates/atm-daemon/src/daemon/socket.rs
@@ -10422,9 +10422,10 @@ exit 1
             "conflicting teammate_idle must not register atm-monitor"
         );
 
-        // ATM-QA-001 closure: IgnoredConflictingOwner must not pollute state tracker
+        drop(reg);
+        let tracker = store.lock().unwrap();
         assert_eq!(
-            store.lock().unwrap().get_state("atm-monitor"),
+            tracker.get_state("atm-monitor"),
             None,
             "IgnoredConflictingOwner must not register atm-monitor in state tracker"
         );


### PR DESCRIPTION
## Summary

Follow-up fix for #692 (atm-qa blocking findings on PR #691).

**Root cause**: `set_state(Idle)` in `socket.rs` fired unconditionally for ALL `TeammateIdleSessionOutcome` variants — including `IgnoredAgentSessionMismatch` and `IgnoredConflictingOwner`. The ownership guard only protected the session registry, not the state store. A session mismatch silently clobbered the agent's `Active` state.

**Fix**: Gate `set_state(Idle)` on safe outcomes only (`NoSessionId | Confirmed`). When the session ownership check rejects the idle event, the agent state is left unchanged.

- Adds explicit test asserting `AgentState::Active` is preserved when a mismatched session_id arrives
- `test_hook_event_teammate_idle_updates_state` updated to use `session_id: ""` (explicit `NoSessionId` path)

## Test plan

- [ ] `cargo test -p agent-team-mail-daemon` — all daemon tests pass
- [ ] atm-qa review: requirements/design compliance
- [ ] rust-qa review: code quality / test coverage

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)