### PR TITLE
test: remove hardcoded tmp fixtures

### DIFF
--- a/crates/atm-daemon/src/plugins/ci_monitor/service.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/service.rs
@@ -1612,7 +1612,10 @@ poll_interval_secs = 60
             }),
             owner: Some(GhRuntimeOwner {
                 runtime: "dev".to_string(),
-                executable_path: "/tmp/fake-atm-daemon".to_string(),
+                executable_path: std::env::temp_dir()
+                    .join("fake-atm-daemon")
+                    .to_string_lossy()
+                    .into_owned(),
                 home_scope: home.display().to_string(),
                 pid: std::process::id(),
             }),

--- a/crates/atm/src/commands/daemon.rs
+++ b/crates/atm/src/commands/daemon.rs
@@ -1153,13 +1153,19 @@ mod tests {
     fn test_read_daemon_touch_rows_returns_sorted_rows() {
         let tmp = TempDir::new().expect("temp dir");
         let daemon_dir = tmp.path().join(".atm/daemon");
+        let binary_a = std::env::temp_dir().join("daemon-touch-team-a");
+        let binary_b = std::env::temp_dir().join("daemon-touch-team-b");
         std::fs::create_dir_all(&daemon_dir).expect("create daemon dir");
         std::fs::write(
             daemon_dir.join("daemon-touch.json"),
-            r#"{
-  "team-b": {"pid": 22, "started_at": "2026-03-16T00:00:02Z", "binary": "/tmp/b"},
-  "team-a": {"pid": 11, "started_at": "2026-03-16T00:00:01Z", "binary": "/tmp/a"}
-}"#,
+            format!(
+                r#"{{
+  "team-b": {{"pid": 22, "started_at": "2026-03-16T00:00:02Z", "binary": "{binary_b}"}},
+  "team-a": {{"pid": 11, "started_at": "2026-03-16T00:00:01Z", "binary": "{binary_a}"}}
+}}"#,
+                binary_a = binary_a.display(),
+                binary_b = binary_b.display(),
+            ),
         )
         .expect("write daemon touch");
 

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -2983,25 +2983,32 @@ mod tests {
     fn check_daemon_ownership_mismatch_reports_home_scope_drift() {
         let tmp = tempfile::tempdir().unwrap();
         let daemon_dir = tmp.path().join(".atm/daemon");
+        let executable_path = std::env::temp_dir().join("atm-daemon");
+        let home_scope = std::env::temp_dir().join("other-home");
         fs::create_dir_all(&daemon_dir).unwrap();
         fs::write(
             daemon_dir.join("daemon.lock.meta.json"),
-            r#"{
+            format!(
+                r#"{{
   "pid": 42,
   "runtime_kind": "dev",
   "build_profile": "release",
-  "executable_path": "/tmp/atm-daemon",
-  "home_scope": "/tmp/other-home",
+  "executable_path": "{executable_path}",
+  "home_scope": "{home_scope}",
   "version": "0.44.1",
   "written_at": "2026-03-02T00:00:00Z"
-}"#,
+}}"#,
+                executable_path = executable_path.display(),
+                home_scope = home_scope.display(),
+            ),
         )
         .unwrap();
 
         let findings = check_daemon_ownership_mismatch(tmp.path());
         assert!(
             findings.iter().any(|f| {
-                f.code == "DAEMON_OWNERSHIP_MISMATCH" && f.message.contains("/tmp/other-home")
+                f.code == "DAEMON_OWNERSHIP_MISMATCH"
+                    && f.message.contains(home_scope.to_string_lossy().as_ref())
             }),
             "expected home-scope mismatch finding, got: {findings:?}"
         );
@@ -3013,6 +3020,7 @@ mod tests {
         let _guard = EnvGuard::isolate(OVERRIDE_ENV_KEYS);
         let tmp = tempfile::tempdir().unwrap();
         let daemon_dir = tmp.path().join(".atm/daemon");
+        let binary = std::env::temp_dir().join("foreign-atm-daemon");
         fs::create_dir_all(&daemon_dir).unwrap();
         fs::write(daemon_dir.join("atm-daemon.pid"), "999999\n").unwrap();
         fs::write(
@@ -3022,10 +3030,11 @@ mod tests {
   "atm-dev": {{
     "pid": {},
     "started_at": "2026-03-16T00:00:00Z",
-    "binary": "/tmp/foreign-atm-daemon"
+    "binary": "{binary}"
   }}
 }}"#,
-                std::process::id()
+                std::process::id(),
+                binary = binary.display(),
             ),
         )
         .unwrap();

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -1759,6 +1759,7 @@ mod tests {
         let exporter = Arc::new(CountingExporter::with_failures(10));
         let event = new_log_event("atm", "send_message", "atm::send", "info");
         let exporters: Vec<Arc<dyn OtelExporter>> = vec![exporter.clone()];
+        let log_path = std::env::temp_dir().join("atm.log.jsonl");
         let err = export_otel_with_retry(
             &event,
             &OtelConfig {
@@ -1769,7 +1770,7 @@ mod tests {
                 ..OtelConfig::default()
             },
             &exporters,
-            Path::new("/tmp/atm.log.jsonl"),
+            &log_path,
             record_sleep,
         )
         .expect_err("should return final export error");


### PR DESCRIPTION
## Summary\n- replace remaining hardcoded /tmp fixture paths in the targeted files with temp-dir based paths\n- keep doctor/daemon fixture assertions portable across environments\n- remove the remaining literal /tmp references from the assigned TMP-CLEANUP-1 scope\n\n## Validation\n- cargo fmt --all --check\n- cargo clippy --all-targets -- -D warnings\n- cargo test --workspace