### PR TITLE
fix(hooks): suppress recv timeout/EOF in hook relay — send succeeded, ack is optional

### DIFF
--- a/.claude/scripts/atm_hook_lib.py
+++ b/.claude/scripts/atm_hook_lib.py
@@ -57,7 +57,10 @@ def _send_unix(dd: Path, msg: bytes) -> None:
             s.settimeout(1.0)
             s.connect(str(sock_path))
             s.sendall(msg)
-            s.recv(4096)  # Drain response
+            try:
+                s.recv(4096)  # Drain response — optional; daemon ack is fire-and-forget
+            except (TimeoutError, ConnectionResetError, OSError):
+                pass  # Send succeeded; recv failure is not an error
     except Exception as exc:
         sys.stderr.write(f"[atm-hook] unix socket send failed: {exc}\n")
 
@@ -78,7 +81,10 @@ def _send_tcp(dd: Path, msg: bytes) -> None:
             s.settimeout(1.0)
             s.connect(("127.0.0.1", port))
             s.sendall(msg)
-            s.recv(4096)  # Drain response
+            try:
+                s.recv(4096)  # Drain response — optional; daemon ack is fire-and-forget
+            except (TimeoutError, ConnectionResetError, OSError):
+                pass  # Send succeeded; recv failure is not an error
     except Exception as exc:
         sys.stderr.write(f"[atm-hook] tcp socket send failed: {exc}\n")
 

--- a/crates/atm/scripts/atm_hook_lib.py
+++ b/crates/atm/scripts/atm_hook_lib.py
@@ -57,7 +57,10 @@ def _send_unix(dd: Path, msg: bytes) -> None:
             s.settimeout(1.0)
             s.connect(str(sock_path))
             s.sendall(msg)
-            s.recv(4096)  # Drain response
+            try:
+                s.recv(4096)  # Drain response — optional; daemon ack is fire-and-forget
+            except (TimeoutError, ConnectionResetError, OSError):
+                pass  # Send succeeded; recv failure is not an error
     except Exception as exc:
         sys.stderr.write(f"[atm-hook] unix socket send failed: {exc}\n")
 
@@ -78,7 +81,10 @@ def _send_tcp(dd: Path, msg: bytes) -> None:
             s.settimeout(1.0)
             s.connect(("127.0.0.1", port))
             s.sendall(msg)
-            s.recv(4096)  # Drain response
+            try:
+                s.recv(4096)  # Drain response — optional; daemon ack is fire-and-forget
+            except (TimeoutError, ConnectionResetError, OSError):
+                pass  # Send succeeded; recv failure is not an error
     except Exception as exc:
         sys.stderr.write(f"[atm-hook] tcp socket send failed: {exc}\n")
 


### PR DESCRIPTION
## Summary

Fixes #710 — spurious hook errors on session stop when daemon closes connection before recv completes.

## Root Cause

`_send_unix` and `_send_tcp` in `atm_hook_lib.py` wrapped connect+send+recv in a single `except` block. A recv timeout or EOF after a successful `sendall` logged to stderr, which Claude Code surfaces as a hook error.

## Fix

Nested inner `try/except` around `recv(4096)` only. Catches `TimeoutError`, `ConnectionResetError`, `OSError` — the daemon ack is fire-and-forget. Outer handler unchanged: genuine connect/send failures still log.

Applied to both `_send_unix` (macOS/Linux) and `_send_tcp` (Windows) for parity.

## Release impact

This is a **release blocker** — must merge to develop before develop→main for v0.44.8.