### PR TITLE
chore: bump workspace version to 0.44.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "anyhow",
  "blake3",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1228,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1240,9 +1240,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "minijinja",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.44.5"
+version = "0.44.6"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.44.5"
+version = "0.44.6"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.5" }
-sc-composer = { path = "crates/sc-composer", version = "=0.44.5" }
-sc-observability = { path = "crates/sc-observability", version = "=0.44.5" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.6" }
+sc-composer = { path = "crates/sc-composer", version = "=0.44.6" }
+sc-observability = { path = "crates/sc-observability", version = "=0.44.6" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.44.5" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.44.6" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.44.5" }
+sc-composer = { path = "../sc-composer", version = "=0.44.6" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary

- Bumps workspace version from `0.44.5` → `0.44.6`
- Updates pinned `=0.44.x` refs in `Cargo.toml`, `crates/atm-tui/Cargo.toml`, `crates/sc-compose/Cargo.toml`
- Regenerates `Cargo.lock`

## Test plan

- [ ] CI green (format, clippy, tests)
- [ ] Merge after PR #693 (fix/hook-session-audit-v2) and PR #666 (develop→main) complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)