### PR TITLE
feat(AV.4): producer rollout health status surfaces

### DIFF
--- a/crates/atm-core/src/daemon_client.rs
+++ b/crates/atm-core/src/daemon_client.rs
@@ -36,6 +36,7 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use crate::event_log::EventFields;
 use agent_team_mail_daemon_launch::{LaunchClass, SpawnDaemonRequest, spawn_daemon_process};
 
 use crate::consts::{
@@ -1981,6 +1982,34 @@ fn new_request_id() -> String {
     format!("req-{id}-{nanos}")
 }
 
+fn daemon_autostart_event(
+    request_id: &str,
+    trace_id: &str,
+    action: &'static str,
+    result: &'static str,
+    target: Option<String>,
+    error: Option<String>,
+) -> EventFields {
+    let mut extra_fields = serde_json::Map::new();
+    extra_fields.insert(
+        "autostart_phase".to_string(),
+        serde_json::Value::String(action.to_string()),
+    );
+    EventFields {
+        level: if error.is_some() { "error" } else { "info" },
+        source: "atm",
+        action,
+        result: Some(result.to_string()),
+        request_id: Some(request_id.to_string()),
+        trace_id: Some(trace_id.to_string()),
+        span_id: Some(crate::event_log::span_id_for_action(trace_id, action)),
+        target,
+        error,
+        extra_fields,
+        ..Default::default()
+    }
+}
+
 // ── Unix implementation ──────────────────────────────────────────────────────
 
 #[cfg(unix)]
@@ -2119,7 +2148,7 @@ fn resolve_daemon_binary() -> anyhow::Result<std::ffi::OsString> {
 
 #[cfg(unix)]
 fn ensure_daemon_running_unix() -> anyhow::Result<()> {
-    use crate::event_log::{EventFields, emit_event_best_effort};
+    use crate::event_log::emit_event_best_effort;
     use crate::io::InboxError;
     use std::io::ErrorKind;
     use std::process::Stdio;
@@ -2133,6 +2162,9 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
     }
 
     let home = crate::home::get_home_dir()?;
+    let autostart_request_id = new_request_id();
+    let autostart_trace_id =
+        crate::event_log::trace_id_for_request("atm:daemon_autostart", &autostart_request_id);
     let socket_connectable = daemon_socket_connectable(&home);
     if daemon_is_running() || socket_connectable {
         if let Some(reason) = detect_daemon_identity_mismatch(&home, socket_connectable) {
@@ -2209,38 +2241,37 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
 
     let daemon_bin = resolve_daemon_binary().map_err(|e| {
         let error = e.to_string();
-        emit_event_best_effort(EventFields {
-            level: "error",
-            source: "atm",
-            action: "daemon_autostart_failure",
-            result: Some("binary_resolution_error".to_string()),
-            error: Some(error.clone()),
-            ..Default::default()
-        });
+        emit_event_best_effort(daemon_autostart_event(
+            &autostart_request_id,
+            &autostart_trace_id,
+            "daemon_autostart_failure",
+            "binary_resolution_error",
+            None,
+            Some(error.clone()),
+        ));
         anyhow::anyhow!("{error}")
     })?;
     let daemon_bin_path = PathBuf::from(&daemon_bin);
     let runtime_owner = validate_runtime_admission(&home, &daemon_bin_path).map_err(|e| {
         let error = e.to_string();
-        emit_event_best_effort(EventFields {
-            level: "error",
-            source: "atm",
-            action: "daemon_autostart_failure",
-            result: Some("runtime_admission_denied".to_string()),
-            target: Some(daemon_bin_path.display().to_string()),
-            error: Some(error.clone()),
-            ..Default::default()
-        });
+        emit_event_best_effort(daemon_autostart_event(
+            &autostart_request_id,
+            &autostart_trace_id,
+            "daemon_autostart_failure",
+            "runtime_admission_denied",
+            Some(daemon_bin_path.display().to_string()),
+            Some(error.clone()),
+        ));
         anyhow::anyhow!("{error}")
     })?;
-    emit_event_best_effort(EventFields {
-        level: "info",
-        source: "atm",
-        action: "daemon_autostart_attempt",
-        result: Some("attempt".to_string()),
-        target: Some(daemon_bin_path.display().to_string()),
-        ..Default::default()
-    });
+    emit_event_best_effort(daemon_autostart_event(
+        &autostart_request_id,
+        &autostart_trace_id,
+        "daemon_autostart_attempt",
+        "attempt",
+        Some(daemon_bin_path.display().to_string()),
+        None,
+    ));
     let stderr_capture = std::env::temp_dir().join(format!(
         "atm-daemon-stderr-{}-{}.log",
         std::process::id(),
@@ -2275,15 +2306,14 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
                     std::path::PathBuf::from(&daemon_bin).display()
                 )
             };
-            emit_event_best_effort(EventFields {
-                level: "error",
-                source: "atm",
-                action: "daemon_autostart_failure",
-                result: Some("spawn_error".to_string()),
-                target: Some(daemon_bin_path.display().to_string()),
-                error: Some(error.clone()),
-                ..Default::default()
-            });
+            emit_event_best_effort(daemon_autostart_event(
+                &autostart_request_id,
+                &autostart_trace_id,
+                "daemon_autostart_failure",
+                "spawn_error",
+                Some(daemon_bin_path.display().to_string()),
+                Some(error.clone()),
+            ));
             anyhow::bail!("{error}");
         }
     };
@@ -2291,18 +2321,18 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
     let deadline = Instant::now() + Duration::from_secs(STARTUP_DEADLINE_SECS);
     while Instant::now() < deadline {
         if daemon_socket_connectable(&home) {
-            emit_event_best_effort(EventFields {
-                level: "info",
-                source: "atm",
-                action: "daemon_autostart_success",
-                result: Some("ok".to_string()),
-                target: Some(format!(
+            emit_event_best_effort(daemon_autostart_event(
+                &autostart_request_id,
+                &autostart_trace_id,
+                "daemon_autostart_success",
+                "ok",
+                Some(format!(
                     "{} {}",
                     daemon_bin_path.display(),
                     format_runtime_owner_summary(&runtime_owner)
                 )),
-                ..Default::default()
-            });
+                None,
+            ));
             return Ok(());
         }
         if let Some(status) = child.try_wait()? {
@@ -2326,15 +2356,14 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
                 }
                 None => format!("daemon process exited during startup with status {status}"),
             };
-            emit_event_best_effort(EventFields {
-                level: "error",
-                source: "atm",
-                action: "daemon_autostart_failure",
-                result: Some("process_exit".to_string()),
-                target: Some(daemon_bin_path.display().to_string()),
-                error: Some(error.clone()),
-                ..Default::default()
-            });
+            emit_event_best_effort(daemon_autostart_event(
+                &autostart_request_id,
+                &autostart_trace_id,
+                "daemon_autostart_failure",
+                "process_exit",
+                Some(daemon_bin_path.display().to_string()),
+                Some(error.clone()),
+            ));
             let _ = std::fs::remove_file(&stderr_capture);
             anyhow::bail!("{error}");
         }
@@ -2352,24 +2381,24 @@ fn ensure_daemon_running_unix() -> anyhow::Result<()> {
         pid_path.display(),
         socket_path.display()
     );
-    emit_event_best_effort(EventFields {
-        level: "warn",
-        source: "atm",
-        action: "daemon_autostart_timeout",
-        result: Some("timeout".to_string()),
-        target: Some(daemon_bin_path.display().to_string()),
-        error: Some(timeout_error.clone()),
-        ..Default::default()
-    });
-    emit_event_best_effort(EventFields {
-        level: "error",
-        source: "atm",
-        action: "daemon_autostart_failure",
-        result: Some("timeout".to_string()),
-        target: Some(daemon_bin_path.display().to_string()),
-        error: Some(timeout_error.clone()),
-        ..Default::default()
-    });
+    let mut timeout_event = daemon_autostart_event(
+        &autostart_request_id,
+        &autostart_trace_id,
+        "daemon_autostart_timeout",
+        "timeout",
+        Some(daemon_bin_path.display().to_string()),
+        Some(timeout_error.clone()),
+    );
+    timeout_event.level = "warn";
+    emit_event_best_effort(timeout_event);
+    emit_event_best_effort(daemon_autostart_event(
+        &autostart_request_id,
+        &autostart_trace_id,
+        "daemon_autostart_failure",
+        "timeout",
+        Some(daemon_bin_path.display().to_string()),
+        Some(timeout_error.clone()),
+    ));
     if child.try_wait()?.is_none() {
         let _ = child.kill();
         let _ = child.wait();

--- a/crates/atm-core/src/event_log.rs
+++ b/crates/atm-core/src/event_log.rs
@@ -66,6 +66,14 @@ fn generate_span_id(seed_parts: &[&str]) -> String {
     hex.chars().take(16).collect()
 }
 
+pub fn trace_id_for_request(source: &str, request_id: &str) -> String {
+    generate_trace_id(&[source, request_id])
+}
+
+pub fn span_id_for_action(trace_id: &str, action: &str) -> String {
+    generate_span_id(&[action, trace_id])
+}
+
 /// Forward `event` to the unified producer channel if a sender is registered.
 fn fallback_home_dir() -> Option<std::path::PathBuf> {
     crate::home::get_home_dir().ok()

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -38,6 +38,43 @@ fn new_reconcile_cycle_state() -> SharedCycleState {
     Arc::new(std::sync::Mutex::new(ReconcileCycleState::default()))
 }
 
+fn emit_plugin_lifecycle_event(
+    action: &'static str,
+    plugin_name: &str,
+    result: &'static str,
+    error: Option<String>,
+) {
+    let request_id = format!("plugin-lifecycle-{plugin_name}-{action}");
+    let trace_id =
+        agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", &request_id);
+    emit_event_best_effort(EventFields {
+        level: if error.is_some() { "error" } else { "info" },
+        source: "atm-daemon",
+        action,
+        target: Some(plugin_name.to_string()),
+        result: Some(result.to_string()),
+        request_id: Some(request_id),
+        trace_id: Some(trace_id.clone()),
+        span_id: Some(agent_team_mail_core::event_log::span_id_for_action(
+            &trace_id, action,
+        )),
+        extra_fields: {
+            let mut fields = serde_json::Map::new();
+            fields.insert(
+                "plugin".to_string(),
+                serde_json::Value::String(plugin_name.to_string()),
+            );
+            fields.insert(
+                "lifecycle_scope".to_string(),
+                serde_json::Value::String("daemon_plugin".to_string()),
+            );
+            fields
+        },
+        error,
+        ..Default::default()
+    });
+}
+
 /// Wait for a daemon shutdown task to finish within `timeout`.
 ///
 /// Shutdown tasks are expected to honor the shared [`CancellationToken`] and
@@ -142,6 +179,12 @@ pub async fn run(
     let _ = registry.init_all(ctx).await;
     let init_failed_plugins = registry.failed_init_plugins();
     for failed in &init_failed_plugins {
+        emit_plugin_lifecycle_event(
+            "plugin_init",
+            &failed.name,
+            "error",
+            Some(failed.error.clone()),
+        );
         warn!(
             plugin = %failed.name,
             error = %failed.error,
@@ -190,17 +233,26 @@ pub async fn run(
 
     for (metadata, plugin_arc) in plugins.clone() {
         let plugin_name = metadata.name.to_string();
+        emit_plugin_lifecycle_event("plugin_init", &plugin_name, "ok", None);
         let cancel_clone = cancel.clone();
 
         let task = tokio::spawn(async move {
+            emit_plugin_lifecycle_event("plugin_run_start", &plugin_name, "starting", None);
             info!("Plugin {} run() starting", plugin_name);
             let mut plugin = plugin_arc.lock().await;
 
             match plugin.run(cancel_clone).await {
                 Ok(()) => {
+                    emit_plugin_lifecycle_event("plugin_run_complete", &plugin_name, "ok", None);
                     info!("Plugin {} run() completed", plugin_name);
                 }
                 Err(e) => {
+                    emit_plugin_lifecycle_event(
+                        "plugin_run_complete",
+                        &plugin_name,
+                        "error",
+                        Some(e.to_string()),
+                    );
                     error!("Plugin {} run() failed: {}", plugin_name, e);
                 }
             }
@@ -533,10 +585,16 @@ pub async fn run(
     )
     .await;
 
+    for (metadata, _) in &plugins {
+        emit_plugin_lifecycle_event("plugin_shutdown", metadata.name, "starting", None);
+    }
     // Graceful shutdown of all plugins
     graceful_shutdown(plugins, Duration::from_secs(GRACEFUL_SHUTDOWN_TIMEOUT_SECS))
         .await
         .context("Plugin shutdown encountered errors")?;
+    for (plugin_name, _) in &plugin_tasks {
+        emit_plugin_lifecycle_event("plugin_shutdown", plugin_name, "ok", None);
+    }
 
     // Wait for plugin tasks to complete
     for (plugin_name, task) in plugin_tasks {

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -1,7 +1,9 @@
 //! Main daemon event loop
 
 use crate::daemon::pid_backend_validation::{roster_process_id, validate_pid_backend};
-use crate::daemon::status::{LoggingHealth, PluginStatus, PluginStatusKind, StatusWriter};
+use crate::daemon::status::{
+    LoggingHealth, OtelHealth, PluginStatus, PluginStatusKind, StatusWriter,
+};
 use crate::daemon::{
     InboxEvent, InboxEventKind, LogEventQueue, SharedDedupeStore, SharedPubSubStore,
     SharedSessionRegistry, SharedStateStore, SharedStreamEventSender,
@@ -1433,10 +1435,13 @@ async fn status_writer_loop(
     let plugin_statuses = build_plugin_statuses(&plugins, &init_failed_plugins, &ctx).await;
     let teams = get_active_teams(&ctx).await;
     let logging = build_logging_health(&ctx, &log_event_queue).await;
+    let otel = build_otel_health(&ctx);
     if let Err(e) = status_writer.write_daemon_touch(&teams) {
         error!("Failed to write daemon touch sidecar: {}", e);
     }
-    if let Err(e) = status_writer.write_status(plugin_statuses.clone(), teams.clone(), logging) {
+    if let Err(e) =
+        status_writer.write_status(plugin_statuses.clone(), teams.clone(), logging, otel)
+    {
         error!("Failed to write initial daemon status: {}", e);
     }
 
@@ -1456,8 +1461,9 @@ async fn status_writer_loop(
                     build_plugin_statuses(&plugins, &init_failed_plugins, &ctx).await;
                 let teams = get_active_teams(&ctx).await;
                 let logging = build_logging_health(&ctx, &log_event_queue).await;
+                let otel = build_otel_health(&ctx);
 
-                if let Err(e) = status_writer.write_status(plugin_statuses, teams, logging) {
+                if let Err(e) = status_writer.write_status(plugin_statuses, teams, logging, otel) {
                     error!("Failed to write daemon status: {}", e);
                 }
             }
@@ -1521,6 +1527,17 @@ fn build_logging_health_snapshot(
         spool_count,
         oldest_spool_age,
     }
+}
+
+fn build_otel_health(ctx: &PluginContext) -> OtelHealth {
+    let home_dir = ctx
+        .system
+        .claude_root
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let canonical_log_path = agent_team_mail_core::logging_event::configured_log_path(&home_dir);
+    sc_observability::current_otel_health(&canonical_log_path).into()
 }
 
 fn derive_logging_state(

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -1537,7 +1537,7 @@ fn build_otel_health(ctx: &PluginContext) -> OtelHealth {
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
     let canonical_log_path = agent_team_mail_core::logging_event::configured_log_path(&home_dir);
-    sc_observability::current_otel_health(&canonical_log_path).into()
+    crate::daemon::observability::current_otel_health(&canonical_log_path).into()
 }
 
 fn derive_logging_state(

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -45,8 +45,7 @@ fn emit_plugin_lifecycle_event(
     error: Option<String>,
 ) {
     let request_id = format!("plugin-lifecycle-{plugin_name}-{action}");
-    let trace_id =
-        agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", &request_id);
+    let trace_id = agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", &request_id);
     emit_event_best_effort(EventFields {
         level: if error.is_some() { "error" } else { "info" },
         source: "atm-daemon",

--- a/crates/atm-daemon/src/daemon/observability.rs
+++ b/crates/atm-daemon/src/daemon/observability.rs
@@ -8,6 +8,45 @@ pub const SOCKET_ERROR_INVALID_PAYLOAD: &str = "INVALID_PAYLOAD";
 pub const SOCKET_ERROR_INTERNAL_ERROR: &str = "INTERNAL_ERROR";
 
 pub type OtelExportHook = Arc<dyn Fn(&Path, &LogEventV1) + Send + Sync>;
+pub type OtelHealthHook = Arc<dyn Fn(&Path) -> OtelHealthSnapshot + Send + Sync>;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub struct OtelLastError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct OtelHealthSnapshot {
+    pub schema_version: String,
+    pub enabled: bool,
+    pub collector_endpoint: Option<String>,
+    pub protocol: String,
+    pub collector_state: String,
+    pub local_mirror_state: String,
+    pub local_mirror_path: String,
+    pub debug_local_export: bool,
+    pub debug_local_state: String,
+    pub last_error: OtelLastError,
+}
+
+impl Default for OtelHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: "otlp_http".to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}
 
 pub fn install_otel_export_hook(hook: OtelExportHook) {
     *otel_export_hook_slot()
@@ -21,9 +60,26 @@ pub fn clear_otel_export_hook() {
         .expect("atm-daemon otel export hook lock poisoned") = None;
 }
 
+pub fn install_otel_health_hook(hook: OtelHealthHook) {
+    *otel_health_hook_slot()
+        .lock()
+        .expect("atm-daemon otel health hook lock poisoned") = Some(hook);
+}
+
+pub fn clear_otel_health_hook() {
+    *otel_health_hook_slot()
+        .lock()
+        .expect("atm-daemon otel health hook lock poisoned") = None;
+}
+
 fn otel_export_hook_slot() -> &'static Mutex<Option<OtelExportHook>> {
     static OTEL_EXPORT_HOOK: OnceLock<Mutex<Option<OtelExportHook>>> = OnceLock::new();
     OTEL_EXPORT_HOOK.get_or_init(|| Mutex::new(None))
+}
+
+fn otel_health_hook_slot() -> &'static Mutex<Option<OtelHealthHook>> {
+    static OTEL_HEALTH_HOOK: OnceLock<Mutex<Option<OtelHealthHook>>> = OnceLock::new();
+    OTEL_HEALTH_HOOK.get_or_init(|| Mutex::new(None))
 }
 
 pub fn export_otel_best_effort(log_path: &Path, event: &LogEventV1) {
@@ -34,4 +90,12 @@ pub fn export_otel_best_effort(log_path: &Path, event: &LogEventV1) {
     if let Some(hook) = hook {
         hook(log_path, event);
     }
+}
+
+pub fn current_otel_health(log_path: &Path) -> OtelHealthSnapshot {
+    let hook = otel_health_hook_slot()
+        .lock()
+        .expect("atm-daemon otel health hook lock poisoned")
+        .clone();
+    hook.map(|hook| hook(log_path)).unwrap_or_default()
 }

--- a/crates/atm-daemon/src/daemon/startup_auth.rs
+++ b/crates/atm-daemon/src/daemon/startup_auth.rs
@@ -110,6 +110,15 @@ fn emit_lifecycle_event(
     let test_identifier = token.and_then(|value| value.test_identifier.clone());
     let owner_pid = token.and_then(|value| value.owner_pid);
     let atm_home_text = canonicalize_lossy(atm_home).display().to_string();
+    let request_id = token_id
+        .as_ref()
+        .map(|token_id| format!("daemon-launch-{token_id}"));
+    let trace_id = request_id.as_deref().map(|request_id| {
+        agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", request_id)
+    });
+    let span_id = trace_id
+        .as_deref()
+        .map(|trace_id| agent_team_mail_core::event_log::span_id_for_action(trace_id, event_name));
     let lifecycle_phase = lifecycle_phase(event_name);
     let termination_reason = termination_reason(event_name);
     let mut extra = serde_json::Map::new();
@@ -158,6 +167,9 @@ fn emit_lifecycle_event(
         source: "atm-daemon",
         action: event_name,
         result: Some(event_name.to_string()),
+        request_id,
+        trace_id,
+        span_id,
         target: Some(atm_home_text),
         error: detail.map(str::to_string),
         extra_fields: extra,
@@ -193,6 +205,15 @@ fn emit_startup_rejection(
 ) {
     let token_id = token.map(|token| token.token_id.clone());
     let atm_home_text = canonicalize_lossy(atm_home).display().to_string();
+    let request_id = token_id
+        .as_ref()
+        .map(|token_id| format!("daemon-launch-{token_id}"));
+    let trace_id = request_id.as_deref().map(|request_id| {
+        agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", request_id)
+    });
+    let span_id = trace_id.as_deref().map(|trace_id| {
+        agent_team_mail_core::event_log::span_id_for_action(trace_id, "daemon_start_rejected")
+    });
     let mut extra = serde_json::Map::new();
     extra.insert(
         "rejection_reason".to_string(),
@@ -217,6 +238,9 @@ fn emit_startup_rejection(
         source: "atm-daemon",
         action: "daemon_start_rejected",
         result: Some(reason.as_str().to_string()),
+        request_id,
+        trace_id,
+        span_id,
         target: Some(atm_home_text),
         error: detail.map(str::to_string),
         extra_fields: extra,

--- a/crates/atm-daemon/src/daemon/status.rs
+++ b/crates/atm-daemon/src/daemon/status.rs
@@ -7,7 +7,6 @@ use agent_team_mail_core::daemon_client::{
     DaemonTouchEntry, DaemonTouchSnapshot, RuntimeOwnerMetadata, daemon_touch_path_for,
 };
 use anyhow::{Context, Result};
-use sc_observability::OtelHealthSnapshot;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -87,7 +86,7 @@ impl Default for OtelHealth {
             schema_version: "v1".to_string(),
             enabled: true,
             collector_endpoint: None,
-            protocol: sc_observability::OTEL_PROTOCOL_HTTP.to_string(),
+            protocol: "otlp_http".to_string(),
             collector_state: "not_configured".to_string(),
             local_mirror_state: "healthy".to_string(),
             local_mirror_path: String::new(),
@@ -98,8 +97,8 @@ impl Default for OtelHealth {
     }
 }
 
-impl From<OtelHealthSnapshot> for OtelHealth {
-    fn from(value: OtelHealthSnapshot) -> Self {
+impl From<crate::daemon::observability::OtelHealthSnapshot> for OtelHealth {
+    fn from(value: crate::daemon::observability::OtelHealthSnapshot) -> Self {
         Self {
             schema_version: value.schema_version,
             enabled: value.enabled,

--- a/crates/atm-daemon/src/daemon/status.rs
+++ b/crates/atm-daemon/src/daemon/status.rs
@@ -7,6 +7,7 @@ use agent_team_mail_core::daemon_client::{
     DaemonTouchEntry, DaemonTouchSnapshot, RuntimeOwnerMetadata, daemon_touch_path_for,
 };
 use anyhow::{Context, Result};
+use sc_observability::OtelHealthSnapshot;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -32,6 +33,9 @@ pub struct DaemonStatus {
     /// Logging pipeline health snapshot
     #[serde(default)]
     pub logging: LoggingHealth,
+    /// OTel exporter health snapshot.
+    #[serde(default)]
+    pub otel: OtelHealth,
 }
 
 /// Logging pipeline health snapshot.
@@ -52,6 +56,67 @@ pub struct LoggingHealth {
     pub spool_count: u64,
     /// Oldest spool file age in seconds (if spool files exist).
     pub oldest_spool_age: Option<u64>,
+}
+
+/// OTel exporter health snapshot.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct OtelHealth {
+    pub schema_version: String,
+    pub enabled: bool,
+    pub collector_endpoint: Option<String>,
+    pub protocol: String,
+    pub collector_state: String,
+    pub local_mirror_state: String,
+    pub local_mirror_path: String,
+    pub debug_local_export: bool,
+    pub debug_local_state: String,
+    pub last_error: OtelLastError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OtelLastError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub at: Option<String>,
+}
+
+impl Default for OtelHealth {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: sc_observability::OTEL_PROTOCOL_HTTP.to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}
+
+impl From<OtelHealthSnapshot> for OtelHealth {
+    fn from(value: OtelHealthSnapshot) -> Self {
+        Self {
+            schema_version: value.schema_version,
+            enabled: value.enabled,
+            collector_endpoint: value.collector_endpoint,
+            protocol: value.protocol,
+            collector_state: value.collector_state,
+            local_mirror_state: value.local_mirror_state,
+            local_mirror_path: value.local_mirror_path,
+            debug_local_export: value.debug_local_export,
+            debug_local_state: value.debug_local_state,
+            last_error: OtelLastError {
+                code: value.last_error.code,
+                message: value.last_error.message,
+                at: value.last_error.at,
+            },
+        }
+    }
 }
 
 impl Default for LoggingHealth {
@@ -218,6 +283,7 @@ impl StatusWriter {
         plugins: Vec<PluginStatus>,
         teams: Vec<String>,
         logging: LoggingHealth,
+        otel: OtelHealth,
     ) -> Result<()> {
         // Ensure parent directory exists
         if let Some(parent) = self.status_path.parent() {
@@ -241,6 +307,7 @@ impl StatusWriter {
             plugins,
             teams,
             logging,
+            otel,
         };
 
         // Serialize to JSON
@@ -301,6 +368,21 @@ mod tests {
         }
     }
 
+    fn otel_health() -> OtelHealth {
+        OtelHealth {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: Some("http://collector:4318".to_string()),
+            protocol: "otlp_http".to_string(),
+            collector_state: "healthy".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: "atm.log.otel.jsonl".to_string(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+
     fn runtime_owner(home: &std::path::Path) -> RuntimeOwnerMetadata {
         RuntimeOwnerMetadata {
             runtime_kind: RuntimeKind::Isolated,
@@ -330,7 +412,7 @@ mod tests {
         let teams = vec!["test-team".to_string()];
 
         writer
-            .write_status(plugins, teams, logging_health())
+            .write_status(plugins, teams, logging_health(), otel_health())
             .unwrap();
 
         assert!(writer.status_path().exists());
@@ -378,7 +460,12 @@ mod tests {
 
         // First write
         writer
-            .write_status(plugins.clone(), teams.clone(), logging_health())
+            .write_status(
+                plugins.clone(),
+                teams.clone(),
+                logging_health(),
+                otel_health(),
+            )
             .unwrap();
         let first_content = std::fs::read_to_string(writer.status_path()).unwrap();
 
@@ -386,7 +473,7 @@ mod tests {
         // Sleep for more than 1 second to ensure timestamp changes
         std::thread::sleep(std::time::Duration::from_millis(1100));
         writer
-            .write_status(plugins, teams, logging_health())
+            .write_status(plugins, teams, logging_health(), otel_health())
             .unwrap();
         let second_content = std::fs::read_to_string(writer.status_path()).unwrap();
 
@@ -423,7 +510,12 @@ mod tests {
         let teams = vec!["my-team".to_string()];
 
         writer
-            .write_status(plugins.clone(), teams.clone(), logging_health())
+            .write_status(
+                plugins.clone(),
+                teams.clone(),
+                logging_health(),
+                otel_health(),
+            )
             .unwrap();
 
         // Read back and verify structure
@@ -474,7 +566,12 @@ mod tests {
 
         // First write
         writer
-            .write_status(plugins.clone(), teams.clone(), logging_health())
+            .write_status(
+                plugins.clone(),
+                teams.clone(),
+                logging_health(),
+                otel_health(),
+            )
             .unwrap();
         let first_content = std::fs::read_to_string(writer.status_path()).unwrap();
         let first_status: DaemonStatus = serde_json::from_str(&first_content).unwrap();
@@ -484,7 +581,7 @@ mod tests {
 
         // Second write
         writer
-            .write_status(plugins, teams, logging_health())
+            .write_status(plugins, teams, logging_health(), otel_health())
             .unwrap();
         let second_content = std::fs::read_to_string(writer.status_path()).unwrap();
         let second_status: DaemonStatus = serde_json::from_str(&second_content).unwrap();

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -24,6 +24,28 @@ fn export_otel_from_entrypoint(
     sc_observability::export_otel_best_effort_from_path(log_path, event);
 }
 
+fn current_otel_health_from_entrypoint(
+    log_path: &std::path::Path,
+) -> agent_team_mail_daemon::daemon::observability::OtelHealthSnapshot {
+    let health = sc_observability::current_otel_health(log_path);
+    agent_team_mail_daemon::daemon::observability::OtelHealthSnapshot {
+        schema_version: health.schema_version,
+        enabled: health.enabled,
+        collector_endpoint: health.collector_endpoint,
+        protocol: health.protocol,
+        collector_state: health.collector_state,
+        local_mirror_state: health.local_mirror_state,
+        local_mirror_path: health.local_mirror_path,
+        debug_local_export: health.debug_local_export,
+        debug_local_state: health.debug_local_state,
+        last_error: agent_team_mail_daemon::daemon::observability::OtelLastError {
+            code: health.last_error.code,
+            message: health.last_error.message,
+            at: health.last_error.at,
+        },
+    }
+}
+
 /// ATM Daemon - Background service for agent team mail plugins
 #[derive(Parser, Debug)]
 #[command(name = "atm-daemon")]
@@ -388,6 +410,7 @@ async fn main() -> Result<()> {
     let log_event_queue = new_log_event_queue();
     let log_cancel = cancel_token.clone();
     daemon::observability::install_otel_export_hook(Arc::new(export_otel_from_entrypoint));
+    daemon::observability::install_otel_health_hook(Arc::new(current_otel_health_from_entrypoint));
     tokio::spawn(run_log_writer_task(
         log_event_queue.clone(),
         log_writer_config,

--- a/crates/atm/src/commands/daemon.rs
+++ b/crates/atm/src/commands/daemon.rs
@@ -15,7 +15,10 @@ use std::time::{Duration, Instant, SystemTime};
 use sysinfo::{Pid, ProcessStatus, System};
 use uuid::Uuid;
 
-use crate::commands::logging_health::{LoggingHealthSnapshot, build_logging_health_contract};
+use crate::commands::logging_health::{
+    LoggingHealthSnapshot, OtelHealthSnapshot, build_logging_health_contract,
+    build_otel_health_contract,
+};
 use crate::util::settings::{get_home_dir, teams_root_dir_for};
 use agent_team_mail_core::daemon_client::{
     create_isolated_runtime_root, daemon_status_path_for, reap_expired_isolated_runtime_roots,
@@ -830,15 +833,21 @@ fn execute_status(args: StatusArgs) -> Result<()> {
     let is_stale = is_status_stale(&status.timestamp, stale_threshold_secs);
 
     let logging_health = build_logging_health_contract(&status.logging, &home_dir);
+    let otel_health = build_otel_health_contract(&status.otel);
 
     if args.json {
         // Output as JSON with stale flag and canonical logging schema.
         let mut output = serde_json::to_value(&status)?;
         if let Some(obj) = output.as_object_mut() {
             obj.remove("logging");
+            obj.remove("otel");
             obj.insert(
                 "logging_health".to_string(),
                 serde_json::to_value(&logging_health)?,
+            );
+            obj.insert(
+                "otel_health".to_string(),
+                serde_json::to_value(&otel_health)?,
             );
             obj.insert("stale".to_string(), serde_json::Value::Bool(is_stale));
         }
@@ -966,6 +975,28 @@ fn execute_status(args: StatusArgs) -> Result<()> {
         if let Some(last_at) = &logging_health.last_error.at {
             println!("  last_error.at:   {last_at}");
         }
+        println!();
+        println!("OTel:");
+        println!("  schema_version:  {}", otel_health.schema_version);
+        println!("  enabled:         {}", otel_health.enabled);
+        println!("  protocol:        {}", otel_health.protocol);
+        println!("  collector_state: {}", otel_health.collector_state);
+        println!("  local_mirror_state: {}", otel_health.local_mirror_state);
+        println!("  local_mirror_path:  {}", otel_health.local_mirror_path);
+        println!("  debug_local_export: {}", otel_health.debug_local_export);
+        println!("  debug_local_state:  {}", otel_health.debug_local_state);
+        if let Some(endpoint) = &otel_health.collector_endpoint {
+            println!("  collector_endpoint: {endpoint}");
+        }
+        if let Some(last_code) = &otel_health.last_error.code {
+            println!("  last_error.code: {last_code}");
+        }
+        if let Some(last_message) = &otel_health.last_error.message {
+            println!("  last_error.message: {last_message}");
+        }
+        if let Some(last_at) = &otel_health.last_error.at {
+            println!("  last_error.at:   {last_at}");
+        }
     }
 
     // Exit with error code if stale
@@ -1047,6 +1078,8 @@ struct DaemonStatus {
     teams: Vec<String>,
     #[serde(default)]
     logging: LoggingHealthSnapshot,
+    #[serde(default)]
+    otel: OtelHealthSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -33,8 +33,8 @@ use crate::commands::init::{
     session_end_cmd, session_start_cmd, stop_cmd,
 };
 use crate::commands::logging_health::{
-    LoggingHealthContract, LoggingHealthSnapshot, build_logging_health_contract,
-    logging_remediation,
+    LoggingHealthContract, LoggingHealthSnapshot, OtelHealthContract, OtelHealthSnapshot,
+    build_logging_health_contract, build_otel_health_contract, logging_remediation,
 };
 use crate::util::caller_identity::resolve_caller_session_id_optional;
 use crate::util::member_labels::UNREGISTERED_MARKER;
@@ -141,6 +141,8 @@ struct DoctorReport {
     gh_rate_limit_audit: Option<GhRateLimitAudit>,
     #[serde(default)]
     logging_health: LoggingHealthContract,
+    #[serde(default)]
+    otel_health: OtelHealthContract,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     members: Vec<MemberSnapshot>,
     #[serde(skip_serializing, skip_deserializing, default)]
@@ -205,6 +207,8 @@ struct DaemonStatusSnapshot {
     plugins: Vec<PluginStatusSnapshot>,
     #[serde(default)]
     logging: LoggingHealthSnapshot,
+    #[serde(default)]
+    otel: OtelHealthSnapshot,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -382,6 +386,7 @@ fn build_report(home_dir: &Path, team: &str, args: &DoctorArgs) -> Result<Doctor
     };
     let logging = daemon_status.logging;
     let logging_health = build_logging_health_contract(&logging, home_dir);
+    let otel_health = build_otel_health_contract(&daemon_status.otel);
 
     let member_snapshot = build_member_snapshot(team_config.as_ref(), &daemon_states_by_agent);
     Ok(DoctorReport {
@@ -400,6 +405,7 @@ fn build_report(home_dir: &Path, team: &str, args: &DoctorArgs) -> Result<Doctor
         env_overrides: active_env_overrides(),
         gh_rate_limit_audit: None,
         logging_health,
+        otel_health,
         members: member_snapshot.clone(),
         member_snapshot,
     })
@@ -1228,12 +1234,14 @@ fn read_daemon_status(home_dir: &Path) -> DaemonStatusSnapshot {
             version: None,
             plugins: Vec::new(),
             logging: LoggingHealthSnapshot::default(),
+            otel: OtelHealthSnapshot::default(),
         };
     };
     serde_json::from_str(&raw).unwrap_or(DaemonStatusSnapshot {
         version: None,
         plugins: Vec::new(),
         logging: LoggingHealthSnapshot::default(),
+        otel: OtelHealthSnapshot::default(),
     })
 }
 
@@ -1886,6 +1894,46 @@ fn render_human(report: &DoctorReport) -> String {
     }
     if let Some(remediation) = logging_remediation(&report.logging_health.state) {
         out.push_str(&format!("  remediation: {remediation}\n"));
+    }
+    out.push('\n');
+    out.push_str("OTel health:\n");
+    out.push_str(&format!(
+        "  schema_version: {}\n",
+        report.otel_health.schema_version
+    ));
+    out.push_str(&format!("  enabled: {}\n", report.otel_health.enabled));
+    out.push_str(&format!("  protocol: {}\n", report.otel_health.protocol));
+    out.push_str(&format!(
+        "  collector_state: {}\n",
+        report.otel_health.collector_state
+    ));
+    out.push_str(&format!(
+        "  local_mirror_state: {}\n",
+        report.otel_health.local_mirror_state
+    ));
+    out.push_str(&format!(
+        "  local_mirror_path: {}\n",
+        report.otel_health.local_mirror_path
+    ));
+    out.push_str(&format!(
+        "  debug_local_export: {}\n",
+        report.otel_health.debug_local_export
+    ));
+    out.push_str(&format!(
+        "  debug_local_state: {}\n",
+        report.otel_health.debug_local_state
+    ));
+    if let Some(endpoint) = &report.otel_health.collector_endpoint {
+        out.push_str(&format!("  collector_endpoint: {endpoint}\n"));
+    }
+    if let Some(code) = &report.otel_health.last_error.code {
+        out.push_str(&format!("  last_error.code: {code}\n"));
+    }
+    if let Some(message) = &report.otel_health.last_error.message {
+        out.push_str(&format!("  last_error.message: {message}\n"));
+    }
+    if let Some(at) = &report.otel_health.last_error.at {
+        out.push_str(&format!("  last_error.at: {at}\n"));
     }
     out.push('\n');
 
@@ -3246,6 +3294,7 @@ mod tests {
             env_overrides: EnvOverrides::default(),
             gh_rate_limit_audit: None,
             logging_health: LoggingHealthContract::default(),
+            otel_health: OtelHealthContract::default(),
             members: vec![MemberSnapshot {
                 name: "team-lead".to_string(),
                 agent_type: "team-lead".to_string(),
@@ -3352,6 +3401,7 @@ mod tests {
             },
             gh_rate_limit_audit: None,
             logging_health: LoggingHealthContract::default(),
+            otel_health: OtelHealthContract::default(),
             members: vec![MemberSnapshot {
                 name: "arch-ctm".to_string(),
                 agent_type: "codex".to_string(),
@@ -3486,6 +3536,7 @@ mod tests {
             },
             gh_rate_limit_audit: None,
             logging_health: LoggingHealthContract::default(),
+            otel_health: OtelHealthContract::default(),
             members: vec![],
             member_snapshot: vec![],
         };
@@ -3525,6 +3576,7 @@ mod tests {
             env_overrides: EnvOverrides::default(),
             gh_rate_limit_audit: None,
             logging_health: LoggingHealthContract::default(),
+            otel_health: OtelHealthContract::default(),
             members: vec![MemberSnapshot {
                 name: "arch-ctm".to_string(),
                 agent_type: "codex".to_string(),
@@ -3586,6 +3638,7 @@ mod tests {
             env_overrides: EnvOverrides::default(),
             gh_rate_limit_audit: None,
             logging_health: LoggingHealthContract::default(),
+            otel_health: OtelHealthContract::default(),
             members: vec![
                 MemberSnapshot {
                     name: "arch-ctm".to_string(),

--- a/crates/atm/src/commands/logging_health.rs
+++ b/crates/atm/src/commands/logging_health.rs
@@ -17,6 +17,38 @@ pub(crate) struct LoggingHealthSnapshot {
     pub(crate) oldest_spool_age: Option<u64>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub(crate) struct OtelHealthSnapshot {
+    pub(crate) schema_version: String,
+    pub(crate) enabled: bool,
+    pub(crate) collector_endpoint: Option<String>,
+    pub(crate) protocol: String,
+    pub(crate) collector_state: String,
+    pub(crate) local_mirror_state: String,
+    pub(crate) local_mirror_path: String,
+    pub(crate) debug_local_export: bool,
+    pub(crate) debug_local_state: String,
+    pub(crate) last_error: OtelLastError,
+}
+
+impl Default for OtelHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: "otlp_http".to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}
+
 impl Default for LoggingHealthSnapshot {
     fn default() -> Self {
         Self {
@@ -38,6 +70,13 @@ pub(crate) struct LastError {
     pub(crate) at: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct OtelLastError {
+    pub(crate) code: Option<String>,
+    pub(crate) message: Option<String>,
+    pub(crate) at: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct LoggingHealthContract {
     pub(crate) schema_version: String,
@@ -49,6 +88,37 @@ pub(crate) struct LoggingHealthContract {
     pub(crate) spool_file_count: u64,
     pub(crate) oldest_spool_age_seconds: Option<u64>,
     pub(crate) last_error: LastError,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OtelHealthContract {
+    pub(crate) schema_version: String,
+    pub(crate) enabled: bool,
+    pub(crate) collector_endpoint: Option<String>,
+    pub(crate) protocol: String,
+    pub(crate) collector_state: String,
+    pub(crate) local_mirror_state: String,
+    pub(crate) local_mirror_path: String,
+    pub(crate) debug_local_export: bool,
+    pub(crate) debug_local_state: String,
+    pub(crate) last_error: OtelLastError,
+}
+
+impl Default for OtelHealthContract {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: "otlp_http".to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
 }
 
 impl Default for LoggingHealthContract {
@@ -71,6 +141,8 @@ impl Default for LoggingHealthContract {
 struct DaemonStatusSnapshot {
     #[serde(default)]
     logging: LoggingHealthSnapshot,
+    #[serde(default)]
+    otel: OtelHealthSnapshot,
 }
 
 pub(crate) fn read_daemon_logging_health(home_dir: &Path) -> LoggingHealthSnapshot {
@@ -80,6 +152,16 @@ pub(crate) fn read_daemon_logging_health(home_dir: &Path) -> LoggingHealthSnapsh
     };
     serde_json::from_str::<DaemonStatusSnapshot>(&content)
         .map(|status| status.logging)
+        .unwrap_or_default()
+}
+
+pub(crate) fn read_daemon_otel_health(home_dir: &Path) -> OtelHealthSnapshot {
+    let status_path = daemon_status_path_for(home_dir);
+    let Ok(content) = fs::read_to_string(status_path) else {
+        return OtelHealthSnapshot::default();
+    };
+    serde_json::from_str::<DaemonStatusSnapshot>(&content)
+        .map(|status| status.otel)
         .unwrap_or_default()
 }
 
@@ -99,6 +181,21 @@ pub(crate) fn build_logging_health_contract(
         spool_file_count: logging.spool_count,
         oldest_spool_age_seconds: logging.oldest_spool_age,
         last_error,
+    }
+}
+
+pub(crate) fn build_otel_health_contract(otel: &OtelHealthSnapshot) -> OtelHealthContract {
+    OtelHealthContract {
+        schema_version: otel.schema_version.clone(),
+        enabled: otel.enabled,
+        collector_endpoint: otel.collector_endpoint.clone(),
+        protocol: otel.protocol.clone(),
+        collector_state: otel.collector_state.clone(),
+        local_mirror_state: otel.local_mirror_state.clone(),
+        local_mirror_path: otel.local_mirror_path.clone(),
+        debug_local_export: otel.debug_local_export,
+        debug_local_state: otel.debug_local_state.clone(),
+        last_error: otel.last_error.clone(),
     }
 }
 

--- a/crates/atm/src/commands/mod.rs
+++ b/crates/atm/src/commands/mod.rs
@@ -123,6 +123,36 @@ enum Commands {
 }
 
 impl Cli {
+    pub fn command_name(&self) -> &'static str {
+        match &self.command {
+            Commands::Ack(_) => "ack",
+            Commands::Send(_) => "send",
+            Commands::Broadcast(_) => "broadcast",
+            Commands::Read(_) => "read",
+            Commands::Request(_) => "request",
+            Commands::Inbox(_) => "inbox",
+            Commands::Teams(_) => "teams",
+            Commands::Members(_) => "members",
+            Commands::Status(_) => "status",
+            Commands::Spawn(_) => "spawn",
+            Commands::Doctor(_) => "doctor",
+            Commands::Gh(_) => "gh",
+            Commands::Monitor(_) => "monitor",
+            Commands::Config(_) => "config",
+            Commands::Cleanup(_) => "cleanup",
+            Commands::Bridge(_) => "bridge",
+            Commands::Daemon(_) => "daemon",
+            Commands::Subscribe(_) => "subscribe",
+            Commands::Unsubscribe(_) => "unsubscribe",
+            Commands::Tail(_) => "tail",
+            Commands::Launch(_) => "launch",
+            Commands::Logs(_) => "logs",
+            Commands::Register(_) => "register",
+            Commands::Mcp(_) => "mcp",
+            Commands::Init(_) => "init",
+        }
+    }
+
     /// Execute the CLI command
     pub fn execute(self) -> Result<()> {
         match self.command {

--- a/crates/atm/src/commands/status.rs
+++ b/crates/atm/src/commands/status.rs
@@ -13,7 +13,8 @@ use std::collections::{BTreeSet, HashMap};
 use std::fs;
 
 use crate::commands::logging_health::{
-    build_logging_health_contract, logging_remediation, read_daemon_logging_health,
+    build_logging_health_contract, build_otel_health_contract, logging_remediation,
+    read_daemon_logging_health, read_daemon_otel_health,
 };
 use crate::util::member_labels::{GHOST_SUFFIX, UNREGISTERED_MARKER};
 use crate::util::settings::{get_home_dir, teams_root_dir_for};
@@ -82,6 +83,8 @@ pub fn execute(args: StatusArgs) -> Result<()> {
     let member_rows = build_status_member_rows(&team_config, &daemon_states);
     let logging = read_daemon_logging_health(&home_dir);
     let logging_health = build_logging_health_contract(&logging, &home_dir);
+    let otel = read_daemon_otel_health(&home_dir);
+    let otel_health = build_otel_health_contract(&otel);
 
     // Count inbox message states for each member
     let inbox_counts = count_inbox_messages(&team_dir, &member_rows)?;
@@ -124,6 +127,8 @@ pub fn execute(args: StatusArgs) -> Result<()> {
             },
             "logging_health": serde_json::to_value(&logging_health)
                 .expect("logging_health should serialize"),
+            "otel_health": serde_json::to_value(&otel_health)
+                .expect("otel_health should serialize"),
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
     } else {
@@ -191,6 +196,28 @@ pub fn execute(args: StatusArgs) -> Result<()> {
         }
         if let Some(remediation) = logging_remediation(&logging.state) {
             println!("  remediation:     {remediation}");
+        }
+        println!();
+        println!("OTel:");
+        println!("  schema_version:  {}", otel_health.schema_version);
+        println!("  enabled:         {}", otel_health.enabled);
+        println!("  protocol:        {}", otel_health.protocol);
+        println!("  collector_state: {}", otel_health.collector_state);
+        println!("  local_mirror_state: {}", otel_health.local_mirror_state);
+        println!("  local_mirror_path:  {}", otel_health.local_mirror_path);
+        println!("  debug_local_export: {}", otel_health.debug_local_export);
+        println!("  debug_local_state:  {}", otel_health.debug_local_state);
+        if let Some(endpoint) = &otel_health.collector_endpoint {
+            println!("  collector_endpoint: {endpoint}");
+        }
+        if let Some(code) = &otel_health.last_error.code {
+            println!("  last_error.code: {code}");
+        }
+        if let Some(message) = &otel_health.last_error.message {
+            println!("  last_error.message: {message}");
+        }
+        if let Some(at) = &otel_health.last_error.at {
+            println!("  last_error.at:   {at}");
         }
     }
 

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -6,6 +6,7 @@
 use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
 use agent_team_mail_core::logging;
 use clap::Parser;
+use uuid::Uuid;
 
 mod commands;
 mod consts;
@@ -34,6 +35,34 @@ fn main() {
     .unwrap_or_else(|_| logging::init_stderr_only());
 
     let cli = Cli::parse();
+    let command_name = cli.command_name().to_string();
+    let request_id = Uuid::new_v4().to_string();
+    let trace_id = agent_team_mail_core::event_log::trace_id_for_request("atm", &request_id);
+    let start_span_id =
+        agent_team_mail_core::event_log::span_id_for_action(&trace_id, "command_start");
+
+    emit_event_best_effort(EventFields {
+        level: "info",
+        source: "atm",
+        action: "command_start",
+        team: std::env::var("ATM_TEAM").ok(),
+        session_id: std::env::var("CLAUDE_SESSION_ID").ok(),
+        agent_id: std::env::var("ATM_IDENTITY").ok(),
+        agent_name: std::env::var("ATM_IDENTITY").ok(),
+        result: Some("starting".to_string()),
+        request_id: Some(request_id.clone()),
+        trace_id: Some(trace_id.clone()),
+        span_id: Some(start_span_id),
+        extra_fields: {
+            let mut fields = serde_json::Map::new();
+            fields.insert(
+                "command".to_string(),
+                serde_json::Value::String(command_name.clone()),
+            );
+            fields
+        },
+        ..Default::default()
+    });
 
     let exit_code = if let Err(e) = cli.execute() {
         let rendered = e.to_string();
@@ -44,7 +73,21 @@ fn main() {
             team: std::env::var("ATM_TEAM").ok(),
             session_id: std::env::var("CLAUDE_SESSION_ID").ok(),
             result: Some("error".to_string()),
+            request_id: Some(request_id.clone()),
+            trace_id: Some(trace_id.clone()),
+            span_id: Some(agent_team_mail_core::event_log::span_id_for_action(
+                &trace_id,
+                "command_error",
+            )),
             error: Some(rendered.clone()),
+            extra_fields: {
+                let mut fields = serde_json::Map::new();
+                fields.insert(
+                    "command".to_string(),
+                    serde_json::Value::String(command_name.clone()),
+                );
+                fields
+            },
             ..Default::default()
         });
         if serde_json::from_str::<serde_json::Value>(&rendered).is_ok() {
@@ -54,6 +97,31 @@ fn main() {
         }
         1
     } else {
+        emit_event_best_effort(EventFields {
+            level: "info",
+            source: "atm",
+            action: "command_success",
+            team: std::env::var("ATM_TEAM").ok(),
+            session_id: std::env::var("CLAUDE_SESSION_ID").ok(),
+            agent_id: std::env::var("ATM_IDENTITY").ok(),
+            agent_name: std::env::var("ATM_IDENTITY").ok(),
+            result: Some("ok".to_string()),
+            request_id: Some(request_id.clone()),
+            trace_id: Some(trace_id.clone()),
+            span_id: Some(agent_team_mail_core::event_log::span_id_for_action(
+                &trace_id,
+                "command_success",
+            )),
+            extra_fields: {
+                let mut fields = serde_json::Map::new();
+                fields.insert(
+                    "command".to_string(),
+                    serde_json::Value::String(command_name.clone()),
+                );
+                fields
+            },
+            ..Default::default()
+        });
         0
     };
 

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -221,10 +221,11 @@ while running:
         if request_log_path:
             request_log_file = Path(request_log_path)
             request_log_file.parent.mkdir(parents=True, exist_ok=True)
-            request_log_file.write_text(json.dumps({
-                "command": command,
-                "payload": payload,
-            }))
+            with request_log_file.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps({
+                    "command": command,
+                    "payload": payload,
+                }) + "\n")
 
         if command == "gh-monitor":
             if monitor_delay_ms > 0:
@@ -411,6 +412,18 @@ fn start_fake_gh_daemon(home: &Path) -> Child {
 #[cfg(unix)]
 fn start_fake_gh_daemon_with_mode(home: &Path, configured: bool, enabled: bool) -> Child {
     start_fake_gh_daemon_with_mode_and_delays(home, configured, enabled, 0, 0, None)
+}
+
+#[cfg(unix)]
+fn read_last_request_matching(request_log: &std::path::Path, command: &str) -> serde_json::Value {
+    std::fs::read_to_string(request_log)
+        .unwrap()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .rev()
+        .find(|request| request["command"].as_str() == Some(command))
+        .unwrap_or_else(|| panic!("missing {command} request in {}", request_log.display()))
 }
 
 /// Start the fake daemon with an explicit request log path.
@@ -1170,8 +1183,7 @@ fn test_gh_monitor_infers_repo_scope_from_git_remote() {
         .stdout
         .clone();
     let _json: serde_json::Value = serde_json::from_slice(&output).unwrap();
-    let request: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&request_log).unwrap()).unwrap();
+    let request = read_last_request_matching(&request_log, "gh-monitor");
     assert_eq!(request["command"].as_str(), Some("gh-monitor"));
     assert_eq!(
         request["payload"]["repo"].as_str(),
@@ -1223,8 +1235,7 @@ fn test_gh_monitor_repo_override_accepts_github_url_and_cc() {
         .stdout
         .clone();
     let _json: serde_json::Value = serde_json::from_slice(&output).unwrap();
-    let request: serde_json::Value =
-        serde_json::from_str(&std::fs::read_to_string(&request_log).unwrap()).unwrap();
+    let request = read_last_request_matching(&request_log, "gh-monitor");
     assert_eq!(
         request["payload"]["repo"].as_str(),
         Some("example/other-repo")

--- a/crates/atm/tests/integration_logging_health_schema.rs
+++ b/crates/atm/tests/integration_logging_health_schema.rs
@@ -56,11 +56,43 @@ fn setup_daemon_status(home: &Path) {
                 "canonical_log_path": log_path,
                 "spool_count": 3,
                 "oldest_spool_age": 15
+            },
+            "otel": {
+                "schema_version": "v1",
+                "enabled": true,
+                "collector_endpoint": "http://collector:4318",
+                "protocol": "otlp_http",
+                "collector_state": "degraded",
+                "local_mirror_state": "healthy",
+                "local_mirror_path": tmp.join("atm.log.otel.jsonl").to_string_lossy(),
+                "debug_local_export": false,
+                "debug_local_state": "disabled",
+                "last_error": {
+                    "code": "COLLECTOR_EXPORT_FAILED",
+                    "message": "collector timeout",
+                    "at": "2026-03-18T00:00:00Z"
+                }
             }
         })
         .to_string(),
     )
     .expect("write daemon status");
+}
+
+fn assert_canonical_otel_health(otel_health: &Value) {
+    assert_eq!(otel_health["schema_version"], "v1");
+    assert!(otel_health["enabled"].is_boolean());
+    assert!(
+        otel_health["collector_endpoint"].is_string()
+            || otel_health["collector_endpoint"].is_null()
+    );
+    assert!(otel_health["protocol"].is_string());
+    assert!(otel_health["collector_state"].is_string());
+    assert!(otel_health["local_mirror_state"].is_string());
+    assert!(otel_health["local_mirror_path"].is_string());
+    assert!(otel_health["debug_local_export"].is_boolean());
+    assert!(otel_health["debug_local_state"].is_string());
+    assert!(otel_health["last_error"].is_object());
 }
 
 fn assert_canonical_logging_health(logging_health: &Value) {
@@ -119,10 +151,14 @@ fn status_json_includes_extended_logging_fields() {
     );
     let logging_health = &value["logging_health"];
     assert_canonical_logging_health(logging_health);
+    let otel_health = &value["otel_health"];
+    assert_canonical_otel_health(otel_health);
     assert_eq!(logging_health["state"], "degraded_spooling");
     assert_eq!(logging_health["spool_file_count"], 3);
     assert_eq!(logging_health["dropped_events_total"], 2);
     assert_eq!(logging_health["last_error"]["code"], "DEGRADED_SPOOLING");
+    assert_eq!(otel_health["collector_state"], "degraded");
+    assert_eq!(otel_health["last_error"]["code"], "COLLECTOR_EXPORT_FAILED");
 }
 
 #[test]
@@ -155,6 +191,7 @@ fn doctor_json_includes_extended_logging_fields() {
     );
     let logging_health = &value["logging_health"];
     assert_canonical_logging_health(logging_health);
+    assert_canonical_otel_health(&value["otel_health"]);
 }
 
 #[test]
@@ -185,10 +222,13 @@ fn daemon_status_json_includes_extended_logging_fields() {
     );
     let logging_health = &value["logging_health"];
     assert_canonical_logging_health(logging_health);
+    let otel_health = &value["otel_health"];
+    assert_canonical_otel_health(otel_health);
     assert_eq!(logging_health["state"], "degraded_spooling");
     assert_eq!(logging_health["spool_file_count"], 3);
     assert_eq!(logging_health["dropped_events_total"], 2);
     assert_eq!(logging_health["last_error"]["code"], "DEGRADED_SPOOLING");
+    assert_eq!(otel_health["collector_state"], "degraded");
 }
 
 #[test]
@@ -249,6 +289,12 @@ fn doctor_and_status_logging_health_schema_parity() {
     assert_canonical_logging_health(status_health);
     assert_canonical_logging_health(doctor_health);
     assert_canonical_logging_health(daemon_health);
+    let status_otel = &status_value["otel_health"];
+    let doctor_otel = &doctor_value["otel_health"];
+    let daemon_otel = &daemon_value["otel_health"];
+    assert_canonical_otel_health(status_otel);
+    assert_canonical_otel_health(doctor_otel);
+    assert_canonical_otel_health(daemon_otel);
 
     let status_keys = status_health
         .as_object()
@@ -303,4 +349,25 @@ fn doctor_and_status_logging_health_schema_parity() {
         status_last_error_keys, daemon_last_error_keys,
         "daemon/status logging_health.last_error keys must be identical"
     );
+
+    let status_otel_keys = status_otel
+        .as_object()
+        .expect("status otel_health object")
+        .keys()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let doctor_otel_keys = doctor_otel
+        .as_object()
+        .expect("doctor otel_health object")
+        .keys()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    let daemon_otel_keys = daemon_otel
+        .as_object()
+        .expect("daemon otel_health object")
+        .keys()
+        .cloned()
+        .collect::<std::collections::BTreeSet<_>>();
+    assert_eq!(status_otel_keys, doctor_otel_keys);
+    assert_eq!(status_otel_keys, daemon_otel_keys);
 }

--- a/crates/sc-compose/tests/cli_smoke.rs
+++ b/crates/sc-compose/tests/cli_smoke.rs
@@ -27,6 +27,14 @@ fn read_log_lines(path: &Path) -> Vec<String> {
         .collect()
 }
 
+fn read_otel_events(path: &Path) -> Vec<Value> {
+    fs::read_to_string(path)
+        .expect("otel sidecar should be readable")
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).expect("each otel line must be valid json"))
+        .collect()
+}
+
 #[test]
 fn render_round_trip() {
     let tmp = TempDir::new().expect("tempdir");
@@ -449,6 +457,54 @@ fn sc_compose_log_format_human_writes_human_readable_lines() {
         serde_json::from_str::<Value>(&lines[0]).is_err(),
         "human mode should not emit JSONL: {}",
         lines[0]
+    );
+}
+
+#[test]
+fn sc_compose_and_sc_composer_emit_otel_sidecar_when_enabled() {
+    let tmp = TempDir::new().expect("tempdir");
+    let log_path = tmp.path().join("sc-compose.log");
+    let otel_path = tmp.path().join("sc-compose.otel.jsonl");
+    let include = tmp.path().join("include.md.j2");
+    let template = tmp.path().join("template.md.j2");
+    fs::write(&include, "included {{ name }}").expect("write include");
+    fs::write(&template, "@<include.md.j2>\nhello {{ name }}").expect("write template");
+
+    run_sc_compose()
+        .env("SC_COMPOSE_LOG_FILE", &log_path)
+        .env("ATM_OTEL_ENABLED", "true")
+        .arg("--root")
+        .arg(tmp.path())
+        .arg("--var")
+        .arg("name=Kai")
+        .arg("render")
+        .arg(&template)
+        .assert()
+        .success();
+
+    assert!(
+        otel_path.exists(),
+        "otel sidecar should exist: {}",
+        otel_path.display()
+    );
+    let events = read_otel_events(&otel_path);
+    assert!(
+        events.iter().any(|event| event["name"] == "command_start"),
+        "command_start otel event missing: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| event["name"] == "command_end"),
+        "command_end otel event missing: {events:?}"
+    );
+    assert!(
+        events.iter().any(|event| event["name"] == "compose"),
+        "sc-composer compose otel event missing: {events:?}"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|event| event["attributes"]["runtime"] == "claude"),
+        "otel events should include runtime attribute from shared facade: {events:?}"
     );
 }
 

--- a/crates/sc-composer/src/lib.rs
+++ b/crates/sc-composer/src/lib.rs
@@ -85,6 +85,16 @@ impl Default for ComposePolicy {
     }
 }
 
+fn runtime_name(runtime: RuntimeKind) -> &'static str {
+    match runtime {
+        RuntimeKind::Claude => "claude",
+        RuntimeKind::Codex => "codex",
+        RuntimeKind::Gemini => "gemini",
+        RuntimeKind::Opencode => "opencode",
+        RuntimeKind::Custom => "custom",
+    }
+}
+
 /// Input request for compose/validate operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ComposeRequest {
@@ -219,7 +229,7 @@ pub fn compose(request: &ComposeRequest) -> Result<ComposeResult, ComposerError>
             "ok",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "resolved_files": composed.resolved_files.len(),
                 "warnings": composed.warnings.len(),
             }),
@@ -229,7 +239,7 @@ pub fn compose(request: &ComposeRequest) -> Result<ComposeResult, ComposerError>
             "err",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "error": err.to_string(),
             }),
         ),
@@ -247,7 +257,7 @@ pub fn validate(request: &ComposeRequest) -> Result<ValidationReport, ComposerEr
             "ok",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "errors": report.errors.len(),
                 "warnings": report.warnings.len(),
             }),
@@ -257,7 +267,7 @@ pub fn validate(request: &ComposeRequest) -> Result<ValidationReport, ComposerEr
             "err",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "error": err.to_string(),
             }),
         ),
@@ -274,7 +284,7 @@ pub fn resolve(request: &ComposeRequest) -> Result<ResolveResult, ComposerError>
             "ok",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "attempted_paths": resolved.attempted_paths.len(),
             }),
         ),
@@ -283,7 +293,7 @@ pub fn resolve(request: &ComposeRequest) -> Result<ResolveResult, ComposerError>
             "err",
             serde_json::json!({
                 "mode": format!("{:?}", request.mode),
-                "runtime": format!("{:?}", request.runtime),
+                "runtime": runtime_name(request.runtime),
                 "error": err.to_string(),
             }),
         ),

--- a/crates/sc-observability-otlp/src/lib.rs
+++ b/crates/sc-observability-otlp/src/lib.rs
@@ -12,6 +12,12 @@ use thiserror::Error;
 pub const OTLP_HTTP_PROTOCOL: &str = "otlp_http";
 pub const DEFAULT_TIMEOUT_MS: u64 = 1_500;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TransportExporterKind {
+    Collector,
+    DebugLocal,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransportConfig {
     pub endpoint: Option<String>,
@@ -72,6 +78,7 @@ pub enum TransportError {
 }
 
 pub trait TransportExporter: Send + Sync {
+    fn kind(&self) -> TransportExporterKind;
     fn export(&self, record: &TransportRecord) -> Result<(), TransportError>;
 }
 
@@ -141,6 +148,10 @@ impl OtlpHttpExporter {
 }
 
 impl TransportExporter for OtlpHttpExporter {
+    fn kind(&self) -> TransportExporterKind {
+        TransportExporterKind::Collector
+    }
+
     fn export(&self, record: &TransportRecord) -> Result<(), TransportError> {
         let body = build_logs_payload(record);
         let response = self
@@ -189,6 +200,10 @@ impl StdoutDebugExporter {
 }
 
 impl TransportExporter for StdoutDebugExporter {
+    fn kind(&self) -> TransportExporterKind {
+        TransportExporterKind::DebugLocal
+    }
+
     fn export(&self, record: &TransportRecord) -> Result<(), TransportError> {
         let line =
             serde_json::to_string(record).map_err(|err| TransportError::Stdout(err.to_string()))?;

--- a/crates/sc-observability/src/health.rs
+++ b/crates/sc-observability/src/health.rs
@@ -1,0 +1,202 @@
+use crate::{OTEL_PROTOCOL_HTTP, OtelConfig, OtelError, OtelExporterKind, default_otel_path};
+use chrono::{SecondsFormat, Utc};
+use std::path::Path;
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub struct OtelLastError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct OtelHealthSnapshot {
+    pub schema_version: String,
+    pub enabled: bool,
+    pub collector_endpoint: Option<String>,
+    pub protocol: String,
+    pub collector_state: String,
+    pub local_mirror_state: String,
+    pub local_mirror_path: String,
+    pub debug_local_export: bool,
+    pub debug_local_state: String,
+    pub last_error: OtelLastError,
+}
+
+impl Default for OtelHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: OTEL_PROTOCOL_HTTP.to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OtelRuntimeHealth {
+    collector_error: Option<String>,
+    collector_error_at: Option<String>,
+    collector_success_at: Option<String>,
+    local_mirror_error: Option<String>,
+    local_mirror_error_at: Option<String>,
+    local_mirror_success_at: Option<String>,
+    debug_local_error: Option<String>,
+    debug_local_error_at: Option<String>,
+    debug_local_success_at: Option<String>,
+}
+
+fn otel_runtime_health_slot() -> &'static Mutex<OtelRuntimeHealth> {
+    static OTEL_RUNTIME_HEALTH: OnceLock<Mutex<OtelRuntimeHealth>> = OnceLock::new();
+    OTEL_RUNTIME_HEALTH.get_or_init(|| Mutex::new(OtelRuntimeHealth::default()))
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+pub(crate) fn note_export_success(kind: OtelExporterKind) {
+    let mut health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+    let now = now_rfc3339();
+    match kind {
+        OtelExporterKind::Collector => {
+            health.collector_error = None;
+            health.collector_error_at = None;
+            health.collector_success_at = Some(now);
+        }
+        OtelExporterKind::LocalMirror => {
+            health.local_mirror_error = None;
+            health.local_mirror_error_at = None;
+            health.local_mirror_success_at = Some(now);
+        }
+        OtelExporterKind::DebugLocal => {
+            health.debug_local_error = None;
+            health.debug_local_error_at = None;
+            health.debug_local_success_at = Some(now);
+        }
+    }
+}
+
+pub(crate) fn note_export_failure(kind: OtelExporterKind, err: &OtelError) {
+    let mut health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+    let now = now_rfc3339();
+    match kind {
+        OtelExporterKind::Collector => {
+            health.collector_error = Some(err.to_string());
+            health.collector_error_at = Some(now);
+        }
+        OtelExporterKind::LocalMirror => {
+            health.local_mirror_error = Some(err.to_string());
+            health.local_mirror_error_at = Some(now);
+        }
+        OtelExporterKind::DebugLocal => {
+            health.debug_local_error = Some(err.to_string());
+            health.debug_local_error_at = Some(now);
+        }
+    }
+}
+
+fn health_state(
+    configured: bool,
+    success_at: &Option<String>,
+    error_at: &Option<String>,
+) -> String {
+    if !configured {
+        return "disabled".to_string();
+    }
+    match (success_at, error_at) {
+        (Some(success), Some(error)) => {
+            if error > success {
+                "degraded".to_string()
+            } else {
+                "healthy".to_string()
+            }
+        }
+        (Some(_), None) => "healthy".to_string(),
+        (None, Some(_)) => "degraded".to_string(),
+        (None, None) => "configured".to_string(),
+    }
+}
+
+pub fn current_otel_health(log_path: &Path) -> OtelHealthSnapshot {
+    let config = OtelConfig::from_env();
+    let local_mirror_path = default_otel_path(log_path);
+    let health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+
+    let collector_configured = config.enabled
+        && config
+            .endpoint
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+    let debug_local_configured = config.enabled && config.debug_local_export;
+    let local_mirror_configured = config.enabled;
+
+    let last_error = if health.collector_error.is_some() {
+        OtelLastError {
+            code: Some("COLLECTOR_EXPORT_FAILED".to_string()),
+            message: health.collector_error.clone(),
+            at: health.collector_error_at.clone(),
+        }
+    } else if health.local_mirror_error.is_some() {
+        OtelLastError {
+            code: Some("LOCAL_MIRROR_EXPORT_FAILED".to_string()),
+            message: health.local_mirror_error.clone(),
+            at: health.local_mirror_error_at.clone(),
+        }
+    } else if health.debug_local_error.is_some() {
+        OtelLastError {
+            code: Some("DEBUG_LOCAL_EXPORT_FAILED".to_string()),
+            message: health.debug_local_error.clone(),
+            at: health.debug_local_error_at.clone(),
+        }
+    } else {
+        OtelLastError::default()
+    };
+
+    let collector_state = if !config.enabled {
+        "disabled".to_string()
+    } else if !collector_configured {
+        "not_configured".to_string()
+    } else {
+        health_state(
+            true,
+            &health.collector_success_at,
+            &health.collector_error_at,
+        )
+    };
+
+    OtelHealthSnapshot {
+        schema_version: "v1".to_string(),
+        enabled: config.enabled,
+        collector_endpoint: config.endpoint.clone(),
+        protocol: config.protocol.clone(),
+        collector_state,
+        local_mirror_state: health_state(
+            local_mirror_configured,
+            &health.local_mirror_success_at,
+            &health.local_mirror_error_at,
+        ),
+        local_mirror_path: local_mirror_path.to_string_lossy().into_owned(),
+        debug_local_export: config.debug_local_export,
+        debug_local_state: health_state(
+            debug_local_configured,
+            &health.debug_local_success_at,
+            &health.debug_local_error_at,
+        ),
+        last_error,
+    }
+}

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -7,7 +7,6 @@
 //! - socket error-code constants for the `log-event` contract
 
 use agent_team_mail_core::logging_event::{LogEventV1, ValidationError};
-use chrono::{SecondsFormat, Utc};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -16,7 +15,10 @@ use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
 
+mod health;
 mod otlp_adapter;
+
+pub use health::{OtelHealthSnapshot, OtelLastError, current_otel_health};
 
 pub const DEFAULT_QUEUE_CAPACITY: usize = 4096;
 pub const DEFAULT_MAX_EVENT_BYTES: usize = 64 * 1024;
@@ -239,204 +241,6 @@ impl OtelPipeline {
     }
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
-pub struct OtelLastError {
-    pub code: Option<String>,
-    pub message: Option<String>,
-    pub at: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct OtelHealthSnapshot {
-    pub schema_version: String,
-    pub enabled: bool,
-    pub collector_endpoint: Option<String>,
-    pub protocol: String,
-    pub collector_state: String,
-    pub local_mirror_state: String,
-    pub local_mirror_path: String,
-    pub debug_local_export: bool,
-    pub debug_local_state: String,
-    pub last_error: OtelLastError,
-}
-
-impl Default for OtelHealthSnapshot {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: OTEL_PROTOCOL_HTTP.to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
-struct OtelRuntimeHealth {
-    collector_error: Option<String>,
-    collector_error_at: Option<String>,
-    collector_success_at: Option<String>,
-    local_mirror_error: Option<String>,
-    local_mirror_error_at: Option<String>,
-    local_mirror_success_at: Option<String>,
-    debug_local_error: Option<String>,
-    debug_local_error_at: Option<String>,
-    debug_local_success_at: Option<String>,
-}
-
-fn otel_runtime_health_slot() -> &'static Mutex<OtelRuntimeHealth> {
-    static OTEL_RUNTIME_HEALTH: OnceLock<Mutex<OtelRuntimeHealth>> = OnceLock::new();
-    OTEL_RUNTIME_HEALTH.get_or_init(|| Mutex::new(OtelRuntimeHealth::default()))
-}
-
-fn now_rfc3339() -> String {
-    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
-}
-
-fn note_export_success(kind: OtelExporterKind) {
-    let mut health = otel_runtime_health_slot()
-        .lock()
-        .expect("sc-observability otel health lock poisoned");
-    let now = now_rfc3339();
-    match kind {
-        OtelExporterKind::Collector => {
-            health.collector_error = None;
-            health.collector_error_at = None;
-            health.collector_success_at = Some(now);
-        }
-        OtelExporterKind::LocalMirror => {
-            health.local_mirror_error = None;
-            health.local_mirror_error_at = None;
-            health.local_mirror_success_at = Some(now);
-        }
-        OtelExporterKind::DebugLocal => {
-            health.debug_local_error = None;
-            health.debug_local_error_at = None;
-            health.debug_local_success_at = Some(now);
-        }
-    }
-}
-
-fn note_export_failure(kind: OtelExporterKind, err: &OtelError) {
-    let mut health = otel_runtime_health_slot()
-        .lock()
-        .expect("sc-observability otel health lock poisoned");
-    let now = now_rfc3339();
-    match kind {
-        OtelExporterKind::Collector => {
-            health.collector_error = Some(err.to_string());
-            health.collector_error_at = Some(now);
-        }
-        OtelExporterKind::LocalMirror => {
-            health.local_mirror_error = Some(err.to_string());
-            health.local_mirror_error_at = Some(now);
-        }
-        OtelExporterKind::DebugLocal => {
-            health.debug_local_error = Some(err.to_string());
-            health.debug_local_error_at = Some(now);
-        }
-    }
-}
-
-fn health_state(
-    configured: bool,
-    success_at: &Option<String>,
-    error_at: &Option<String>,
-) -> String {
-    if !configured {
-        return "disabled".to_string();
-    }
-    match (success_at, error_at) {
-        (Some(success), Some(error)) => {
-            if error > success {
-                "degraded".to_string()
-            } else {
-                "healthy".to_string()
-            }
-        }
-        (Some(_), None) => "healthy".to_string(),
-        (None, Some(_)) => "degraded".to_string(),
-        (None, None) => "configured".to_string(),
-    }
-}
-
-pub fn current_otel_health(log_path: &Path) -> OtelHealthSnapshot {
-    let config = OtelConfig::from_env();
-    let local_mirror_path = default_otel_path(log_path);
-    let health = otel_runtime_health_slot()
-        .lock()
-        .expect("sc-observability otel health lock poisoned");
-
-    let collector_configured = config.enabled
-        && config
-            .endpoint
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty());
-    let debug_local_configured = config.enabled && config.debug_local_export;
-    let local_mirror_configured = config.enabled;
-
-    let last_error = if health.collector_error.is_some() {
-        OtelLastError {
-            code: Some("COLLECTOR_EXPORT_FAILED".to_string()),
-            message: health.collector_error.clone(),
-            at: health.collector_error_at.clone(),
-        }
-    } else if health.local_mirror_error.is_some() {
-        OtelLastError {
-            code: Some("LOCAL_MIRROR_EXPORT_FAILED".to_string()),
-            message: health.local_mirror_error.clone(),
-            at: health.local_mirror_error_at.clone(),
-        }
-    } else if health.debug_local_error.is_some() {
-        OtelLastError {
-            code: Some("DEBUG_LOCAL_EXPORT_FAILED".to_string()),
-            message: health.debug_local_error.clone(),
-            at: health.debug_local_error_at.clone(),
-        }
-    } else {
-        OtelLastError::default()
-    };
-
-    let collector_state = if !config.enabled {
-        "disabled".to_string()
-    } else if !collector_configured {
-        "not_configured".to_string()
-    } else {
-        health_state(
-            true,
-            &health.collector_success_at,
-            &health.collector_error_at,
-        )
-    };
-
-    OtelHealthSnapshot {
-        schema_version: "v1".to_string(),
-        enabled: config.enabled,
-        collector_endpoint: config.endpoint.clone(),
-        protocol: config.protocol.clone(),
-        collector_state,
-        local_mirror_state: health_state(
-            local_mirror_configured,
-            &health.local_mirror_success_at,
-            &health.local_mirror_error_at,
-        ),
-        local_mirror_path: local_mirror_path.to_string_lossy().into_owned(),
-        debug_local_export: config.debug_local_export,
-        debug_local_state: health_state(
-            debug_local_configured,
-            &health.debug_local_success_at,
-            &health.debug_local_error_at,
-        ),
-        last_error,
-    }
-}
-
 fn export_otel_with_retry(
     event: &LogEventV1,
     config: &OtelConfig,
@@ -459,11 +263,11 @@ fn export_otel_with_retry(
         let mut any_failed = false;
         for exporter in exporters {
             if let Err(err) = exporter.export(&record) {
-                note_export_failure(exporter.kind(), &err);
+                health::note_export_failure(exporter.kind(), &err);
                 any_failed = true;
                 last_err = Some(err);
             } else {
-                note_export_success(exporter.kind());
+                health::note_export_success(exporter.kind());
             }
         }
         if !any_failed {
@@ -499,10 +303,10 @@ pub fn export_otel_best_effort(
     let mut backoff = config.initial_backoff_ms;
     loop {
         if exporter.export(&record).is_ok() {
-            note_export_success(exporter.kind());
+            health::note_export_success(exporter.kind());
             return;
         }
-        note_export_failure(
+        health::note_export_failure(
             exporter.kind(),
             &OtelError::ExportFailed("best-effort exporter failed".to_string()),
         );
@@ -1096,7 +900,7 @@ fn rotate_log_files(base: &Path, max_files: u32) -> Result<(), LoggerError> {
     Ok(())
 }
 
-fn default_otel_path(log_path: &Path) -> PathBuf {
+pub(crate) fn default_otel_path(log_path: &Path) -> PathBuf {
     let mut otel_path = log_path.to_path_buf();
     let stem = log_path
         .file_stem()

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -7,6 +7,7 @@
 //! - socket error-code constants for the `log-event` contract
 
 use agent_team_mail_core::logging_event::{LogEventV1, ValidationError};
+use chrono::{SecondsFormat, Utc};
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -143,7 +144,15 @@ pub enum OtelError {
 }
 
 pub trait OtelExporter: Send + Sync {
+    fn kind(&self) -> OtelExporterKind;
     fn export(&self, record: &OtelRecord) -> Result<(), OtelError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OtelExporterKind {
+    LocalMirror,
+    Collector,
+    DebugLocal,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
@@ -166,6 +175,10 @@ impl FileOtelExporter {
 }
 
 impl OtelExporter for FileOtelExporter {
+    fn kind(&self) -> OtelExporterKind {
+        OtelExporterKind::LocalMirror
+    }
+
     fn export(&self, record: &OtelRecord) -> Result<(), OtelError> {
         if let Some(parent) = self.path.parent()
             && let Err(err) = fs::create_dir_all(parent)
@@ -187,6 +200,7 @@ impl OtelExporter for FileOtelExporter {
 struct OtelPipeline {
     config: OtelConfig,
     exporters: Vec<Arc<dyn OtelExporter>>,
+    log_path: PathBuf,
     sleeper: fn(Duration),
 }
 
@@ -209,12 +223,217 @@ impl OtelPipeline {
         Self {
             config,
             exporters,
+            log_path: log_path.to_path_buf(),
             sleeper: std::thread::sleep,
         }
     }
 
     fn export_event(&self, event: &LogEventV1) -> Result<(), OtelError> {
-        export_otel_with_retry(event, &self.config, &self.exporters, self.sleeper)
+        export_otel_with_retry(
+            event,
+            &self.config,
+            &self.exporters,
+            &self.log_path,
+            self.sleeper,
+        )
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub struct OtelLastError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct OtelHealthSnapshot {
+    pub schema_version: String,
+    pub enabled: bool,
+    pub collector_endpoint: Option<String>,
+    pub protocol: String,
+    pub collector_state: String,
+    pub local_mirror_state: String,
+    pub local_mirror_path: String,
+    pub debug_local_export: bool,
+    pub debug_local_state: String,
+    pub last_error: OtelLastError,
+}
+
+impl Default for OtelHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: OTEL_PROTOCOL_HTTP.to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+struct OtelRuntimeHealth {
+    collector_error: Option<String>,
+    collector_error_at: Option<String>,
+    collector_success_at: Option<String>,
+    local_mirror_error: Option<String>,
+    local_mirror_error_at: Option<String>,
+    local_mirror_success_at: Option<String>,
+    debug_local_error: Option<String>,
+    debug_local_error_at: Option<String>,
+    debug_local_success_at: Option<String>,
+}
+
+fn otel_runtime_health_slot() -> &'static Mutex<OtelRuntimeHealth> {
+    static OTEL_RUNTIME_HEALTH: OnceLock<Mutex<OtelRuntimeHealth>> = OnceLock::new();
+    OTEL_RUNTIME_HEALTH.get_or_init(|| Mutex::new(OtelRuntimeHealth::default()))
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn note_export_success(kind: OtelExporterKind) {
+    let mut health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+    let now = now_rfc3339();
+    match kind {
+        OtelExporterKind::Collector => {
+            health.collector_error = None;
+            health.collector_error_at = None;
+            health.collector_success_at = Some(now);
+        }
+        OtelExporterKind::LocalMirror => {
+            health.local_mirror_error = None;
+            health.local_mirror_error_at = None;
+            health.local_mirror_success_at = Some(now);
+        }
+        OtelExporterKind::DebugLocal => {
+            health.debug_local_error = None;
+            health.debug_local_error_at = None;
+            health.debug_local_success_at = Some(now);
+        }
+    }
+}
+
+fn note_export_failure(kind: OtelExporterKind, err: &OtelError) {
+    let mut health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+    let now = now_rfc3339();
+    match kind {
+        OtelExporterKind::Collector => {
+            health.collector_error = Some(err.to_string());
+            health.collector_error_at = Some(now);
+        }
+        OtelExporterKind::LocalMirror => {
+            health.local_mirror_error = Some(err.to_string());
+            health.local_mirror_error_at = Some(now);
+        }
+        OtelExporterKind::DebugLocal => {
+            health.debug_local_error = Some(err.to_string());
+            health.debug_local_error_at = Some(now);
+        }
+    }
+}
+
+fn health_state(
+    configured: bool,
+    success_at: &Option<String>,
+    error_at: &Option<String>,
+) -> String {
+    if !configured {
+        return "disabled".to_string();
+    }
+    match (success_at, error_at) {
+        (Some(success), Some(error)) => {
+            if error > success {
+                "degraded".to_string()
+            } else {
+                "healthy".to_string()
+            }
+        }
+        (Some(_), None) => "healthy".to_string(),
+        (None, Some(_)) => "degraded".to_string(),
+        (None, None) => "configured".to_string(),
+    }
+}
+
+pub fn current_otel_health(log_path: &Path) -> OtelHealthSnapshot {
+    let config = OtelConfig::from_env();
+    let local_mirror_path = default_otel_path(log_path);
+    let health = otel_runtime_health_slot()
+        .lock()
+        .expect("sc-observability otel health lock poisoned");
+
+    let collector_configured = config.enabled
+        && config
+            .endpoint
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty());
+    let debug_local_configured = config.enabled && config.debug_local_export;
+    let local_mirror_configured = config.enabled;
+
+    let last_error = if health.collector_error.is_some() {
+        OtelLastError {
+            code: Some("COLLECTOR_EXPORT_FAILED".to_string()),
+            message: health.collector_error.clone(),
+            at: health.collector_error_at.clone(),
+        }
+    } else if health.local_mirror_error.is_some() {
+        OtelLastError {
+            code: Some("LOCAL_MIRROR_EXPORT_FAILED".to_string()),
+            message: health.local_mirror_error.clone(),
+            at: health.local_mirror_error_at.clone(),
+        }
+    } else if health.debug_local_error.is_some() {
+        OtelLastError {
+            code: Some("DEBUG_LOCAL_EXPORT_FAILED".to_string()),
+            message: health.debug_local_error.clone(),
+            at: health.debug_local_error_at.clone(),
+        }
+    } else {
+        OtelLastError::default()
+    };
+
+    let collector_state = if !config.enabled {
+        "disabled".to_string()
+    } else if !collector_configured {
+        "not_configured".to_string()
+    } else {
+        health_state(
+            true,
+            &health.collector_success_at,
+            &health.collector_error_at,
+        )
+    };
+
+    OtelHealthSnapshot {
+        schema_version: "v1".to_string(),
+        enabled: config.enabled,
+        collector_endpoint: config.endpoint.clone(),
+        protocol: config.protocol.clone(),
+        collector_state,
+        local_mirror_state: health_state(
+            local_mirror_configured,
+            &health.local_mirror_success_at,
+            &health.local_mirror_error_at,
+        ),
+        local_mirror_path: local_mirror_path.to_string_lossy().into_owned(),
+        debug_local_export: config.debug_local_export,
+        debug_local_state: health_state(
+            debug_local_configured,
+            &health.debug_local_success_at,
+            &health.debug_local_error_at,
+        ),
+        last_error,
     }
 }
 
@@ -222,6 +441,7 @@ fn export_otel_with_retry(
     event: &LogEventV1,
     config: &OtelConfig,
     exporters: &[Arc<dyn OtelExporter>],
+    _log_path: &Path,
     sleeper: fn(Duration),
 ) -> Result<(), OtelError> {
     if !config.enabled {
@@ -239,8 +459,11 @@ fn export_otel_with_retry(
         let mut any_failed = false;
         for exporter in exporters {
             if let Err(err) = exporter.export(&record) {
+                note_export_failure(exporter.kind(), &err);
                 any_failed = true;
                 last_err = Some(err);
+            } else {
+                note_export_success(exporter.kind());
             }
         }
         if !any_failed {
@@ -276,8 +499,13 @@ pub fn export_otel_best_effort(
     let mut backoff = config.initial_backoff_ms;
     loop {
         if exporter.export(&record).is_ok() {
+            note_export_success(exporter.kind());
             return;
         }
+        note_export_failure(
+            exporter.kind(),
+            &OtelError::ExportFailed("best-effort exporter failed".to_string()),
+        );
         if attempt >= config.max_retries {
             return;
         }
@@ -382,6 +610,11 @@ fn build_otel_record(event: &LogEventV1) -> Result<OtelRecord, OtelError> {
         "action".to_string(),
         serde_json::Value::String(event.action.clone()),
     );
+    for (key, value) in &event.fields {
+        attributes
+            .entry(key.clone())
+            .or_insert_with(|| value.clone());
+    }
 
     Ok(OtelRecord {
         name: event.action.clone(),
@@ -578,6 +811,7 @@ impl Logger {
             otel: OtelPipeline {
                 config: otel_config,
                 exporters: vec![exporter],
+                log_path: PathBuf::new(),
                 sleeper: std::thread::sleep,
             },
         }
@@ -917,6 +1151,10 @@ mod tests {
     }
 
     impl OtelExporter for CountingExporter {
+        fn kind(&self) -> OtelExporterKind {
+            OtelExporterKind::Collector
+        }
+
         fn export(&self, record: &OtelRecord) -> Result<(), OtelError> {
             let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
             let fail_for = self.fail_for.load(Ordering::SeqCst);
@@ -1505,6 +1743,7 @@ mod tests {
                 ..OtelConfig::default()
             },
             &exporters,
+            Path::new("/tmp/atm.log.jsonl"),
             record_sleep,
         )
         .expect_err("should return final export error");
@@ -1595,6 +1834,40 @@ mod tests {
                 .get("subagent_id")
                 .and_then(|v| v.as_str()),
             Some("subagent-7")
+        );
+    }
+
+    #[test]
+    fn build_otel_record_projects_event_fields_without_overwriting_core_attributes() {
+        let mut event = new_log_event("sc-compose", "compose", "sc_compose::cli", "info");
+        event.fields.insert(
+            "runtime".to_string(),
+            serde_json::Value::String("claude".to_string()),
+        );
+        event.fields.insert(
+            "resolved_files".to_string(),
+            serde_json::Value::Number(serde_json::Number::from(2)),
+        );
+        event.fields.insert(
+            "action".to_string(),
+            serde_json::Value::String("wrong".to_string()),
+        );
+
+        let record = build_otel_record(&event).expect("record should build");
+        assert_eq!(
+            record.attributes.get("runtime").and_then(|v| v.as_str()),
+            Some("claude")
+        );
+        assert_eq!(
+            record
+                .attributes
+                .get("resolved_files")
+                .and_then(|v| v.as_u64()),
+            Some(2)
+        );
+        assert_eq!(
+            record.attributes.get("action").and_then(|v| v.as_str()),
+            Some("compose")
         );
     }
 }

--- a/crates/sc-observability/src/otlp_adapter.rs
+++ b/crates/sc-observability/src/otlp_adapter.rs
@@ -1,5 +1,7 @@
-use crate::{OtelConfig, OtelError, OtelExporter, OtelRecord};
-use sc_observability_otlp::{TransportConfig, TransportError, TransportExporter, TransportRecord};
+use crate::{OtelConfig, OtelError, OtelExporter, OtelExporterKind, OtelRecord};
+use sc_observability_otlp::{
+    TransportConfig, TransportError, TransportExporter, TransportExporterKind, TransportRecord,
+};
 use std::sync::Arc;
 
 pub fn build_transport_exporters(
@@ -28,6 +30,13 @@ struct BridgeExporter {
 }
 
 impl OtelExporter for BridgeExporter {
+    fn kind(&self) -> OtelExporterKind {
+        match self.exporter.kind() {
+            TransportExporterKind::Collector => OtelExporterKind::Collector,
+            TransportExporterKind::DebugLocal => OtelExporterKind::DebugLocal,
+        }
+    }
+
     fn export(&self, record: &OtelRecord) -> Result<(), OtelError> {
         self.exporter
             .export(&to_transport_record(record))

--- a/docs/arch-boundary.md
+++ b/docs/arch-boundary.md
@@ -69,6 +69,7 @@ The following files are the allowlisted entry-point wiring surfaces for
 
 | File | Rationale |
 |---|---|
+| `crates/atm/src/main.rs` | CLI process entry point; allowed to initialize generic observability and process-level command lifecycle wiring. |
 | `crates/atm-daemon/src/main.rs` | Daemon process entry point; owns process-level observability initialization and injected export-hook wiring. |
 | `crates/sc-compose/src/main.rs` | Standalone binary entry point; allowed to initialize generic observability for the process. |
 | Integration test files under `crates/*/tests/` | Test-only harness entry points that may validate facade wiring behavior without turning internal library modules into transport owners. |

--- a/docs/arch-boundary.md
+++ b/docs/arch-boundary.md
@@ -55,7 +55,10 @@ Examples of blocking violations:
 - Crate-local facades are allowed only if they are transport-neutral shims
   (for example, storing an injected hook or trait object). A crate-local daemon
   facade must not import `sc-observability` itself; the real exporter wiring
-  belongs in the entry-point binary.
+  belongs in the entry-point binary. In other words: daemon-local facade types
+  and hook slots are allowed, but the facade implementation must be injected
+  from `crates/atm-daemon/src/main.rs` rather than importing `sc_observability`
+  inside daemon internals.
 - AV.1 must deliver `scripts/ci/observability_boundary_check.sh` plus a CI
   workflow step that runs it before AV.2 begins.
 - QA/CI should use this section as the enforcement reference for the

--- a/docs/logging-troubleshooting.md
+++ b/docs/logging-troubleshooting.md
@@ -7,6 +7,10 @@ Last updated: 2026-03-10
 This runbook maps unified logging health states to concrete diagnostics and
 remediation actions.
 
+Related references:
+- `docs/observability/requirements.md`
+- `docs/observability/architecture.md`
+
 ## Health States
 
 ### `healthy`
@@ -134,6 +138,11 @@ Look for:
 - `logging_health.state` in JSON output
 - `logging_health.last_error.code` and `logging_health.last_error.message`
   when exporter or sink paths are degraded
+- `otel_health.collector_state`
+- `otel_health.local_mirror_state`
+- `otel_health.local_mirror_path`
+- `otel_health.last_error.code`
+- `otel_health.last_error.message`
 
 Canonical JSON keys referenced by this runbook:
 - `logging_health.schema_version`
@@ -147,6 +156,18 @@ Canonical JSON keys referenced by this runbook:
 - `logging_health.last_error.code`
 - `logging_health.last_error.message`
 - `logging_health.last_error.at`
+- `otel_health.schema_version`
+- `otel_health.enabled`
+- `otel_health.collector_endpoint`
+- `otel_health.protocol`
+- `otel_health.collector_state`
+- `otel_health.local_mirror_state`
+- `otel_health.local_mirror_path`
+- `otel_health.debug_local_export`
+- `otel_health.debug_local_state`
+- `otel_health.last_error.code`
+- `otel_health.last_error.message`
+- `otel_health.last_error.at`
 
 ### Remediation
 

--- a/docs/observability/architecture.md
+++ b/docs/observability/architecture.md
@@ -4,7 +4,7 @@
 **Primary crate**: `sc-observability`
 **See also**:
 - `docs/observability/requirements.md`
-- `docs/observability/troubleshooting.md`
+- `docs/logging-troubleshooting.md`
 - `docs/project-plan.md` (Phase AJ and Phase AV sections)
 
 ## 1. Architecture Goals

--- a/docs/observability/architecture.md
+++ b/docs/observability/architecture.md
@@ -4,7 +4,7 @@
 **Primary crate**: `sc-observability`
 **See also**:
 - `docs/observability/requirements.md`
-- `docs/logging-troubleshooting.md`
+- `docs/observability/troubleshooting.md`
 - `docs/project-plan.md` (Phase AJ and Phase AV sections)
 
 ## 1. Architecture Goals
@@ -196,3 +196,6 @@ object contract:
 - `logging_health.last_error.at`
 
 No drift is allowed across these two command surfaces for shared keys.
+
+See [docs/observability/troubleshooting.md](troubleshooting.md) for the
+operator runbook that interprets this locked contract.

--- a/docs/observability/troubleshooting.md
+++ b/docs/observability/troubleshooting.md
@@ -1,4 +1,4 @@
-# Observability Troubleshooting (AK.4)
+# Observability Troubleshooting
 
 This runbook defines how to interpret mandatory OpenTelemetry behavior without
 blocking ATM workflows.
@@ -7,21 +7,30 @@ blocking ATM workflows.
 
 - Local structured logging is always considered available (`local_structured=true`).
 - OTel export is fail-open: exporter issues must not fail `atm` commands.
-- `atm doctor --json` and `atm status --json` expose:
-  - `logging_health.status` (`ok|degraded|unavailable`)
-  - `logging_health.otel_exporter`
-  - `logging_health.local_structured`
-  - `logging_health.last_export_error` (optional)
+- `atm doctor --json` and `atm status --json` expose the locked
+  `logging_health` object from
+  [section 10 of the observability architecture](architecture.md#10-diagnostics-json-contract-lock):
+  - `logging_health.schema_version`
+  - `logging_health.state`
+  - `logging_health.log_root`
+  - `logging_health.canonical_log_path`
+  - `logging_health.spool_path`
+  - `logging_health.dropped_events_total`
+  - `logging_health.spool_file_count`
+  - `logging_health.oldest_spool_age_seconds`
+  - `logging_health.last_error.code`
+  - `logging_health.last_error.message`
+  - `logging_health.last_error.at`
 
 ## Health Interpretation
 
-- `status=ok`: canonical local logging is healthy.
-- `status=degraded`: local logging remains active, but backlog/drop conditions
-  were detected.
-- `status=unavailable`: local logging health is unavailable (for example,
+- `state=healthy`: canonical local logging is healthy.
+- `state=degraded_spooling`: canonical local logging remains active, but spool
+  backlog was detected.
+- `state=degraded_dropping`: canonical local logging remains active, but queue
+  pressure caused dropped events.
+- `state=unavailable`: local logging health is unavailable (for example,
   disabled by env or daemon/path failures).
-
-`otel_exporter` follows the same state buckets and never blocks command flow.
 
 ## Fallback Paths
 
@@ -36,10 +45,10 @@ blocking ATM workflows.
   - Treat as non-fatal exporter/local-health signal.
   - Continue normal operations; investigate exporter/env/path configuration.
 - `ATM_OTEL_ENABLED=false|0|off|disabled|no`:
-  - `otel_exporter=unavailable` by design.
-  - Local structured logging remains available.
+  - remote export stays disabled by design.
+  - canonical local logging remains available.
 - Spool growth / dropped queue signals:
-  - Expect `status=degraded`; commands continue.
+  - Expect `state=degraded_spooling` or `state=degraded_dropping`; commands continue.
   - Remediate daemon availability and reduce burst log pressure.
 
 ## Operator Commands

--- a/examples/provider-stub/Cargo.lock
+++ b/examples/provider-stub/Cargo.lock
@@ -186,10 +186,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
@@ -263,6 +275,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -465,16 +483,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -493,8 +548,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -505,7 +576,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -553,6 +624,106 @@ dependencies = [
  "cfg-if",
  "libc",
  "windows-link",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -729,6 +900,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +1017,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -958,6 +1151,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -970,6 +1169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -992,6 +1200,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,9 +1265,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1053,10 +1351,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1074,6 +1473,17 @@ dependencies = [
  "agent-team-mail-core",
  "anyhow",
  "chrono",
+ "sc-observability-otlp",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sc-observability-otlp"
+version = "0.45.2"
+dependencies = [
+ "reqwest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1145,6 +1555,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,6 +1603,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,6 +1637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1651,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -1303,6 +1746,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1328,6 +1786,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -1383,6 +1851,51 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -1442,6 +1955,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,6 +1977,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -1517,6 +2042,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1551,6 +2085,20 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -1617,6 +2165,35 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -2037,6 +2614,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,6 +2653,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/scripts/ci/observability_boundary_check.sh
+++ b/scripts/ci/observability_boundary_check.sh
@@ -8,6 +8,7 @@ declare -a matches=()
 is_allowed_sc_observability_rust_path() {
   local rel="$1"
   case "$rel" in
+    crates/atm/src/main.rs) return 0 ;;
     crates/sc-compose/src/main.rs) return 0 ;;
     crates/atm-daemon/src/main.rs) return 0 ;;
     *) return 1 ;;


### PR DESCRIPTION
## AV.4 — Producer Rollout Health / Status Surfaces

Adds OTel health tracking surfaces across `atm status`, `atm doctor`, and daemon for `otel_health`, rollout coverage for sc-compose/sc-composer sidecar emission, and OTel health tracking in sc-observability with daemon status wiring.

### Deliverables
- `otel_health` field surfaced in `atm status` / `atm doctor` / daemon status
- Rollout coverage metrics for sc-compose/sc-composer sidecar emission
- OTel health tracking in sc-observability + daemon status wiring
- Docs troubleshooting cross-links

### QA
Pending — quality-mgr assigned.

### References
- Phase AV plan: `docs/phase-av-otel-planning.md`
- Integration branch: `integrate/phase-AV`