### PR TITLE
AW.3: Producer trace rollout — ATM CLI + daemon span instrumentation

### DIFF
--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -135,27 +135,34 @@ fn build_dispatch_root_trace_record(
     }
 }
 
+struct PluginDispatchTrace<'a> {
+    plugin_name: &'a str,
+    operation: &'a str,
+    duration_ms: u64,
+    status: TraceStatus,
+    error: Option<&'a str>,
+}
+
 fn build_plugin_dispatch_trace_record(
     event: &InboxEvent,
     message_id: Option<&str>,
     trace_id: &str,
     parent_span_id: &str,
-    plugin_name: &str,
-    operation: &str,
-    duration_ms: u64,
-    status: TraceStatus,
-    error: Option<&str>,
+    plugin_trace: PluginDispatchTrace<'_>,
 ) -> TraceRecord {
-    let span_action = format!("plugin_dispatch_{plugin_name}_{operation}");
+    let span_action = format!(
+        "plugin_dispatch_{}_{}",
+        plugin_trace.plugin_name, plugin_trace.operation
+    );
     let span_id = agent_team_mail_core::event_log::span_id_for_action(trace_id, &span_action);
     let mut attributes = serde_json::Map::new();
     attributes.insert(
         "plugin".to_string(),
-        serde_json::Value::String(plugin_name.to_string()),
+        serde_json::Value::String(plugin_trace.plugin_name.to_string()),
     );
     attributes.insert(
         "operation".to_string(),
-        serde_json::Value::String(operation.to_string()),
+        serde_json::Value::String(plugin_trace.operation.to_string()),
     );
     attributes.insert(
         "path".to_string(),
@@ -167,7 +174,7 @@ fn build_plugin_dispatch_trace_record(
             serde_json::Value::String(message_id.to_string()),
         );
     }
-    if let Some(error) = error {
+    if let Some(error) = plugin_trace.error {
         attributes.insert(
             "error".to_string(),
             serde_json::Value::String(error.to_string()),
@@ -183,9 +190,12 @@ fn build_plugin_dispatch_trace_record(
         trace_id: trace_id.to_string(),
         span_id,
         parent_span_id: Some(parent_span_id.to_string()),
-        name: format!("atm-daemon.plugin.{plugin_name}.{operation}"),
-        status,
-        duration_ms,
+        name: format!(
+            "atm-daemon.plugin.{}.{}",
+            plugin_trace.plugin_name, plugin_trace.operation
+        ),
+        status: plugin_trace.status,
+        duration_ms: plugin_trace.duration_ms,
         source_binary: "atm-daemon".to_string(),
         attributes,
     }
@@ -598,11 +608,15 @@ pub async fn run(
                                         message_id.as_deref(),
                                         &dispatch_trace_id,
                                         &dispatch_root_span_id,
-                                        metadata.name,
-                                        "handle_message",
-                                        plugin_dispatch_started_at.elapsed().as_millis() as u64,
-                                        trace_status,
-                                        trace_error.as_deref(),
+                                        PluginDispatchTrace {
+                                            plugin_name: metadata.name,
+                                            operation: "handle_message",
+                                            duration_ms: plugin_dispatch_started_at.elapsed()
+                                                .as_millis()
+                                                as u64,
+                                            status: trace_status,
+                                            error: trace_error.as_deref(),
+                                        },
                                     )],
                                     &otel_config,
                                 );
@@ -1905,8 +1919,9 @@ fn format_timestamp(time: SystemTime) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        InboxCursor, build_dispatch_root_trace_record, build_logging_health_snapshot,
-        build_plugin_dispatch_trace_record, dispatch_trace_id, read_new_inbox_messages,
+        InboxCursor, PluginDispatchTrace, build_dispatch_root_trace_record,
+        build_logging_health_snapshot, build_plugin_dispatch_trace_record, dispatch_trace_id,
+        read_new_inbox_messages,
     };
     use crate::daemon::InboxEventKind;
     use crate::daemon::session_registry::new_session_registry;
@@ -2022,11 +2037,13 @@ mod tests {
             Some("msg-123"),
             &trace_id,
             &root_span_id,
-            "ci-monitor",
-            "handle_message",
-            17,
-            TraceStatus::Ok,
-            None,
+            PluginDispatchTrace {
+                plugin_name: "ci-monitor",
+                operation: "handle_message",
+                duration_ms: 17,
+                status: TraceStatus::Ok,
+                error: None,
+            },
         );
 
         assert_eq!(record.trace_id, trace_id);

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -19,10 +19,12 @@ use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
 use agent_team_mail_core::schema::TeamConfig;
 use agent_team_mail_core::team_config_store::TeamConfigStore;
 use anyhow::{Context, Result};
+use chrono::Utc;
+use sc_observability::{OtelConfig, TraceRecord, TraceStatus, export_trace_records_best_effort};
 use serde_json::Value;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -74,6 +76,119 @@ fn emit_plugin_lifecycle_event(
         error,
         ..Default::default()
     });
+}
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn dispatch_trace_id(event: &InboxEvent, message_id: Option<&str>) -> String {
+    let seed = message_id.unwrap_or_else(|| event.path.to_str().unwrap_or("unknown-dispatch"));
+    agent_team_mail_core::event_log::trace_id_for_request("atm-daemon", seed)
+}
+
+fn build_dispatch_root_trace_record(
+    event: &InboxEvent,
+    message_id: Option<&str>,
+    trace_id: &str,
+    root_span_id: &str,
+    duration_ms: u64,
+    status: TraceStatus,
+) -> TraceRecord {
+    let mut attributes = serde_json::Map::new();
+    attributes.insert(
+        "operation".to_string(),
+        serde_json::Value::String("dispatch_message".to_string()),
+    );
+    attributes.insert(
+        "path".to_string(),
+        serde_json::Value::String(event.path.display().to_string()),
+    );
+    if let Some(message_id) = message_id {
+        attributes.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+
+    TraceRecord {
+        timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        team: Some(event.team.clone()),
+        agent: Some(event.agent.clone()),
+        runtime: env_nonempty("ATM_RUNTIME"),
+        session_id: env_nonempty("CLAUDE_SESSION_ID"),
+        trace_id: trace_id.to_string(),
+        span_id: root_span_id.to_string(),
+        parent_span_id: None,
+        name: "atm-daemon.dispatch_message".to_string(),
+        status,
+        duration_ms,
+        source_binary: "atm-daemon".to_string(),
+        attributes,
+    }
+}
+
+fn build_plugin_dispatch_trace_record(
+    event: &InboxEvent,
+    message_id: Option<&str>,
+    trace_id: &str,
+    parent_span_id: &str,
+    plugin_name: &str,
+    operation: &str,
+    duration_ms: u64,
+    status: TraceStatus,
+    error: Option<&str>,
+) -> TraceRecord {
+    let span_action = format!("plugin_dispatch_{plugin_name}_{operation}");
+    let span_id = agent_team_mail_core::event_log::span_id_for_action(trace_id, &span_action);
+    let mut attributes = serde_json::Map::new();
+    attributes.insert(
+        "plugin".to_string(),
+        serde_json::Value::String(plugin_name.to_string()),
+    );
+    attributes.insert(
+        "operation".to_string(),
+        serde_json::Value::String(operation.to_string()),
+    );
+    attributes.insert(
+        "path".to_string(),
+        serde_json::Value::String(event.path.display().to_string()),
+    );
+    if let Some(message_id) = message_id {
+        attributes.insert(
+            "message_id".to_string(),
+            serde_json::Value::String(message_id.to_string()),
+        );
+    }
+    if let Some(error) = error {
+        attributes.insert(
+            "error".to_string(),
+            serde_json::Value::String(error.to_string()),
+        );
+    }
+
+    TraceRecord {
+        timestamp: Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        team: Some(event.team.clone()),
+        agent: Some(event.agent.clone()),
+        runtime: env_nonempty("ATM_RUNTIME"),
+        session_id: env_nonempty("CLAUDE_SESSION_ID"),
+        trace_id: trace_id.to_string(),
+        span_id,
+        parent_span_id: Some(parent_span_id.to_string()),
+        name: format!("atm-daemon.plugin.{plugin_name}.{operation}"),
+        status,
+        duration_ms,
+        source_binary: "atm-daemon".to_string(),
+        attributes,
+    }
 }
 
 /// Wait for a daemon shutdown task to finish within `timeout`.
@@ -423,6 +538,17 @@ pub async fn run(
                     }
 
                     for mut inbox_msg in inbox_msgs {
+                        let dispatch_started_at = Instant::now();
+                        let message_id = inbox_msg.message_id.clone();
+                        let dispatch_trace_id = dispatch_trace_id(&event, message_id.as_deref());
+                        let dispatch_root_span_id =
+                            agent_team_mail_core::event_log::span_id_for_action(
+                                &dispatch_trace_id,
+                                "dispatch_message",
+                            );
+                        let otel_config = OtelConfig::from_env();
+                        let mut dispatch_failed = false;
+
                         emit_event_best_effort(EventFields {
                             level: "info",
                             source: "atm-daemon",
@@ -457,10 +583,31 @@ pub async fn run(
                         // Dispatch to all plugins with EventListener capability
                         for (metadata, plugin_arc) in &dispatch_plugins {
                             if metadata.capabilities.contains(&Capability::EventListener) {
+                                let plugin_dispatch_started_at = Instant::now();
                                 // Await lock to avoid dropping events under load
                                 let mut plugin = plugin_arc.lock().await;
                                 debug!("Dispatching to plugin: {}", metadata.name);
-                                if let Err(e) = plugin.handle_message(&inbox_msg).await {
+                                let dispatch_result = plugin.handle_message(&inbox_msg).await;
+                                let (trace_status, trace_error) = match &dispatch_result {
+                                    Ok(_) => (TraceStatus::Ok, None),
+                                    Err(e) => (TraceStatus::Error, Some(e.to_string())),
+                                };
+                                export_trace_records_best_effort(
+                                    &[build_plugin_dispatch_trace_record(
+                                        &event,
+                                        message_id.as_deref(),
+                                        &dispatch_trace_id,
+                                        &dispatch_root_span_id,
+                                        metadata.name,
+                                        "handle_message",
+                                        plugin_dispatch_started_at.elapsed().as_millis() as u64,
+                                        trace_status,
+                                        trace_error.as_deref(),
+                                    )],
+                                    &otel_config,
+                                );
+                                if let Err(e) = dispatch_result {
+                                    dispatch_failed = true;
                                     emit_event_best_effort(EventFields {
                                         level: "error",
                                         source: "atm-daemon",
@@ -479,6 +626,22 @@ pub async fn run(
                                 }
                             }
                         }
+
+                        export_trace_records_best_effort(
+                            &[build_dispatch_root_trace_record(
+                                &event,
+                                message_id.as_deref(),
+                                &dispatch_trace_id,
+                                &dispatch_root_span_id,
+                                dispatch_started_at.elapsed().as_millis() as u64,
+                                if dispatch_failed {
+                                    TraceStatus::Error
+                                } else {
+                                    TraceStatus::Ok
+                                },
+                            )],
+                            &otel_config,
+                        );
                     }
                 }
             }
@@ -1741,13 +1904,20 @@ fn format_timestamp(time: SystemTime) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{InboxCursor, build_logging_health_snapshot, read_new_inbox_messages};
+    use super::{
+        InboxCursor, build_dispatch_root_trace_record, build_logging_health_snapshot,
+        build_plugin_dispatch_trace_record, dispatch_trace_id, read_new_inbox_messages,
+    };
+    use crate::daemon::InboxEventKind;
     use crate::daemon::session_registry::new_session_registry;
     use crate::daemon::socket::new_state_store;
     use crate::plugins::worker_adapter::AgentState;
+    use agent_team_mail_core::event_log::span_id_for_action;
     use agent_team_mail_core::schema::InboxMessage;
+    use sc_observability::TraceStatus;
     use std::collections::HashMap;
     use std::fs as stdfs;
+    use std::path::PathBuf;
     use std::time::Duration;
     use tempfile::TempDir;
     use tokio::fs;
@@ -1755,6 +1925,16 @@ mod tests {
     async fn write_inbox(path: &std::path::Path, msgs: &[InboxMessage]) {
         let content = serde_json::to_string_pretty(msgs).unwrap();
         fs::write(path, content).await.unwrap();
+    }
+
+    fn sample_inbox_event() -> crate::daemon::InboxEvent {
+        crate::daemon::InboxEvent {
+            team: "atm-dev".to_string(),
+            agent: "arch-ctm".to_string(),
+            path: PathBuf::from("/tmp/atm-dev/arch-ctm/inbox.json"),
+            kind: InboxEventKind::MessageReceived,
+            origin: None,
+        }
     }
 
     #[test]
@@ -1828,6 +2008,66 @@ mod tests {
                 .unwrap_or_default()
                 .contains("disabled"),
             "expected disabled reason in last_error"
+        );
+    }
+
+    #[test]
+    fn test_build_plugin_dispatch_trace_record_links_to_parent_span() {
+        let event = sample_inbox_event();
+        let trace_id = dispatch_trace_id(&event, Some("msg-123"));
+        let root_span_id = span_id_for_action(&trace_id, "dispatch_message");
+
+        let record = build_plugin_dispatch_trace_record(
+            &event,
+            Some("msg-123"),
+            &trace_id,
+            &root_span_id,
+            "ci-monitor",
+            "handle_message",
+            17,
+            TraceStatus::Ok,
+            None,
+        );
+
+        assert_eq!(record.trace_id, trace_id);
+        assert_eq!(
+            record.parent_span_id.as_deref(),
+            Some(root_span_id.as_str())
+        );
+        assert_eq!(record.status, TraceStatus::Ok);
+        assert_eq!(record.name, "atm-daemon.plugin.ci-monitor.handle_message");
+        assert_eq!(
+            record.attributes.get("plugin").and_then(|v| v.as_str()),
+            Some("ci-monitor")
+        );
+        assert_eq!(
+            record.attributes.get("operation").and_then(|v| v.as_str()),
+            Some("handle_message")
+        );
+    }
+
+    #[test]
+    fn test_build_dispatch_root_trace_record_uses_message_context() {
+        let event = sample_inbox_event();
+        let trace_id = dispatch_trace_id(&event, Some("msg-456"));
+        let root_span_id = span_id_for_action(&trace_id, "dispatch_message");
+
+        let record = build_dispatch_root_trace_record(
+            &event,
+            Some("msg-456"),
+            &trace_id,
+            &root_span_id,
+            42,
+            TraceStatus::Error,
+        );
+
+        assert_eq!(record.trace_id, trace_id);
+        assert_eq!(record.span_id, root_span_id);
+        assert_eq!(record.status, TraceStatus::Error);
+        assert_eq!(record.name, "atm-daemon.dispatch_message");
+        assert_eq!(
+            record.attributes.get("message_id").and_then(|v| v.as_str()),
+            Some("msg-456")
         );
     }
 

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -119,7 +119,7 @@ fn main() {
         result: Some("starting".to_string()),
         request_id: Some(request_id.clone()),
         trace_id: Some(trace_id.clone()),
-        span_id: Some(start_span_id),
+        span_id: Some(start_span_id.clone()),
         extra_fields: {
             let mut fields = serde_json::Map::new();
             fields.insert(

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -6,6 +6,8 @@
 use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
 use agent_team_mail_core::logging;
 use clap::Parser;
+use sc_observability::{OtelConfig, TraceRecord, TraceStatus, export_trace_records_best_effort};
+use std::time::Instant;
 use uuid::Uuid;
 
 mod commands;
@@ -13,6 +15,70 @@ mod consts;
 mod util;
 
 use commands::Cli;
+
+fn env_nonempty(key: &str) -> Option<String> {
+    std::env::var(key).ok().and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn build_command_trace_record(
+    command_name: &str,
+    request_id: &str,
+    trace_id: &str,
+    span_id: &str,
+    status: TraceStatus,
+    duration_ms: u64,
+    error: Option<&str>,
+) -> TraceRecord {
+    let mut attributes = serde_json::Map::new();
+    attributes.insert(
+        "command".to_string(),
+        serde_json::Value::String(command_name.to_string()),
+    );
+    attributes.insert(
+        "request_id".to_string(),
+        serde_json::Value::String(request_id.to_string()),
+    );
+    attributes.insert(
+        "outcome".to_string(),
+        serde_json::Value::String(
+            match status {
+                TraceStatus::Ok => "ok",
+                TraceStatus::Error => "error",
+                TraceStatus::Unset => "unset",
+            }
+            .to_string(),
+        ),
+    );
+    if let Some(error) = error {
+        attributes.insert(
+            "error".to_string(),
+            serde_json::Value::String(error.to_string()),
+        );
+    }
+
+    TraceRecord {
+        timestamp: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        team: env_nonempty("ATM_TEAM"),
+        agent: env_nonempty("ATM_IDENTITY"),
+        runtime: env_nonempty("ATM_RUNTIME"),
+        session_id: env_nonempty("CLAUDE_SESSION_ID"),
+        trace_id: trace_id.to_string(),
+        span_id: span_id.to_string(),
+        parent_span_id: None,
+        name: format!("atm.command.{command_name}"),
+        status,
+        duration_ms,
+        source_binary: "atm".to_string(),
+        attributes,
+    }
+}
 
 fn main() {
     // Enable daemon auto-start for daemon-backed ATM commands.
@@ -40,6 +106,7 @@ fn main() {
     let trace_id = agent_team_mail_core::event_log::trace_id_for_request("atm", &request_id);
     let start_span_id =
         agent_team_mail_core::event_log::span_id_for_action(&trace_id, "command_start");
+    let started_at = Instant::now();
 
     emit_event_best_effort(EventFields {
         level: "info",
@@ -64,6 +131,7 @@ fn main() {
         ..Default::default()
     });
 
+    let otel_config = OtelConfig::from_env();
     let exit_code = if let Err(e) = cli.execute() {
         let rendered = e.to_string();
         emit_event_best_effort(EventFields {
@@ -90,6 +158,18 @@ fn main() {
             },
             ..Default::default()
         });
+        export_trace_records_best_effort(
+            &[build_command_trace_record(
+                &command_name,
+                &request_id,
+                &trace_id,
+                &start_span_id,
+                TraceStatus::Error,
+                started_at.elapsed().as_millis() as u64,
+                Some(&rendered),
+            )],
+            &otel_config,
+        );
         if serde_json::from_str::<serde_json::Value>(&rendered).is_ok() {
             eprintln!("{rendered}");
         } else {
@@ -122,6 +202,18 @@ fn main() {
             },
             ..Default::default()
         });
+        export_trace_records_best_effort(
+            &[build_command_trace_record(
+                &command_name,
+                &request_id,
+                &trace_id,
+                &start_span_id,
+                TraceStatus::Ok,
+                started_at.elapsed().as_millis() as u64,
+                None,
+            )],
+            &otel_config,
+        );
         0
     };
 

--- a/crates/atm/tests/integration_conflict_tests.rs
+++ b/crates/atm/tests/integration_conflict_tests.rs
@@ -299,7 +299,8 @@ async fn test_concurrent_sends_no_data_loss() {
     // Deterministic drain convergence with bounded wall-clock timeout.
     let teams_dir = temp_dir.path().join(".claude/teams");
     let spool_base = temp_dir.path();
-    let deadline = Instant::now() + Duration::from_secs(10);
+    let drain_timeout_secs = if cfg!(windows) { 20 } else { 10 };
+    let deadline = Instant::now() + Duration::from_secs(drain_timeout_secs);
     let mut status =
         agent_team_mail_core::io::spool::spool_drain_with_base(&teams_dir, Some(spool_base))
             .unwrap();
@@ -331,7 +332,8 @@ async fn test_concurrent_sends_no_data_loss() {
         serde_json::from_str(&content).unwrap()
     };
     let mut messages = read_messages();
-    let delivery_deadline = Instant::now() + Duration::from_secs(15);
+    let delivery_timeout_secs = if cfg!(windows) { 30 } else { 15 };
+    let delivery_deadline = Instant::now() + Duration::from_secs(delivery_timeout_secs);
     while messages.len() < expected && Instant::now() < delivery_deadline {
         std::thread::sleep(Duration::from_millis(50));
         let _ =

--- a/crates/atm/tests/integration_otel_traces.rs
+++ b/crates/atm/tests/integration_otel_traces.rs
@@ -183,8 +183,8 @@ fn cli_status_exports_trace_record_to_collector() {
     let payload: Value = serde_json::from_str(&body).expect("valid traces payload");
     let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
     assert_eq!(span["name"], "atm.command.status");
-    assert_eq!(span["traceId"].as_str().is_some(), true);
-    assert_eq!(span["spanId"].as_str().is_some(), true);
+    assert!(span["traceId"].as_str().is_some());
+    assert!(span["spanId"].as_str().is_some());
 
     let attrs = payload["resourceSpans"][0]["resource"]["attributes"]
         .as_array()

--- a/crates/atm/tests/integration_otel_traces.rs
+++ b/crates/atm/tests/integration_otel_traces.rs
@@ -1,0 +1,230 @@
+use assert_cmd::cargo::cargo_bin;
+use serde_json::Value;
+use serial_test::serial;
+use std::fs;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::path::Path;
+use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+use tempfile::TempDir;
+
+fn setup_team(home: &Path, team: &str) {
+    let team_dir = home.join(".claude/teams").join(team);
+    fs::create_dir_all(team_dir.join("inboxes")).expect("create team dirs");
+    fs::write(
+        team_dir.join("config.json"),
+        serde_json::json!({
+            "name": team,
+            "description": "test team",
+            "createdAt": 1739284800000u64,
+            "leadAgentId": format!("team-lead@{team}"),
+            "leadSessionId": "sess-team-lead",
+            "members": [
+                {
+                    "agentId": format!("team-lead@{team}"),
+                    "name": "team-lead",
+                    "agentType": "team-lead",
+                    "model": "claude-sonnet-4-6",
+                    "joinedAt": 1739284800000u64,
+                    "cwd": ".",
+                    "subscriptions": []
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .expect("write team config");
+}
+
+fn setup_daemon_status(home: &Path) {
+    let daemon_dir = home.join(".atm/daemon");
+    fs::create_dir_all(&daemon_dir).expect("create daemon dir");
+    fs::write(
+        daemon_dir.join("status.json"),
+        serde_json::json!({
+            "timestamp": "2026-03-18T00:00:00Z",
+            "pid": 4242,
+            "version": "0.45.0",
+            "uptime_secs": 1,
+            "plugins": [],
+            "teams": ["atm-dev"],
+            "logging": {
+                "state": "healthy",
+                "dropped_counter": 0,
+                "spool_path": home.join(".atm/log-spool").to_string_lossy(),
+                "last_error": null,
+                "canonical_log_path": home.join(".atm/atm.log.jsonl").to_string_lossy(),
+                "spool_count": 0,
+                "oldest_spool_age": null
+            },
+            "otel": {
+                "schema_version": "v1",
+                "enabled": true,
+                "collector_endpoint": "http://collector:4318",
+                "protocol": "otlp_http",
+                "collector_state": "healthy",
+                "local_mirror_state": "healthy",
+                "local_mirror_path": home.join(".atm/atm.log.otel.jsonl").to_string_lossy(),
+                "debug_local_export": false,
+                "debug_local_state": "disabled",
+                "last_error": {
+                    "code": null,
+                    "message": null,
+                    "at": null
+                }
+            }
+        })
+        .to_string(),
+    )
+    .expect("write daemon status");
+}
+
+fn start_collector() -> (String, mpsc::Receiver<(String, String)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind collector");
+    listener
+        .set_nonblocking(false)
+        .expect("collector blocking mode");
+    let addr = listener.local_addr().expect("collector addr");
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        for _ in 0..4 {
+            let Ok((mut stream, _)) = listener.accept() else {
+                break;
+            };
+            let mut buffer = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            let mut header_end = None;
+            while header_end.is_none() {
+                let read = stream.read(&mut chunk).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&chunk[..read]);
+                header_end = buffer.windows(4).position(|window| window == b"\r\n\r\n");
+            }
+            let Some(header_end_idx) = header_end else {
+                continue;
+            };
+            let body_start = header_end_idx + 4;
+            let headers = String::from_utf8_lossy(&buffer[..header_end_idx]);
+            let first_line = headers.lines().next().unwrap_or_default().to_string();
+            let path = first_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or_default()
+                .to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    (name.eq_ignore_ascii_case("content-length"))
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+
+            while buffer.len().saturating_sub(body_start) < content_length {
+                let read = stream.read(&mut chunk).expect("read request body");
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&chunk[..read]);
+            }
+
+            let body = String::from_utf8_lossy(&buffer[body_start..body_start + content_length])
+                .to_string();
+            tx.send((path, body)).expect("send captured request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                .expect("write response");
+        }
+    });
+
+    (format!("http://{}", addr), rx)
+}
+
+#[test]
+#[serial]
+fn cli_status_exports_trace_record_to_collector() {
+    let temp = TempDir::new().expect("temp dir");
+    setup_team(temp.path(), "atm-dev");
+    setup_daemon_status(temp.path());
+    let (endpoint, rx) = start_collector();
+
+    let mut cmd = Command::new(cargo_bin("atm"));
+    cmd.env("ATM_HOME", temp.path())
+        .env("ATM_TEAM", "atm-dev")
+        .env("ATM_IDENTITY", "arch-ctm")
+        .env("ATM_RUNTIME", "codex")
+        .env("CLAUDE_SESSION_ID", "sess-123")
+        .env("ATM_LOG", "0")
+        .env("ATM_DAEMON_AUTOSTART", "0")
+        .env("ATM_OTEL_ENABLED", "true")
+        .env("ATM_OTEL_ENDPOINT", endpoint)
+        .args(["status", "--json"]);
+
+    let output = cmd.output().expect("run atm status");
+    assert!(
+        output.status.success(),
+        "status command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let (path, body) = rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("collector request");
+    assert_eq!(path, "/v1/traces");
+
+    let payload: Value = serde_json::from_str(&body).expect("valid traces payload");
+    let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+    assert_eq!(span["name"], "atm.command.status");
+    assert_eq!(span["traceId"].as_str().is_some(), true);
+    assert_eq!(span["spanId"].as_str().is_some(), true);
+
+    let attrs = payload["resourceSpans"][0]["resource"]["attributes"]
+        .as_array()
+        .expect("resource attributes");
+    assert!(
+        attrs
+            .iter()
+            .any(|item| { item["key"] == "team" && item["value"]["stringValue"] == "atm-dev" })
+    );
+    assert!(
+        attrs
+            .iter()
+            .any(|item| { item["key"] == "agent" && item["value"]["stringValue"] == "arch-ctm" })
+    );
+}
+
+#[test]
+#[serial]
+fn cli_status_trace_export_is_fail_open_when_collector_unreachable() {
+    let temp = TempDir::new().expect("temp dir");
+    setup_team(temp.path(), "atm-dev");
+    setup_daemon_status(temp.path());
+
+    let mut cmd = Command::new(cargo_bin("atm"));
+    cmd.env("ATM_HOME", temp.path())
+        .env("ATM_TEAM", "atm-dev")
+        .env("ATM_IDENTITY", "arch-ctm")
+        .env("ATM_RUNTIME", "codex")
+        .env("CLAUDE_SESSION_ID", "sess-123")
+        .env("ATM_LOG", "0")
+        .env("ATM_DAEMON_AUTOSTART", "0")
+        .env("ATM_OTEL_ENABLED", "true")
+        .env("ATM_OTEL_ENDPOINT", "http://127.0.0.1:1")
+        .args(["status", "--json"]);
+
+    let output = cmd.output().expect("run atm status");
+    assert!(
+        output.status.success(),
+        "trace export failure must not fail the command: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/atm/tests/integration_otel_traces.rs
+++ b/crates/atm/tests/integration_otel_traces.rs
@@ -186,16 +186,22 @@ fn cli_status_exports_trace_record_to_collector() {
     assert!(span["traceId"].as_str().is_some());
     assert!(span["spanId"].as_str().is_some());
 
-    let attrs = payload["resourceSpans"][0]["resource"]["attributes"]
+    let resource_attrs = payload["resourceSpans"][0]["resource"]["attributes"]
         .as_array()
         .expect("resource attributes");
     assert!(
-        attrs
+        resource_attrs
+            .iter()
+            .any(|item| { item["key"] == "service.name" && item["value"]["stringValue"] == "atm" })
+    );
+    let span_attrs = span["attributes"].as_array().expect("span attributes");
+    assert!(
+        span_attrs
             .iter()
             .any(|item| { item["key"] == "team" && item["value"]["stringValue"] == "atm-dev" })
     );
     assert!(
-        attrs
+        span_attrs
             .iter()
             .any(|item| { item["key"] == "agent" && item["value"]["stringValue"] == "arch-ctm" })
     );

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -371,6 +371,47 @@ pub fn export_otel_best_effort(
     }
 }
 
+/// Export trace records without allowing exporter failures to affect callers.
+///
+/// AW.3 uses this to emit native trace spans from CLI and daemon code while
+/// keeping all failures fail-open.
+pub fn export_trace_records_best_effort(records: &[TraceRecord], config: &OtelConfig) {
+    if !config.enabled || records.is_empty() {
+        return;
+    }
+    if config
+        .endpoint
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+    {
+        return;
+    }
+    if let Err(err) = otlp_adapter::export_traces(config, records) {
+        health::note_export_failure(OtelExporterKind::Collector, &err);
+    } else {
+        health::note_export_success(OtelExporterKind::Collector);
+    }
+}
+
+/// Export metric records without allowing exporter failures to affect callers.
+pub fn export_metric_records_best_effort(records: &[MetricRecord], config: &OtelConfig) {
+    if !config.enabled || records.is_empty() {
+        return;
+    }
+    if config
+        .endpoint
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+    {
+        return;
+    }
+    if let Err(err) = otlp_adapter::export_metrics(config, records) {
+        health::note_export_failure(OtelExporterKind::Collector, &err);
+    } else {
+        health::note_export_success(OtelExporterKind::Collector);
+    }
+}
+
 fn build_otel_record(event: &LogEventV1) -> Result<OtelRecord, OtelError> {
     let runtime_scoped = event.team.is_some()
         || event.agent.is_some()

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -16,9 +16,13 @@ use std::time::Duration;
 use thiserror::Error;
 
 mod health;
+mod metrics;
 mod otlp_adapter;
+mod trace;
 
 pub use health::{OtelHealthSnapshot, OtelLastError, current_otel_health};
+pub use metrics::{MetricKind, MetricRecord, export_metric_records_best_effort};
+pub use trace::{TraceRecord, TraceStatus, export_trace_records_best_effort};
 
 pub const DEFAULT_QUEUE_CAPACITY: usize = 4096;
 pub const DEFAULT_MAX_EVENT_BYTES: usize = 64 * 1024;
@@ -159,62 +163,6 @@ pub struct OtelRecord {
     pub trace_id: Option<String>,
     pub span_id: Option<String>,
     pub attributes: serde_json::Map<String, serde_json::Value>,
-}
-
-/// Neutral trace signal contract for producer-side observability code.
-///
-/// Correlation fields are intentionally optional and fail-open in AW.1 so
-/// producers can adopt trace emission incrementally without blocking callers.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-pub struct TraceRecord {
-    pub timestamp: String,
-    pub team: Option<String>,
-    pub agent: Option<String>,
-    pub runtime: Option<String>,
-    pub session_id: Option<String>,
-    pub trace_id: String,
-    pub span_id: String,
-    pub parent_span_id: Option<String>,
-    pub name: String,
-    pub status: TraceStatus,
-    pub duration_ms: u64,
-    pub source_binary: String,
-    pub attributes: serde_json::Map<String, serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum TraceStatus {
-    Ok,
-    Error,
-    Unset,
-}
-
-/// Neutral metric signal contract for producer-side observability code.
-///
-/// Correlation fields are intentionally optional and fail-open in AW.1 so
-/// metric rollout can happen before every producer is fully correlated.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-pub struct MetricRecord {
-    pub timestamp: String,
-    pub team: Option<String>,
-    pub agent: Option<String>,
-    pub runtime: Option<String>,
-    pub session_id: Option<String>,
-    pub name: String,
-    pub kind: MetricKind,
-    pub value: f64,
-    pub unit: Option<String>,
-    pub source_binary: String,
-    pub attributes: serde_json::Map<String, serde_json::Value>,
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum MetricKind {
-    Counter,
-    Gauge,
-    Histogram,
 }
 
 #[derive(Debug, Clone)]
@@ -368,47 +316,6 @@ pub fn export_otel_best_effort(
         std::thread::sleep(Duration::from_millis(backoff));
         backoff = backoff.saturating_mul(2).min(config.max_backoff_ms);
         attempt = attempt.saturating_add(1);
-    }
-}
-
-/// Export trace records without allowing exporter failures to affect callers.
-///
-/// AW.3 uses this to emit native trace spans from CLI and daemon code while
-/// keeping all failures fail-open.
-pub fn export_trace_records_best_effort(records: &[TraceRecord], config: &OtelConfig) {
-    if !config.enabled || records.is_empty() {
-        return;
-    }
-    if config
-        .endpoint
-        .as_deref()
-        .is_none_or(|value| value.trim().is_empty())
-    {
-        return;
-    }
-    if let Err(err) = otlp_adapter::export_traces(config, records) {
-        health::note_export_failure(OtelExporterKind::Collector, &err);
-    } else {
-        health::note_export_success(OtelExporterKind::Collector);
-    }
-}
-
-/// Export metric records without allowing exporter failures to affect callers.
-pub fn export_metric_records_best_effort(records: &[MetricRecord], config: &OtelConfig) {
-    if !config.enabled || records.is_empty() {
-        return;
-    }
-    if config
-        .endpoint
-        .as_deref()
-        .is_none_or(|value| value.trim().is_empty())
-    {
-        return;
-    }
-    if let Err(err) = otlp_adapter::export_metrics(config, records) {
-        health::note_export_failure(OtelExporterKind::Collector, &err);
-    } else {
-        health::note_export_success(OtelExporterKind::Collector);
     }
 }
 
@@ -1159,58 +1066,6 @@ mod tests {
         let mut event = new_log_event("atm", "test_action", "atm::test", "info");
         event.ts = ts.to_string();
         event
-    }
-
-    #[test]
-    fn trace_record_round_trip_allows_missing_correlation_fields() {
-        let record = TraceRecord {
-            timestamp: "2026-03-18T06:00:00Z".to_string(),
-            team: None,
-            agent: None,
-            runtime: None,
-            session_id: None,
-            trace_id: "trace-123".to_string(),
-            span_id: "span-456".to_string(),
-            parent_span_id: Some("span-000".to_string()),
-            name: "atm.send".to_string(),
-            status: TraceStatus::Ok,
-            duration_ms: 42,
-            source_binary: "atm".to_string(),
-            attributes: serde_json::Map::from_iter([(
-                "target".to_string(),
-                serde_json::Value::String("team-lead@atm-dev".to_string()),
-            )]),
-        };
-
-        let json = serde_json::to_value(&record).expect("serialize trace record");
-        let round_trip: TraceRecord =
-            serde_json::from_value(json).expect("deserialize trace record");
-        assert_eq!(round_trip, record);
-    }
-
-    #[test]
-    fn metric_record_round_trip_with_partial_correlation() {
-        let record = MetricRecord {
-            timestamp: "2026-03-18T06:00:00Z".to_string(),
-            team: Some("atm-dev".to_string()),
-            agent: None,
-            runtime: Some("codex".to_string()),
-            session_id: None,
-            name: "atm_messages_total".to_string(),
-            kind: MetricKind::Counter,
-            value: 7.0,
-            unit: Some("count".to_string()),
-            source_binary: "atm".to_string(),
-            attributes: serde_json::Map::from_iter([(
-                "scope".to_string(),
-                serde_json::Value::String("mail".to_string()),
-            )]),
-        };
-
-        let json = serde_json::to_value(&record).expect("serialize metric record");
-        let round_trip: MetricRecord =
-            serde_json::from_value(json).expect("deserialize metric record");
-        assert_eq!(round_trip, record);
     }
 
     static BACKOFF_SLEEPS_MS: OnceLock<Mutex<Vec<u64>>> = OnceLock::new();

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -1582,7 +1582,12 @@ mod tests {
         );
         logger.emit(&event).expect("emit should succeed");
 
-        let requests = collector.requests();
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut requests = collector.requests();
+        while requests.is_empty() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+            requests = collector.requests();
+        }
         assert_eq!(requests.len(), 1, "collector should receive one request");
         assert!(
             requests[0].starts_with("POST /v1/logs HTTP/1.1"),

--- a/crates/sc-observability/src/metrics.rs
+++ b/crates/sc-observability/src/metrics.rs
@@ -1,4 +1,4 @@
-use crate::{health, otlp_adapter, OtelConfig};
+use crate::{OtelConfig, health, otlp_adapter};
 
 /// Neutral metric signal contract for producer-side observability code.
 ///

--- a/crates/sc-observability/src/metrics.rs
+++ b/crates/sc-observability/src/metrics.rs
@@ -1,0 +1,77 @@
+use crate::{health, otlp_adapter, OtelConfig};
+
+/// Neutral metric signal contract for producer-side observability code.
+///
+/// Correlation fields are intentionally optional and fail-open in AW.1 so
+/// metric rollout can happen before every producer is fully correlated.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct MetricRecord {
+    pub timestamp: String,
+    pub team: Option<String>,
+    pub agent: Option<String>,
+    pub runtime: Option<String>,
+    pub session_id: Option<String>,
+    pub name: String,
+    pub kind: MetricKind,
+    pub value: f64,
+    pub unit: Option<String>,
+    pub source_binary: String,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+/// Export metric records without allowing exporter failures to affect callers.
+pub fn export_metric_records_best_effort(records: &[MetricRecord], config: &OtelConfig) {
+    if !config.enabled || records.is_empty() {
+        return;
+    }
+    if config
+        .endpoint
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+    {
+        return;
+    }
+    if let Err(err) = otlp_adapter::export_metrics(config, records) {
+        health::note_export_failure(crate::OtelExporterKind::Collector, &err);
+    } else {
+        health::note_export_success(crate::OtelExporterKind::Collector);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MetricKind, MetricRecord};
+
+    #[test]
+    fn metric_record_round_trip_with_partial_correlation() {
+        let record = MetricRecord {
+            timestamp: "2026-03-18T06:00:00Z".to_string(),
+            team: Some("atm-dev".to_string()),
+            agent: None,
+            runtime: Some("codex".to_string()),
+            session_id: None,
+            name: "atm_messages_total".to_string(),
+            kind: MetricKind::Counter,
+            value: 7.0,
+            unit: Some("count".to_string()),
+            source_binary: "atm".to_string(),
+            attributes: serde_json::Map::from_iter([(
+                "scope".to_string(),
+                serde_json::Value::String("mail".to_string()),
+            )]),
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize metric record");
+        let round_trip: MetricRecord =
+            serde_json::from_value(json).expect("deserialize metric record");
+        assert_eq!(round_trip, record);
+    }
+}

--- a/crates/sc-observability/src/otlp_adapter.rs
+++ b/crates/sc-observability/src/otlp_adapter.rs
@@ -1,6 +1,11 @@
-use crate::{OtelConfig, OtelError, OtelExporter, OtelExporterKind, OtelRecord};
+use crate::{
+    MetricKind, MetricRecord, OtelConfig, OtelError, OtelExporter, OtelExporterKind, OtelRecord,
+    TraceRecord, TraceStatus,
+};
 use sc_observability_otlp::{
-    TransportConfig, TransportError, TransportExporter, TransportExporterKind, TransportRecord,
+    MetricKind as TransportMetricKind, MetricTransportRecord, TraceStatus as TransportTraceStatus,
+    TraceTransportRecord, TransportConfig, TransportError, TransportExporter,
+    TransportExporterKind, TransportRecord,
 };
 use std::sync::Arc;
 
@@ -53,6 +58,83 @@ fn to_transport_record(record: &OtelRecord) -> TransportRecord {
         trace_id: record.trace_id.clone(),
         span_id: record.span_id.clone(),
         attributes: record.attributes.clone(),
+    }
+}
+
+pub fn export_traces(config: &OtelConfig, records: &[TraceRecord]) -> Result<(), OtelError> {
+    let transport_config = build_transport_config(config);
+    let records = records
+        .iter()
+        .cloned()
+        .map(to_trace_transport_record)
+        .collect::<Vec<_>>();
+    sc_observability_otlp::export_traces(&transport_config, &records).map_err(map_transport_error)
+}
+
+pub fn export_metrics(config: &OtelConfig, records: &[MetricRecord]) -> Result<(), OtelError> {
+    let transport_config = build_transport_config(config);
+    let records = records
+        .iter()
+        .cloned()
+        .map(to_metric_transport_record)
+        .collect::<Vec<_>>();
+    sc_observability_otlp::export_metrics(&transport_config, &records).map_err(map_transport_error)
+}
+
+fn build_transport_config(config: &OtelConfig) -> TransportConfig {
+    TransportConfig {
+        endpoint: config.endpoint.clone(),
+        protocol: config.protocol.clone(),
+        auth_header: config.auth_header.clone(),
+        ca_file: config.ca_file.clone(),
+        insecure_skip_verify: config.insecure_skip_verify,
+        timeout_ms: config.timeout_ms,
+        debug_local_export: config.debug_local_export,
+        max_retries: config.max_retries,
+        initial_backoff_ms: config.initial_backoff_ms,
+        max_backoff_ms: config.max_backoff_ms,
+    }
+}
+
+fn to_trace_transport_record(record: TraceRecord) -> TraceTransportRecord {
+    TraceTransportRecord {
+        timestamp: record.timestamp,
+        team: record.team,
+        agent: record.agent,
+        runtime: record.runtime,
+        session_id: record.session_id,
+        trace_id: record.trace_id,
+        span_id: record.span_id,
+        parent_span_id: record.parent_span_id,
+        name: record.name,
+        status: match record.status {
+            TraceStatus::Ok => TransportTraceStatus::Ok,
+            TraceStatus::Error => TransportTraceStatus::Error,
+            TraceStatus::Unset => TransportTraceStatus::Unset,
+        },
+        duration_ms: record.duration_ms,
+        source_binary: record.source_binary,
+        attributes: record.attributes,
+    }
+}
+
+fn to_metric_transport_record(record: MetricRecord) -> MetricTransportRecord {
+    MetricTransportRecord {
+        timestamp: record.timestamp,
+        team: record.team,
+        agent: record.agent,
+        runtime: record.runtime,
+        session_id: record.session_id,
+        name: record.name,
+        kind: match record.kind {
+            MetricKind::Counter => TransportMetricKind::Counter,
+            MetricKind::Gauge => TransportMetricKind::Gauge,
+            MetricKind::Histogram => TransportMetricKind::Histogram,
+        },
+        value: record.value,
+        unit: record.unit,
+        source_binary: record.source_binary,
+        attributes: record.attributes,
     }
 }
 

--- a/crates/sc-observability/src/trace.rs
+++ b/crates/sc-observability/src/trace.rs
@@ -1,4 +1,4 @@
-use crate::{health, otlp_adapter, OtelConfig};
+use crate::{OtelConfig, health, otlp_adapter};
 
 /// Neutral trace signal contract for producer-side observability code.
 ///

--- a/crates/sc-observability/src/trace.rs
+++ b/crates/sc-observability/src/trace.rs
@@ -1,0 +1,84 @@
+use crate::{health, otlp_adapter, OtelConfig};
+
+/// Neutral trace signal contract for producer-side observability code.
+///
+/// Correlation fields are intentionally optional and fail-open in AW.1 so
+/// producers can adopt trace emission incrementally without blocking callers.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+pub struct TraceRecord {
+    pub timestamp: String,
+    pub team: Option<String>,
+    pub agent: Option<String>,
+    pub runtime: Option<String>,
+    pub session_id: Option<String>,
+    pub trace_id: String,
+    pub span_id: String,
+    pub parent_span_id: Option<String>,
+    pub name: String,
+    pub status: TraceStatus,
+    pub duration_ms: u64,
+    pub source_binary: String,
+    pub attributes: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TraceStatus {
+    Ok,
+    Error,
+    Unset,
+}
+
+/// Export trace records without allowing exporter failures to affect callers.
+///
+/// AW.3 uses this to emit native trace spans from CLI and daemon code while
+/// keeping all failures fail-open.
+pub fn export_trace_records_best_effort(records: &[TraceRecord], config: &OtelConfig) {
+    if !config.enabled || records.is_empty() {
+        return;
+    }
+    if config
+        .endpoint
+        .as_deref()
+        .is_none_or(|value| value.trim().is_empty())
+    {
+        return;
+    }
+    if let Err(err) = otlp_adapter::export_traces(config, records) {
+        health::note_export_failure(crate::OtelExporterKind::Collector, &err);
+    } else {
+        health::note_export_success(crate::OtelExporterKind::Collector);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraceRecord, TraceStatus};
+
+    #[test]
+    fn trace_record_round_trip_allows_missing_correlation_fields() {
+        let record = TraceRecord {
+            timestamp: "2026-03-18T06:00:00Z".to_string(),
+            team: None,
+            agent: None,
+            runtime: None,
+            session_id: None,
+            trace_id: "trace-123".to_string(),
+            span_id: "span-456".to_string(),
+            parent_span_id: Some("span-000".to_string()),
+            name: "atm.send".to_string(),
+            status: TraceStatus::Ok,
+            duration_ms: 42,
+            source_binary: "atm".to_string(),
+            attributes: serde_json::Map::from_iter([(
+                "target".to_string(),
+                serde_json::Value::String("team-lead@atm-dev".to_string()),
+            )]),
+        };
+
+        let json = serde_json::to_value(&record).expect("serialize trace record");
+        let round_trip: TraceRecord =
+            serde_json::from_value(json).expect("deserialize trace record");
+        assert_eq!(round_trip, record);
+    }
+}

--- a/crates/sc-observability/tests/trace_export_integration.rs
+++ b/crates/sc-observability/tests/trace_export_integration.rs
@@ -1,0 +1,138 @@
+use sc_observability::{
+    OtelConfig, TraceRecord, TraceStatus, export_trace_records_best_effort,
+};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+
+struct TraceCollector {
+    endpoint: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    join: Option<thread::JoinHandle<()>>,
+}
+
+impl TraceCollector {
+    fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind collector");
+        listener
+            .set_nonblocking(true)
+            .expect("collector nonblocking");
+        let addr = listener.local_addr().expect("collector addr");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let shared = Arc::clone(&requests);
+        let join = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut request = Vec::new();
+                        let mut header_buf = [0_u8; 4096];
+                        let header_len = stream.read(&mut header_buf).expect("read request");
+                        request.extend_from_slice(&header_buf[..header_len]);
+                        let header_text = String::from_utf8_lossy(&request);
+                        let content_length = header_text
+                            .lines()
+                            .find_map(|line| {
+                                let (name, value) = line.split_once(':')?;
+                                (name.eq_ignore_ascii_case("content-length"))
+                                    .then(|| value.trim().parse::<usize>().ok())
+                                    .flatten()
+                            })
+                            .unwrap_or(0);
+                        let header_end = header_text
+                            .find("\r\n\r\n")
+                            .map(|idx| idx + 4)
+                            .unwrap_or(request.len());
+                        let body_read = request.len().saturating_sub(header_end);
+                        if body_read < content_length {
+                            let mut body = vec![0_u8; content_length - body_read];
+                            stream.read_exact(&mut body).expect("read request body");
+                            request.extend_from_slice(&body);
+                        }
+                        shared
+                            .lock()
+                            .expect("collector lock")
+                            .push(String::from_utf8_lossy(&request).to_string());
+                        stream
+                            .write_all(
+                                b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+                            )
+                            .expect("write response");
+                    }
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(err) => panic!("collector accept failed: {err}"),
+                }
+            }
+        });
+        Self {
+            endpoint: format!("http://{addr}"),
+            requests,
+            join: Some(join),
+        }
+    }
+
+    fn wait_for_request(&self) -> Vec<String> {
+        let deadline = Instant::now() + Duration::from_secs(3);
+        let mut requests = self.requests.lock().expect("collector lock").clone();
+        while requests.is_empty() && Instant::now() < deadline {
+            thread::sleep(Duration::from_millis(25));
+            requests = self.requests.lock().expect("collector lock").clone();
+        }
+        requests
+    }
+}
+
+impl Drop for TraceCollector {
+    fn drop(&mut self) {
+        if let Some(join) = self.join.take() {
+            join.join().expect("collector thread should join");
+        }
+    }
+}
+
+#[test]
+fn trace_record_exports_to_otlp_http_collector() {
+    let collector = TraceCollector::start();
+    let record = TraceRecord {
+        timestamp: "2026-03-18T08:00:00Z".to_string(),
+        team: Some("atm-dev".to_string()),
+        agent: Some("arch-ctm".to_string()),
+        runtime: Some("codex".to_string()),
+        session_id: Some("session-123".to_string()),
+        trace_id: "trace-123".to_string(),
+        span_id: "span-456".to_string(),
+        parent_span_id: Some("span-root".to_string()),
+        name: "atm.send".to_string(),
+        status: TraceStatus::Ok,
+        duration_ms: 12,
+        source_binary: "atm".to_string(),
+        attributes: serde_json::Map::from_iter([(
+            "command".to_string(),
+            serde_json::Value::String("send".to_string()),
+        )]),
+    };
+
+    let config = OtelConfig {
+        enabled: true,
+        endpoint: Some(collector.endpoint.clone()),
+        ..OtelConfig::default()
+    };
+
+    export_trace_records_best_effort(&[record], &config);
+
+    let requests = collector.wait_for_request();
+    assert_eq!(requests.len(), 1, "collector should receive one trace request");
+    assert!(
+        requests[0].starts_with("POST /v1/traces HTTP/1.1"),
+        "collector request should target OTLP traces endpoint: {requests:?}"
+    );
+    assert!(requests[0].contains("\"traceId\":\"trace-123\""));
+    assert!(requests[0].contains("\"spanId\":\"span-456\""));
+    assert!(requests[0].contains("\"service.name\""));
+    assert!(requests[0].contains("\"atm-dev\""));
+    assert!(requests[0].contains("\"arch-ctm\""));
+}

--- a/crates/sc-observability/tests/trace_export_integration.rs
+++ b/crates/sc-observability/tests/trace_export_integration.rs
@@ -1,6 +1,4 @@
-use sc_observability::{
-    OtelConfig, TraceRecord, TraceStatus, export_trace_records_best_effort,
-};
+use sc_observability::{OtelConfig, TraceRecord, TraceStatus, export_trace_records_best_effort};
 use std::io::{Read, Write};
 use std::net::TcpListener;
 use std::sync::{Arc, Mutex};
@@ -125,7 +123,11 @@ fn trace_record_exports_to_otlp_http_collector() {
     export_trace_records_best_effort(&[record], &config);
 
     let requests = collector.wait_for_request();
-    assert_eq!(requests.len(), 1, "collector should receive one trace request");
+    assert_eq!(
+        requests.len(),
+        1,
+        "collector should receive one trace request"
+    );
     assert!(
         requests[0].starts_with("POST /v1/traces HTTP/1.1"),
         "collector request should target OTLP traces endpoint: {requests:?}"

--- a/scripts/ci/observability_boundary_check.sh
+++ b/scripts/ci/observability_boundary_check.sh
@@ -10,7 +10,7 @@ is_allowed_sc_observability_rust_path() {
   case "$rel" in
     crates/atm/src/main.rs) return 0 ;;
     crates/sc-compose/src/main.rs) return 0 ;;
-    crates/atm-daemon/src/main.rs) return 0 ;;
+    crates/atm-daemon/src/*) return 0 ;;
     *) return 1 ;;
   esac
 }


### PR DESCRIPTION
## Summary

- Root command spans wired in `atm` CLI — each command emits a TraceRecord with name, team, agent identity, outcome
- Daemon dispatch child spans wired in `event_loop` — plugin name and operation type in span attributes
- AW.2 `export_traces()` consumed via `sc-observability` facade
- Fail-open: span creation/export failure does not affect command exit code

## Test plan

- [ ] ATM CLI commands emit at least one TraceRecord per invocation
- [ ] Daemon dispatch emits child spans
- [ ] Existing integration tests unaffected
- [ ] Fail-open: broken exporter does not fail commands
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)