### PR TITLE
AS.4: Hard gh Firewall (GH-CI-FR-45, GH-CI-FR-46)

### DIFF
--- a/.claude/agents/quality-mgr.md
+++ b/.claude/agents/quality-mgr.md
@@ -211,6 +211,14 @@ After every QA run, apply these escalation checks:
    - installed-binary fallback instead of isolated test runtime
 3. Output: fenced JSON findings with affected runtime, risk type, still_active, remediation_direction
 
+#### gh-firewall QA rule:
+1. Treat any new direct `Command::new("gh")` in `gh_monitor`, `atm gh` monitor/status paths,
+   repo-state refresh, or GitHub budget/rate auditing as a **blocking failure**.
+2. The only allowed exceptions are explicit `// NOT_MONITORED_PATH:` callsites with rationale
+   outside monitor/status enforcement scope.
+3. Any in-scope bypass without that rationale must be reported as a firewall defect against
+   `GH-CI-FR-45` / `GH-CI-FR-46`.
+
 #### arch-qa-agent prompt (fenced JSON):
 1. `worktree_path`: absolute path to the sprint worktree
 2. `branch`: branch name

--- a/crates/atm-ci-monitor/src/github_provider.rs
+++ b/crates/atm-ci-monitor/src/github_provider.rs
@@ -6,6 +6,8 @@ use crate::types::{
 };
 use serde::Deserialize;
 use std::process::Command;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Instant;
 
 pub struct GitHubActionsProvider {
@@ -28,47 +30,20 @@ impl GitHubActionsProvider {
         self
     }
 
-    async fn run_gh_with_metadata(
-        &self,
+    pub fn run_gh_with_metadata_blocking(
+        observer: Option<GhCliObserverRef>,
         metadata: GhCliCallMetadata,
     ) -> Result<String, CiProviderError> {
-        if let Some(observer) = &self.observer {
+        if let Some(observer) = &observer {
             observer.before_gh_call(&metadata)?;
         }
 
         let started = Instant::now();
-        let observer = self.observer.clone();
         let metadata_for_outcome = metadata.clone();
-        let args_owned: Vec<String> = metadata.args.clone();
-        let result = tokio::task::spawn_blocking(move || {
-            let output = Command::new("gh").args(&args_owned).output().map_err(|e| {
-                if e.kind() == std::io::ErrorKind::NotFound {
-                    CiProviderError::provider(
-                        "gh CLI not found. Install from https://cli.github.com/",
-                    )
-                } else {
-                    CiProviderError::provider(format!("Failed to execute gh: {e}"))
-                }
-            })?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                return Err(CiProviderError::provider(format!(
-                    "gh command failed: {stderr}"
-                )));
-            }
-
-            let stdout = String::from_utf8(output.stdout).map_err(|e| {
-                CiProviderError::provider(format!("Invalid UTF-8 in gh output: {e}"))
-            })?;
-
-            Ok(stdout)
-        })
-        .await
-        .map_err(|e| CiProviderError::runtime(format!("Task join error: {e}")))?;
+        let result = run_gh_subprocess(&metadata.args);
+        let duration_ms = started.elapsed().as_millis() as u64;
 
         if let Some(observer) = observer {
-            let duration_ms = started.elapsed().as_millis() as u64;
             match &result {
                 Ok(_) => observer.after_gh_call(&GhCliCallOutcome {
                     metadata: metadata_for_outcome,
@@ -86,6 +61,16 @@ impl GitHubActionsProvider {
         }
 
         result
+    }
+
+    async fn run_gh_with_metadata(
+        &self,
+        metadata: GhCliCallMetadata,
+    ) -> Result<String, CiProviderError> {
+        let observer = self.observer.clone();
+        tokio::task::spawn_blocking(move || Self::run_gh_with_metadata_blocking(observer, metadata))
+            .await
+            .map_err(|e| CiProviderError::runtime(format!("Task join error: {e}")))?
     }
 
     fn repo_scope(&self) -> String {
@@ -176,6 +161,32 @@ impl GitHubActionsProvider {
         }
     }
 }
+
+fn run_gh_subprocess(args: &[String]) -> Result<String, CiProviderError> {
+    #[cfg(test)]
+    GH_SUBPROCESS_COUNT.fetch_add(1, Ordering::SeqCst);
+
+    let output = Command::new("gh").args(args).output().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            CiProviderError::provider("gh CLI not found. Install from https://cli.github.com/")
+        } else {
+            CiProviderError::provider(format!("Failed to execute gh: {e}"))
+        }
+    })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CiProviderError::provider(format!(
+            "gh command failed: {stderr}"
+        )));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| CiProviderError::provider(format!("Invalid UTF-8 in gh output: {e}")))
+}
+
+#[cfg(test)]
+static GH_SUBPROCESS_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 impl std::fmt::Debug for GitHubActionsProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -394,4 +405,48 @@ struct GhPrView {
     created_at: Option<String>,
     #[serde(default)]
     merge_state_status: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[derive(Debug)]
+    struct BlockingObserver;
+
+    impl crate::provider::GhCliObserver for BlockingObserver {
+        fn before_gh_call(&self, _metadata: &GhCliCallMetadata) -> Result<(), CiProviderError> {
+            Err(CiProviderError::provider(
+                r#"{"code":"gh_firewall_blocked","reason":"test_block","message":"blocked by test observer"}"#,
+            ))
+        }
+
+        fn after_gh_call(&self, _outcome: &GhCliCallOutcome) {}
+    }
+
+    #[test]
+    fn blocked_calls_do_not_spawn_gh_subprocess() {
+        GH_SUBPROCESS_COUNT.store(0, Ordering::SeqCst);
+        let metadata = GhCliCallMetadata {
+            repo_scope: "owner/repo".to_string(),
+            action: "gh_run_list".to_string(),
+            args: vec!["run".to_string(), "list".to_string()],
+            branch: None,
+            reference: None,
+        };
+
+        let err = GitHubActionsProvider::run_gh_with_metadata_blocking(
+            Some(Arc::new(BlockingObserver)),
+            metadata,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("\"code\":\"gh_firewall_blocked\""));
+        assert_eq!(
+            GH_SUBPROCESS_COUNT.load(Ordering::SeqCst),
+            0,
+            "blocked requests must fail before launching gh"
+        );
+    }
 }

--- a/crates/atm-core/src/gh_monitor_observability.rs
+++ b/crates/atm-core/src/gh_monitor_observability.rs
@@ -4,15 +4,13 @@ use agent_team_mail_ci_monitor::repo_state::{
 };
 use agent_team_mail_ci_monitor::{
     CiProviderError, GhBranchRefCount, GhCliCallMetadata, GhCliCallOutcome, GhCliObserver,
-    GhRateLimitSnapshot, GhRepoStateFile, GhRepoStateRecord, GhRuntimeOwner,
+    GhRateLimitSnapshot, GhRepoStateFile, GhRepoStateRecord, GhRuntimeOwner, GitHubActionsProvider,
 };
 use anyhow::{Context, Result};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::json;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
-use std::time::Instant;
 
 use crate::consts::{
     GH_ACTIVE_POLL_INTERVAL_SECS, GH_BUDGET_LIMIT_PER_HOUR, GH_IDLE_POLL_INTERVAL_SECS,
@@ -50,12 +48,16 @@ impl GhCliObserver for SharedGhCliObserver {
             .map_err(|err| CiProviderError::runtime(err.to_string()))?;
         if record.budget_used_in_window >= record.budget_limit_per_hour {
             emit_rate_limit_event("rate_limit_critical", &self.ctx, metadata, &record, None);
-            return Err(CiProviderError::provider(format!(
-                "GitHub budget exhausted for team {} on repo {} ({}/{})",
-                self.ctx.team,
-                self.ctx.repo,
-                record.budget_used_in_window,
-                record.budget_limit_per_hour
+            return Err(CiProviderError::provider(format_firewall_blocked_reason(
+                "budget_exhausted",
+                "GitHub budget exhausted",
+                json!({
+                    "team": self.ctx.team,
+                    "repo": self.ctx.repo,
+                    "budget_used_in_window": record.budget_used_in_window,
+                    "budget_limit_per_hour": record.budget_limit_per_hour,
+                    "action": metadata.action,
+                }),
             )));
         }
         Ok(())
@@ -77,7 +79,7 @@ pub fn run_attributed_gh_command(
     branch: Option<&str>,
     reference: Option<&str>,
 ) -> Result<String> {
-    let observer = SharedGhCliObserver::new(ctx.clone());
+    let observer: Arc<dyn GhCliObserver> = Arc::new(SharedGhCliObserver::new(ctx.clone()));
     let metadata = GhCliCallMetadata {
         repo_scope: ctx.repo.clone(),
         action: action.to_string(),
@@ -85,35 +87,8 @@ pub fn run_attributed_gh_command(
         branch: branch.map(str::to_string),
         reference: reference.map(str::to_string),
     };
-    observer
-        .before_gh_call(&metadata)
-        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
-
-    let started = Instant::now();
-    let output = Command::new("gh")
-        .args(args)
-        .output()
-        .map_err(|err| anyhow::anyhow!("failed to execute gh: {err}"))?;
-    let duration_ms = started.elapsed().as_millis() as u64;
-
-    let result = if output.status.success() {
-        String::from_utf8(output.stdout)
-            .map_err(|err| anyhow::anyhow!("invalid UTF-8 in gh output: {err}"))
-    } else {
-        Err(anyhow::anyhow!(
-            "gh command failed: {}",
-            String::from_utf8_lossy(&output.stderr).trim()
-        ))
-    };
-
-    observer.after_gh_call(&GhCliCallOutcome {
-        metadata,
-        duration_ms,
-        success: result.is_ok(),
-        error: result.as_ref().err().map(|err| err.to_string()),
-    });
-
-    result
+    GitHubActionsProvider::run_gh_with_metadata_blocking(Some(observer), metadata)
+        .map_err(|err| anyhow::anyhow!(err.to_string()))
 }
 
 pub fn gh_repo_state_path_for(home: &Path) -> PathBuf {
@@ -459,10 +434,31 @@ fn build_lease_conflict_event_fields(
 }
 
 fn format_lease_conflict_error(team: &str, repo: &str, existing_owner: &GhRuntimeOwner) -> String {
-    format!(
-        "gh_monitor lease conflict for team={} repo={}: active owner pid={} executable={} home={}",
-        team, repo, existing_owner.pid, existing_owner.executable_path, existing_owner.home_scope
+    format_firewall_blocked_reason(
+        "lease_conflict",
+        "gh_monitor lease conflict",
+        json!({
+            "team": team,
+            "repo": repo,
+            "owner_pid": existing_owner.pid,
+            "owner_executable_path": existing_owner.executable_path,
+            "owner_home_scope": existing_owner.home_scope,
+        }),
     )
+}
+
+fn format_firewall_blocked_reason(
+    reason: &str,
+    message: &str,
+    details: serde_json::Value,
+) -> String {
+    json!({
+        "code": "gh_firewall_blocked",
+        "reason": reason,
+        "message": message,
+        "details": details,
+    })
+    .to_string()
 }
 
 fn read_or_create_record(home: &Path, team: &str, repo: &str) -> Result<GhRepoStateRecord> {
@@ -686,7 +682,8 @@ mod tests {
                 reference: None,
             })
             .unwrap_err();
-        assert!(err.to_string().contains("budget exhausted"));
+        assert!(err.to_string().contains("\"code\":\"gh_firewall_blocked\""));
+        assert!(err.to_string().contains("\"reason\":\"budget_exhausted\""));
     }
 
     #[test]
@@ -858,8 +855,9 @@ mod tests {
                 reference: None,
             })
             .unwrap_err();
-        assert!(err.to_string().contains("lease conflict"));
-        assert!(err.to_string().contains(&format!("pid={}", child.id())));
+        assert!(err.to_string().contains("\"code\":\"gh_firewall_blocked\""));
+        assert!(err.to_string().contains("\"reason\":\"lease_conflict\""));
+        assert!(err.to_string().contains(&child.id().to_string()));
         assert!(err.to_string().contains(FAKE_FOREIGN_DAEMON_BINARY));
         let fields = build_lease_conflict_event_fields(
             "atm-dev",

--- a/crates/atm-daemon/src/plugins/issues/github.rs
+++ b/crates/atm-daemon/src/plugins/issues/github.rs
@@ -21,6 +21,9 @@ impl GitHubProvider {
 
     /// Execute a `gh` command and return stdout
     async fn run_gh(&self, args: &[&str]) -> Result<String, PluginError> {
+        // NOT_MONITORED_PATH: the issues plugin is outside the gh_monitor /
+        // `atm gh ...` status+budget firewall scope. AS.4 only hardens monitor/status
+        // execution paths; this provider remains an explicit non-monitor exception.
         // Run gh command in a blocking task
         let args_owned: Vec<String> = args.iter().map(|s| s.to_string()).collect();
         tokio::task::spawn_blocking(move || {

--- a/crates/atm/src/commands/gh.rs
+++ b/crates/atm/src/commands/gh.rs
@@ -2112,6 +2112,9 @@ fn execute_init(
 }
 
 fn validate_gh_cli_prerequisites() -> Result<()> {
+    // NOT_MONITORED_PATH: `atm gh init` validates local gh installation/auth before
+    // monitor configuration exists, so this bootstrap probe intentionally stays
+    // outside the gh_monitor execution firewall.
     let version = Command::new("gh")
         .arg("--version")
         .output()
@@ -2122,6 +2125,8 @@ fn validate_gh_cli_prerequisites() -> Result<()> {
         );
     }
 
+    // NOT_MONITORED_PATH: `gh auth status` is a local auth prerequisite check for
+    // `atm gh init`, not a monitored repo-state refresh or gh_monitor budgeted call.
     let auth = Command::new("gh")
         .args(["auth", "status"])
         .output()


### PR DESCRIPTION
## Sprint AS.4 — Hard gh Firewall

Routes all in-scope `gh_monitor`/`atm gh` execution through the canonical adapter (`GitHubActionsProvider::run_gh_with_metadata_blocking`), making direct `Command::new("gh")` bypasses impossible by policy in monitor paths.

## Changes

- `run_attributed_gh_command` now routes through `run_gh_with_metadata_blocking` (the single canonical gh execution path)
- Blocked firewall decisions return machine-readable `gh_firewall_blocked` reasons (budget block, lease block, etc.)
- Explicit `NOT_MONITORED_PATH` exceptions annotated in `atm gh init` and issues plugin with rationale
- QA rule added: any new monitor/status `gh` bypass is a blocking failure

## Acceptance Criteria

- GH-CI-FR-45: single canonical execution surface reviewable by QA ✅
- GH-CI-FR-46: no in-scope monitor/status path can launch `gh` outside the firewall ✅
- GH-CI-FR-46: blocked calls fail with structured reason ✅

## References

- docs/phase-as-planning.md (Sprint AS.1 spec)
- Commit: f2066ba2

🤖 Generated with [Claude Code](https://claude.com/claude-code)