### PR TITLE
feat(AN.0a): replace CI-monitor plugin init .unwrap() with explicit error propagation

### DIFF
--- a/crates/atm-daemon/src/plugins/ci_monitor/plugin.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/plugin.rs
@@ -2553,10 +2553,9 @@ provider = "custom-missing"
             .find(|record| record.team == "dev-team")
             .expect("dev-team health record");
         assert_eq!(record.availability_state, "disabled_config_error");
-        assert!(record
-            .message
-            .as_deref()
-            .is_some_and(|message| message.contains("CI provider 'custom-missing' not registered")));
+        assert!(record.message.as_deref().is_some_and(|message| {
+            message.contains("CI provider 'custom-missing' not registered")
+        }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace runtime-reachable `.unwrap()` calls in `ci_monitor/plugin.rs` init paths with explicit `PluginError::Init` propagation and `disabled_config_error` health/state handling
- Daemon startup with bad CI-monitor config now degrades/disables the plugin gracefully instead of panicking
- Plugin init errors remain operator-visible in status/doctor surfaces
- Added regression coverage for the failure path

## Phase AN Context

Sprint AN.0a — ARCH-003 Init Error Propagation. First prep sprint before ci-monitor extraction (AN.1–AN.6).

## Validation

- `cargo clippy -p agent-team-mail-daemon --all-targets --all-features -- -D warnings` PASS
- `cargo test` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)