### PR TITLE
AW.1: Signal contracts — neutral TraceRecord/MetricRecord types + import boundary

### DIFF
--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -161,6 +161,62 @@ pub struct OtelRecord {
     pub attributes: serde_json::Map<String, serde_json::Value>,
 }
 
+/// Neutral trace signal contract for producer-side observability code.
+///
+/// Correlation fields are intentionally optional and fail-open in AW.1 so
+/// producers can adopt trace emission incrementally without blocking callers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct TraceRecord {
+    pub timestamp: String,
+    pub team: Option<String>,
+    pub agent: Option<String>,
+    pub runtime: Option<String>,
+    pub session_id: Option<String>,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub name: String,
+    pub status: TraceStatus,
+    pub duration_ms: u64,
+    pub source_binary: String,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceStatus {
+    Ok,
+    Error,
+    Unset,
+}
+
+/// Neutral metric signal contract for producer-side observability code.
+///
+/// Correlation fields are intentionally optional and fail-open in AW.1 so
+/// metric rollout can happen before every producer is fully correlated.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct MetricRecord {
+    pub timestamp: String,
+    pub team: Option<String>,
+    pub agent: Option<String>,
+    pub runtime: Option<String>,
+    pub session_id: Option<String>,
+    pub name: String,
+    pub kind: MetricKind,
+    pub value: f64,
+    pub unit: Option<String>,
+    pub source_binary: String,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
 #[derive(Debug, Clone)]
 pub struct FileOtelExporter {
     path: PathBuf,
@@ -1062,6 +1118,58 @@ mod tests {
         let mut event = new_log_event("atm", "test_action", "atm::test", "info");
         event.ts = ts.to_string();
         event
+    }
+
+    #[test]
+    fn trace_record_round_trip_allows_missing_correlation_fields() {
+        let record = TraceRecord {
+            timestamp: "2026-03-18T06:00:00Z".to_string(),
+            team: None,
+            agent: None,
+            runtime: None,
+            session_id: None,
+            trace_id: "trace-123".to_string(),
+            span_id: "span-456".to_string(),
+            parent_span_id: Some("span-000".to_string()),
+            name: "atm.send".to_string(),
+            status: TraceStatus::Ok,
+            duration_ms: 42,
+            source_binary: "atm".to_string(),
+            attributes: serde_json::Map::from_iter([(
+                "target".to_string(),
+                serde_json::Value::String("team-lead@atm-dev".to_string()),
+            )]),
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize trace record");
+        let round_trip: TraceRecord =
+            serde_json::from_value(json).expect("deserialize trace record");
+        assert_eq!(round_trip, record);
+    }
+
+    #[test]
+    fn metric_record_round_trip_with_partial_correlation() {
+        let record = MetricRecord {
+            timestamp: "2026-03-18T06:00:00Z".to_string(),
+            team: Some("atm-dev".to_string()),
+            agent: None,
+            runtime: Some("codex".to_string()),
+            session_id: None,
+            name: "atm_messages_total".to_string(),
+            kind: MetricKind::Counter,
+            value: 7.0,
+            unit: Some("count".to_string()),
+            source_binary: "atm".to_string(),
+            attributes: serde_json::Map::from_iter([(
+                "scope".to_string(),
+                serde_json::Value::String("mail".to_string()),
+            )]),
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize metric record");
+        let round_trip: MetricRecord =
+            serde_json::from_value(json).expect("deserialize metric record");
+        assert_eq!(round_trip, record);
     }
 
     static BACKOFF_SLEEPS_MS: OnceLock<Mutex<Vec<u64>>> = OnceLock::new();


### PR DESCRIPTION
## Summary

- Adds neutral `TraceRecord` and `MetricRecord` types to `sc-observability`
- Exports both types from crate root
- Correlation fields optional/fail-open (same contract as `LogRecord`)
- OTLP boundary preserved: `sc-observability` has no OTLP crate imports
- `sc-observability-otlp` untouched (AW.2 expands it)

## Test plan

- [ ] `TraceRecord` and `MetricRecord` exported from `sc-observability` crate root
- [ ] No OTLP crate imports in `sc-observability`
- [ ] Existing `LogRecord` / log export tests unaffected
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)