### PR TITLE
test: add #[serial] to test_emit_event_best_effort_is_fail_open

### DIFF
--- a/crates/atm-core/src/event_log.rs
+++ b/crates/atm-core/src/event_log.rs
@@ -546,6 +546,7 @@ mod tests {
     /// Verify that `emit_event_best_effort` is fail-open: calling it without
     /// an initialised unified channel must not panic.
     #[test]
+    #[serial]
     fn test_emit_event_best_effort_is_fail_open() {
         // No unified channel is registered in unit-test context; the call
         // should spool the event rather than panicking or dropping it.


### PR DESCRIPTION
## Summary

- Adds `#[serial]` to `test_emit_event_best_effort_is_fail_open` in `crates/atm-core/src/event_log.rs`

Test mutates `ATM_HOME` via `std::env::set_var`/`remove_var` without a serialization guard, creating a race condition against other `#[serial]` tests in the same binary. The `serial_test` crate is already imported in the test module.

One-line fix, no logic changes.