### PR TITLE
AQ.1 follow-up: add missing settle and poller constants (4222b8c9)

### DIFF
--- a/crates/atm-core/src/consts.rs
+++ b/crates/atm-core/src/consts.rs
@@ -33,5 +33,8 @@ pub const SHORT_SLEEP_MS: u64 = 50;
 /// Short deadline used in test-only daemon wait loops.
 pub const SHORT_DEADLINE_SECS: u64 = 2;
 
+/// Brief settle delay before re-reading daemon metadata written asynchronously after startup.
+pub const DAEMON_METADATA_SETTLE_MS: u64 = 150;
+
 /// Capacity for the producer fan-in logging channel.
 pub const LOG_EVENT_CHANNEL_CAPACITY: usize = 512;

--- a/crates/atm-core/src/daemon_client.rs
+++ b/crates/atm-core/src/daemon_client.rs
@@ -2457,7 +2457,9 @@ fn detect_daemon_identity_mismatch(
         && pid_alive(candidate_pid as i32)
     {
         // Retry backoff: daemon may not have flushed lock metadata yet; wait once before re-reading.
-        std::thread::sleep(std::time::Duration::from_millis(150));
+        std::thread::sleep(std::time::Duration::from_millis(
+            crate::consts::DAEMON_METADATA_SETTLE_MS,
+        ));
         metadata = std::fs::read_to_string(&metadata_path)
             .ok()
             .and_then(|s| serde_json::from_str::<DaemonLockMetadata>(&s).ok());

--- a/crates/atm-daemon/src/daemon/consts.rs
+++ b/crates/atm-daemon/src/daemon/consts.rs
@@ -27,6 +27,15 @@ pub const STREAM_CHECK_SLEEP_MS: u64 = 25;
 /// Sleep interval between repeated drain-status checks.
 pub const DRAIN_SLEEP_MS: u64 = 250;
 
+/// Backoff delay after shared repo-state refresh/load errors in the shared poller loop.
+pub const SHARED_POLLER_ERROR_BACKOFF_SECS: u64 = 60;
+
+/// Active shared-poller cadence while at least one monitor is subscribed.
+pub const SHARED_POLLER_ACTIVE_SLEEP_SECS: u64 = 60;
+
+/// Idle shared-poller cadence when no active monitor subscriptions exist.
+pub const SHARED_POLLER_IDLE_SLEEP_SECS: u64 = 300;
+
 /// Threshold used for elapsed timestamp assertions in hook dedupe tests.
 pub const MIN_ELAPSED_CHECK_MS: u64 = 20;
 

--- a/crates/atm-daemon/src/plugins/ci_monitor/service.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/service.rs
@@ -263,7 +263,10 @@ async fn run_shared_repo_poller(home: std::path::PathBuf, team: String, owner_re
             Ok(records) => records,
             Err(err) => {
                 warn!(team = %team, repo = %owner_repo, "failed to load gh monitor state: {err}");
-                tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    crate::daemon::consts::SHARED_POLLER_ERROR_BACKOFF_SECS,
+                ))
+                .await;
                 continue;
             }
         };
@@ -302,7 +305,11 @@ async fn run_shared_repo_poller(home: std::path::PathBuf, team: String, owner_re
         }
 
         let _ = update_gh_repo_state_in_flight(&home, &team, &owner_repo, 0, "atm-daemon");
-        let sleep_secs = if active_records.is_empty() { 300 } else { 60 };
+        let sleep_secs = if active_records.is_empty() {
+            crate::daemon::consts::SHARED_POLLER_IDLE_SLEEP_SECS
+        } else {
+            crate::daemon::consts::SHARED_POLLER_ACTIVE_SLEEP_SECS
+        };
         tokio::time::sleep(std::time::Duration::from_secs(sleep_secs)).await;
     }
 }


### PR DESCRIPTION
## Summary

Clean cherry-apply of AQ.1 missing constants off `integrate/phase-AQ` tip (`ce748403`), resolving the merge:CONFLICT that blocked PR #777.

Closes #777 (superseded).

## Changes

- `crates/atm-core/src/consts.rs`: `pub const DAEMON_METADATA_SETTLE_MS: u64 = 150;`
- `crates/atm-core/src/daemon_client.rs`: callsite updated to `crate::consts::DAEMON_METADATA_SETTLE_MS`
- `crates/atm-daemon/src/daemon/consts.rs`: `SHARED_POLLER_ERROR_BACKOFF_SECS=60`, `SHARED_POLLER_ACTIVE_SLEEP_SECS=60`, `SHARED_POLLER_IDLE_SLEEP_SECS=300`
- `crates/atm-daemon/src/plugins/ci_monitor/service.rs`: two callsite updates using new constants

## QA

AQ.1 QA r3: **PASS** (quality-mgr confirmed constants correct at 665630a7 — same constants, clean ancestry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)