### PR TITLE
Bump workspace version to 0.44.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "anyhow",
  "blake3",
@@ -56,7 +56,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1584,7 +1584,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1603,7 +1603,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "minijinja",
@@ -1618,7 +1618,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.44.6"
+version = "0.44.7"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.44.6"
+version = "0.44.7"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -37,6 +37,6 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.6" }
-sc-composer = { path = "crates/sc-composer", version = "=0.44.6" }
-sc-observability = { path = "crates/sc-observability", version = "=0.44.6" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.44.7" }
+sc-composer = { path = "crates/sc-composer", version = "=0.44.7" }
+sc-observability = { path = "crates/sc-observability", version = "=0.44.7" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.44.6" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.44.7" }
 sc-observability.workspace = true
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.44.6" }
+sc-composer = { path = "../sc-composer", version = "=0.44.7" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- bump the workspace version from 0.44.6 to 0.44.7 after the daemon leak fix landed
- update pinned internal crate references and Cargo.lock

## Validation
- python3 scripts/check-workspace-versions
