### PR TITLE
fix(AX.1): dev-install daemon owner session + config member persistence (#835, #793)

### DIFF
--- a/crates/atm-daemon-launch/src/lib.rs
+++ b/crates/atm-daemon-launch/src/lib.rs
@@ -136,6 +136,36 @@ pub struct SpawnDaemonRequest<'a> {
     pub stderr: Stdio,
 }
 
+fn scrub_shared_runtime_owner_env(command: &mut Command) {
+    for key in ["CLAUDE_SESSION_ID", "ATM_IDENTITY", "ATM_TEAM"] {
+        command.env_remove(key);
+    }
+}
+
+fn configure_spawn_command(
+    command: &mut Command,
+    request: SpawnDaemonRequest<'_>,
+    token: &DaemonLaunchToken,
+) -> serde_json::Result<()> {
+    if let Some(team) = request.team {
+        command.arg("--team").arg(team);
+    }
+    command
+        .env("ATM_HOME", request.atm_home)
+        .stdin(request.stdin)
+        .stdout(request.stdout)
+        .stderr(request.stderr);
+    if request.launch_class != LaunchClass::IsolatedTest {
+        scrub_shared_runtime_owner_env(command);
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+    }
+    attach_launch_token(command, token)
+}
+
 /// Spawn `atm-daemon` through the canonical launcher surface.
 pub fn spawn_daemon_process(request: SpawnDaemonRequest<'_>) -> io::Result<Child> {
     let binary_identity = request.daemon_bin.to_string_lossy().into_owned();
@@ -159,15 +189,7 @@ pub fn spawn_daemon_process(request: SpawnDaemonRequest<'_>) -> io::Result<Child
     };
 
     let mut command = Command::new(request.daemon_bin);
-    if let Some(team) = request.team {
-        command.arg("--team").arg(team);
-    }
-    command
-        .env("ATM_HOME", request.atm_home)
-        .stdin(request.stdin)
-        .stdout(request.stdout)
-        .stderr(request.stderr);
-    attach_launch_token(&mut command, &token)
+    configure_spawn_command(&mut command, request, &token)
         .map_err(|e| io::Error::other(format!("failed to encode daemon launch token: {e}")))?;
     command.spawn()
 }
@@ -237,5 +259,91 @@ mod tests {
             Some("daemon_tests::test_daemon_start_requires_launch_token")
         );
         assert_eq!(token.owner_pid, Some(4242));
+    }
+
+    #[test]
+    fn shared_runtime_spawn_scrubs_owner_session_env() {
+        let atm_home = std::env::temp_dir().join("shared-home");
+        let token = issue_launch_token(
+            LaunchClass::DevShared,
+            &atm_home,
+            "target/debug/atm-daemon",
+            "launcher-test",
+            Duration::from_secs(15),
+        );
+        let mut command = Command::new("sh");
+        command
+            .env("CLAUDE_SESSION_ID", "session-123")
+            .env("ATM_IDENTITY", "team-lead")
+            .env("ATM_TEAM", "atm-dev");
+
+        configure_spawn_command(
+            &mut command,
+            SpawnDaemonRequest {
+                daemon_bin: OsStr::new("atm-daemon"),
+                atm_home: &atm_home,
+                launch_class: LaunchClass::DevShared,
+                issuer: "launcher-test",
+                team: Some("atm-dev"),
+                stdin: Stdio::null(),
+                stdout: Stdio::null(),
+                stderr: Stdio::null(),
+            },
+            &token,
+        )
+        .unwrap();
+
+        let envs: std::collections::HashMap<_, _> = command.get_envs().collect();
+        assert_eq!(envs.get(OsStr::new("CLAUDE_SESSION_ID")), Some(&None));
+        assert_eq!(envs.get(OsStr::new("ATM_IDENTITY")), Some(&None));
+        assert_eq!(envs.get(OsStr::new("ATM_TEAM")), Some(&None));
+    }
+
+    #[test]
+    fn isolated_test_spawn_keeps_caller_env_available() {
+        let atm_home = std::env::temp_dir().join("isolated-home");
+        let token = issue_isolated_test_launch_token(
+            &atm_home,
+            "target/debug/atm-daemon",
+            "launcher-test",
+            "daemon_tests::isolated",
+            4242,
+            Duration::from_secs(600),
+        );
+        let mut command = Command::new("sh");
+        command
+            .env("CLAUDE_SESSION_ID", "session-123")
+            .env("ATM_IDENTITY", "team-lead")
+            .env("ATM_TEAM", "atm-dev");
+
+        configure_spawn_command(
+            &mut command,
+            SpawnDaemonRequest {
+                daemon_bin: OsStr::new("atm-daemon"),
+                atm_home: &atm_home,
+                launch_class: LaunchClass::IsolatedTest,
+                issuer: "launcher-test",
+                team: None,
+                stdin: Stdio::null(),
+                stdout: Stdio::null(),
+                stderr: Stdio::null(),
+            },
+            &token,
+        )
+        .unwrap();
+
+        let envs: std::collections::HashMap<_, _> = command.get_envs().collect();
+        assert_eq!(
+            envs.get(OsStr::new("CLAUDE_SESSION_ID")),
+            Some(&Some(OsStr::new("session-123")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_IDENTITY")),
+            Some(&Some(OsStr::new("team-lead")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_TEAM")),
+            Some(&Some(OsStr::new("atm-dev")))
+        );
     }
 }

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -835,10 +835,11 @@ fn reconcile_team_member_activity_with_mode(
                 );
             }
 
-            // Terminal non-lead members must be fully removed (roster + mailbox)
-            // once daemon confirms the session is dead. A grace-skip cycle is
-            // inserted when a member just re-appeared after an absence (detected
-            // via ABSENT_REGISTRY_CYCLES), preventing premature cleanup during
+            // Terminal non-lead members still need daemon-side cleanup once the
+            // session is confirmed dead, but config.json remains authoritative
+            // for roster membership. A grace-skip cycle is inserted when a
+            // member just re-appeared after an absence (detected via
+            // ABSENT_REGISTRY_CYCLES), preventing premature cleanup during
             // config-watcher races or remove+recreate flows.
             if member.name != "team-lead"
                 && let Some(ref rec) = record
@@ -945,17 +946,12 @@ fn reconcile_team_member_activity_with_mode(
         }
 
         if changed {
-            let terminal_set: std::collections::HashSet<_> =
-                terminal_non_lead_members.iter().cloned().collect();
             let alive_members = alive_members.clone();
             let _ = store.update(|mut config| {
                 for member in &mut config.members {
                     if alive_members.contains(&member.name) {
                         member.last_active = Some(now_ms);
                     }
-                }
-                if !terminal_set.is_empty() {
-                    config.members.retain(|m| !terminal_set.contains(&m.name));
                 }
                 Ok(Some(config))
             })?;
@@ -2370,7 +2366,7 @@ mod tests {
         );
     }
 
-    fn assert_terminal_non_lead_cleanup(
+    fn assert_terminal_non_lead_session_cleanup_preserves_roster(
         home: &std::path::Path,
         team_name: &str,
         inbox_dir: &std::path::Path,
@@ -2381,12 +2377,12 @@ mod tests {
         )
         .unwrap();
         assert!(
-            cfg.members.iter().all(|m| m.name != "arch-ctm"),
-            "terminal non-lead should be removed from roster"
+            cfg.members.iter().any(|m| m.name == "arch-ctm"),
+            "dead non-lead should remain in config roster until explicit removal"
         );
         assert!(
             !inbox_dir.join("arch-ctm.json").exists(),
-            "terminal non-lead inbox should be removed"
+            "dead non-lead inbox should be removed"
         );
     }
 
@@ -2445,7 +2441,7 @@ mod tests {
     }
 
     #[test]
-    fn test_session_end_converges_to_remove_dead_member_from_roster_and_mailbox() {
+    fn test_session_end_converges_to_cleanup_dead_member_session_without_dropping_roster() {
         let (tmp, inbox_dir, team_name, sr, state_store) = setup_dead_terminal_non_lead();
         let home = tmp.path();
         let cycle_state = super::new_reconcile_cycle_state();
@@ -2470,18 +2466,18 @@ mod tests {
             &cycle_state,
         )
         .unwrap();
-        assert_terminal_non_lead_cleanup(home, &team_name, &inbox_dir);
+        assert_terminal_non_lead_session_cleanup_preserves_roster(home, &team_name, &inbox_dir);
         assert!(
             sr.lock()
                 .unwrap()
                 .query_for_team(&team_name, "arch-ctm")
                 .is_none(),
-            "terminal non-lead session record should be removed"
+            "dead non-lead session record should be removed"
         );
     }
 
     #[test]
-    fn test_sigterm_escalation_converges_to_remove_dead_member_from_roster_and_mailbox() {
+    fn test_sigterm_escalation_converges_to_cleanup_dead_member_session_without_dropping_roster() {
         let (tmp, inbox_dir, team_name, sr, state_store) = setup_dead_terminal_non_lead();
         let home = tmp.path();
         let cycle_state = super::new_reconcile_cycle_state();
@@ -2506,18 +2502,18 @@ mod tests {
             &cycle_state,
         )
         .unwrap();
-        assert_terminal_non_lead_cleanup(home, &team_name, &inbox_dir);
+        assert_terminal_non_lead_session_cleanup_preserves_roster(home, &team_name, &inbox_dir);
         assert!(
             sr.lock()
                 .unwrap()
                 .query_for_team(&team_name, "arch-ctm")
                 .is_none(),
-            "terminal non-lead session record should be removed"
+            "dead non-lead session record should be removed"
         );
     }
 
     #[test]
-    fn test_kill_timeout_fallback_converges_to_remove_dead_member_from_roster_and_mailbox() {
+    fn test_kill_timeout_fallback_converges_to_cleanup_dead_member_session_without_dropping_roster() {
         let (tmp, inbox_dir, team_name, sr, state_store) = setup_dead_terminal_non_lead();
         let home = tmp.path();
         let cycle_state = super::new_reconcile_cycle_state();
@@ -2542,13 +2538,13 @@ mod tests {
             &cycle_state,
         )
         .unwrap();
-        assert_terminal_non_lead_cleanup(home, &team_name, &inbox_dir);
+        assert_terminal_non_lead_session_cleanup_preserves_roster(home, &team_name, &inbox_dir);
         assert!(
             sr.lock()
                 .unwrap()
                 .query_for_team(&team_name, "arch-ctm")
                 .is_none(),
-            "terminal non-lead session record should be removed"
+            "dead non-lead session record should be removed"
         );
     }
 

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -2513,7 +2513,8 @@ mod tests {
     }
 
     #[test]
-    fn test_kill_timeout_fallback_converges_to_cleanup_dead_member_session_without_dropping_roster() {
+    fn test_kill_timeout_fallback_converges_to_cleanup_dead_member_session_without_dropping_roster()
+    {
         let (tmp, inbox_dir, team_name, sr, state_store) = setup_dead_terminal_non_lead();
         let home = tmp.path();
         let cycle_state = super::new_reconcile_cycle_state();

--- a/scripts/dev-install
+++ b/scripts/dev-install
@@ -200,10 +200,25 @@ def restart_daemon() -> None:
         die(f"atm binary not found at {atm_bin}")
     if daemon_bin.exists():
         kill_matching_daemons(daemon_bin)
+    restart_env = os.environ.copy()
+    restart_env["ATM_DEV_MODE"] = "1"
+    for key in ("CLAUDE_SESSION_ID", "ATM_IDENTITY", "ATM_TEAM"):
+        restart_env.pop(key, None)
     try:
-        run([str(atm_bin), "daemon", "restart"])
+        subprocess.run(
+            [str(atm_bin), "daemon", "restart"],
+            check=True,
+            env=restart_env,
+            start_new_session=True,
+            text=True,
+        )
     except SystemExit:
         print("  note: daemon restart returned non-zero (first-time start ok)")
+    except subprocess.CalledProcessError as exc:
+        print(
+            "  note: daemon restart returned non-zero "
+            f"(exit {exc.returncode}; first-time start ok)"
+        )
 
 
 def matching_pids_for_binary(binary_path: Path) -> list[int]:


### PR DESCRIPTION
## Summary

- **#835**: Shared dev/prod launcher scrubs caller session env and detaches process group so the daemon survives after `scripts/dev-install` exits. `dev-install` restarts daemon with scrubbed detached env.
- **#793**: Daemon config reconcile preserves all members while cleaning only dead session artifacts — manually-added members no longer dropped on `atm send`.

## Phase

Phase AX Sprint 1 — critical bug fixes
Integration branch: `integrate/phase-AX`

## Test plan
- [ ] `scripts/dev-install` completes and daemon remains running under `ATM_HOME=$HOME/.local/share/atm-dev/home`
- [ ] `atm send` does not drop manually-added team members from config.json
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean

Closes #835
Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)