### PR TITLE
AQ.1 follow-up: add missing settle and poller constants (665630a7)

### DIFF
--- a/crates/atm-core/src/consts.rs
+++ b/crates/atm-core/src/consts.rs
@@ -33,5 +33,8 @@ pub const SHORT_SLEEP_MS: u64 = 50;
 /// Short deadline used in test-only daemon wait loops.
 pub const SHORT_DEADLINE_SECS: u64 = 2;
 
+/// Brief settle delay before re-reading daemon metadata written asynchronously after startup.
+pub const DAEMON_METADATA_SETTLE_MS: u64 = 150;
+
 /// Capacity for the producer fan-in logging channel.
 pub const LOG_EVENT_CHANNEL_CAPACITY: usize = 512;

--- a/crates/atm-core/src/daemon_client.rs
+++ b/crates/atm-core/src/daemon_client.rs
@@ -36,8 +36,8 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use crate::consts::{
-    DAEMON_QUERY_TIMEOUT_MS, DAEMON_TIMEOUT_MAX_SECS, DAEMON_TIMEOUT_MIN_SECS, RETRY_SLEEP_MS,
-    SOCKET_IO_TIMEOUT_MS, STARTUP_DEADLINE_SECS,
+    DAEMON_METADATA_SETTLE_MS, DAEMON_QUERY_TIMEOUT_MS, DAEMON_TIMEOUT_MAX_SECS,
+    DAEMON_TIMEOUT_MIN_SECS, RETRY_SLEEP_MS, SOCKET_IO_TIMEOUT_MS, STARTUP_DEADLINE_SECS,
 };
 
 /// Protocol version for the socket JSON protocol.
@@ -2456,7 +2456,7 @@ fn detect_daemon_identity_mismatch(
         && let Some(candidate_pid) = pid_from_file.or(pid_from_status)
         && pid_alive(candidate_pid as i32)
     {
-        std::thread::sleep(std::time::Duration::from_millis(150));
+        std::thread::sleep(std::time::Duration::from_millis(DAEMON_METADATA_SETTLE_MS));
         metadata = std::fs::read_to_string(&metadata_path)
             .ok()
             .and_then(|s| serde_json::from_str::<DaemonLockMetadata>(&s).ok());

--- a/crates/atm-daemon/src/daemon/consts.rs
+++ b/crates/atm-daemon/src/daemon/consts.rs
@@ -27,6 +27,15 @@ pub const STREAM_CHECK_SLEEP_MS: u64 = 25;
 /// Sleep interval between repeated drain-status checks.
 pub const DRAIN_SLEEP_MS: u64 = 250;
 
+/// Backoff delay after shared repo-state refresh/load errors in the shared poller loop.
+pub const SHARED_POLLER_ERROR_BACKOFF_SECS: u64 = 60;
+
+/// Active shared-poller cadence while at least one monitor is subscribed.
+pub const SHARED_POLLER_ACTIVE_SLEEP_SECS: u64 = 60;
+
+/// Idle shared-poller cadence when no active monitor subscriptions exist.
+pub const SHARED_POLLER_IDLE_SLEEP_SECS: u64 = 300;
+
 /// Threshold used for elapsed timestamp assertions in hook dedupe tests.
 pub const MIN_ELAPSED_CHECK_MS: u64 = 20;
 

--- a/crates/atm-daemon/src/plugins/ci_monitor/service.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/service.rs
@@ -5,7 +5,10 @@
 //! for translating wire payloads into these CI monitor request/status types before
 //! calling into the service layer.
 
-use crate::daemon::consts::{DEFAULT_DRAIN_TIMEOUT_SECS, DRAIN_SLEEP_MS};
+use crate::daemon::consts::{
+    DEFAULT_DRAIN_TIMEOUT_SECS, DRAIN_SLEEP_MS, SHARED_POLLER_ACTIVE_SLEEP_SECS,
+    SHARED_POLLER_ERROR_BACKOFF_SECS, SHARED_POLLER_IDLE_SLEEP_SECS,
+};
 
 #[cfg(unix)]
 use super::gh_monitor::{
@@ -263,7 +266,10 @@ async fn run_shared_repo_poller(home: std::path::PathBuf, team: String, owner_re
             Ok(records) => records,
             Err(err) => {
                 warn!(team = %team, repo = %owner_repo, "failed to load gh monitor state: {err}");
-                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    SHARED_POLLER_ERROR_BACKOFF_SECS,
+                ))
+                .await;
                 continue;
             }
         };
@@ -302,7 +308,11 @@ async fn run_shared_repo_poller(home: std::path::PathBuf, team: String, owner_re
         }
 
         let _ = update_gh_repo_state_in_flight(&home, &team, &owner_repo, 0, "atm-daemon");
-        let sleep_secs = if active_records.is_empty() { 300 } else { 60 };
+        let sleep_secs = if active_records.is_empty() {
+            SHARED_POLLER_IDLE_SLEEP_SECS
+        } else {
+            SHARED_POLLER_ACTIVE_SLEEP_SECS
+        };
         tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #769. Adds 4 constants omitted from the original merge commit (44640f4a):

- `DAEMON_METADATA_SETTLE_MS: u64 = 150` in `atm-core/src/consts.rs`; callsite at `daemon_client.rs:2459`
- `SHARED_POLLER_ERROR_BACKOFF_SECS: u64 = 60` in `atm-daemon/src/daemon/consts.rs`; callsite at `ci_monitor/service.rs:266`
- `SHARED_POLLER_ACTIVE_SLEEP_SECS: u64 = 60` in `atm-daemon/src/daemon/consts.rs`; callsite at `ci_monitor/service.rs:305`
- `SHARED_POLLER_IDLE_SLEEP_SECS: u64 = 300` in `atm-daemon/src/daemon/consts.rs`; callsite at `ci_monitor/service.rs:305`

AQ.1 QA r3 is in progress. All gates passed locally (fmt + clippy + tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)