### PR TITLE
chore: bump version 0.45.2 → 0.46.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-team-mail"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-ci-monitor",
  "agent-team-mail-core",
@@ -37,7 +37,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-ci-monitor"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -53,7 +53,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-core"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-daemon-launch",
  "anyhow",
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-ci-monitor",
  "agent-team-mail-core",
@@ -112,7 +112,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-daemon-launch"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "chrono",
  "serde",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-mcp"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -145,7 +145,7 @@ dependencies = [
 
 [[package]]
 name = "agent-team-mail-tui"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "agent-team-mail-daemon-launch",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "sc-compose"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1963,7 +1963,7 @@ dependencies = [
 
 [[package]]
 name = "sc-composer"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "minijinja",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "agent-team-mail-core",
  "anyhow",
@@ -1992,7 +1992,7 @@ dependencies = [
 
 [[package]]
 name = "sc-observability-otlp"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.45.2"
+version = "0.46.0"
 edition = "2024"
 authors = ["agent-team-mail contributors"]
 license = "MIT OR Apache-2.0"
@@ -41,10 +41,10 @@ thiserror = "2.0"
 anyhow = "1.0"
 
 # Internal dependencies
-agent-team-mail-ci-monitor = { path = "crates/atm-ci-monitor", version = "=0.45.2" }
-agent-team-mail-core = { path = "crates/atm-core", version = "=0.45.2" }
-agent-team-mail-daemon-launch = { path = "crates/atm-daemon-launch", version = "=0.45.2" }
-agent-team-mail-daemon = { path = "crates/atm-daemon", version = "=0.45.2" }
-sc-composer = { path = "crates/sc-composer", version = "=0.45.2" }
-sc-observability = { path = "crates/sc-observability", version = "=0.45.2" }
-sc-observability-otlp = { path = "crates/sc-observability-otlp", version = "=0.45.2" }
+agent-team-mail-ci-monitor = { path = "crates/atm-ci-monitor", version = "=0.46.0" }
+agent-team-mail-core = { path = "crates/atm-core", version = "=0.46.0" }
+agent-team-mail-daemon-launch = { path = "crates/atm-daemon-launch", version = "=0.46.0" }
+agent-team-mail-daemon = { path = "crates/atm-daemon", version = "=0.46.0" }
+sc-composer = { path = "crates/sc-composer", version = "=0.46.0" }
+sc-observability = { path = "crates/sc-observability", version = "=0.46.0" }
+sc-observability-otlp = { path = "crates/sc-observability-otlp", version = "=0.46.0" }

--- a/crates/atm-tui/Cargo.toml
+++ b/crates/atm-tui/Cargo.toml
@@ -13,7 +13,7 @@ name = "atm-tui"
 path = "src/main.rs"
 
 [dependencies]
-agent-team-mail-core = { path = "../atm-core", version = "=0.45.2" }
+agent-team-mail-core = { path = "../atm-core", version = "=0.46.0" }
 agent-team-mail-daemon-launch.workspace = true
 sc-observability.workspace = true
 ratatui = "0.29"

--- a/crates/sc-compose/Cargo.toml
+++ b/crates/sc-compose/Cargo.toml
@@ -12,7 +12,7 @@ description = "CLI for composing AI prompts with sc-composer"
 [dependencies]
 anyhow.workspace = true
 agent-team-mail-core.workspace = true
-sc-composer = { path = "../sc-composer", version = "=0.45.2" }
+sc-composer = { path = "../sc-composer", version = "=0.46.0" }
 sc-observability.workspace = true
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
## Summary
- Bump workspace version from 0.45.2 to 0.46.0
- Update all pinned `=0.45.2` internal dependency references in `Cargo.toml`, `crates/atm-tui/Cargo.toml`, `crates/sc-compose/Cargo.toml`
- Regenerate `Cargo.lock`

Pre-release minor version bump for Phase AX dogfood cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)