### PR TITLE
fix: align B.4 smoke plan path and add ATM_HOME budget gate regression tests

### DIFF
--- a/crates/atm-ci-monitor/src/observability.rs
+++ b/crates/atm-ci-monitor/src/observability.rs
@@ -1266,4 +1266,96 @@ mod tests {
         let _ = child.kill();
         let _ = child.wait();
     }
+
+    /// Verify that the budget-gate state file is created at the correct ATM_HOME-relative path
+    /// when ATM_HOME is overridden to an arbitrary temp directory (smoke-test B.4 coverage).
+    ///
+    /// The state file must appear at `$ATM_HOME/.atm/daemon/gh-monitor-repo-state.json` and must
+    /// carry both `budget_limit_per_hour` and `budget_used_in_window` fields so that the gate can
+    /// enforce them when the next call arrives.
+    #[test]
+    fn test_gh_budget_state_written_under_overridden_atm_home() {
+        // Use a nested subdirectory so we verify that the write path creates all missing
+        // intermediate directories — matching the B.4 smoke pattern where ATM_HOME points at a
+        // path that does not yet exist on disk.
+        let temp_root = tempfile::tempdir().unwrap();
+        let atm_home = temp_root.path().join("atm-b4-home");
+
+        // The ATM_HOME directory itself must NOT exist yet; mutate_record must create it.
+        assert!(
+            !atm_home.exists(),
+            "test setup: ATM_HOME must not exist before the observer call"
+        );
+
+        // Invoke read_or_create_record via the SharedGhCliObserver so we exercise the real
+        // before_gh_call path that the CLI uses when running `atm gh pr list`.
+        let ctx = GhCliObserverContext::new(
+            atm_home.clone(),
+            "atm-dev".to_string(),
+            "owner/repo".to_string(),
+            "atm".to_string(),
+        );
+        let observer = SharedGhCliObserver::new(ctx);
+        let metadata = GhCliCallMetadata {
+            request_id: new_gh_request_id(),
+            call_id: new_gh_call_id(),
+            repo_scope: "owner/repo".to_string(),
+            caller: "gh_pr_list".to_string(),
+            action: "gh_pr_list".to_string(),
+            args: vec![
+                "pr".to_string(),
+                "list".to_string(),
+                "--json".to_string(),
+                "number".to_string(),
+            ],
+            branch: None,
+            reference: None,
+            ledger_home: Some(atm_home.clone()),
+            team: Some("atm-dev".to_string()),
+            runtime: Some("atm".to_string()),
+            poller_key: None,
+        };
+        // before_gh_call writes the record; it must succeed (budget is not yet exhausted).
+        observer
+            .before_gh_call(&metadata)
+            .expect("before_gh_call must succeed for a fresh ATM_HOME with no prior budget usage");
+
+        // The state file must now exist at the canonical ATM_HOME-relative path.
+        let expected_state_path = atm_home.join(".atm/daemon/gh-monitor-repo-state.json");
+        assert!(
+            expected_state_path.exists(),
+            "gh budget state file must be written at $ATM_HOME/.atm/daemon/gh-monitor-repo-state.json; \
+             not found at {}",
+            expected_state_path.display()
+        );
+
+        // Parse the file and verify the budget fields are present with sensible defaults.
+        let raw = std::fs::read_to_string(&expected_state_path).expect("read state file");
+        let parsed: serde_json::Value = serde_json::from_str(&raw).expect("parse state JSON");
+        let records = parsed["records"]
+            .as_array()
+            .expect("state file must have a 'records' array");
+        assert!(
+            !records.is_empty(),
+            "state file must contain at least one record after before_gh_call"
+        );
+        let record = &records[0];
+        assert!(
+            record.get("budget_limit_per_hour").is_some(),
+            "record must contain 'budget_limit_per_hour'"
+        );
+        assert!(
+            record.get("budget_used_in_window").is_some(),
+            "record must contain 'budget_used_in_window'"
+        );
+        assert_eq!(
+            record["budget_used_in_window"].as_u64().unwrap_or(u64::MAX),
+            0,
+            "budget_used_in_window must be 0 before any call completes"
+        );
+        assert!(
+            record["budget_limit_per_hour"].as_u64().unwrap_or(0) > 0,
+            "budget_limit_per_hour must be a positive default"
+        );
+    }
 }

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -153,8 +153,8 @@ from pathlib import Path
 home = Path(os.environ["ATM_HOME"])
 daemon_dir = home / ".atm" / "daemon"
 daemon_dir.mkdir(parents=True, exist_ok=True)
-state_path = daemon_dir / "gh-state.json"
-health_path = daemon_dir / "gh-health.json"
+state_path = daemon_dir / "gh-monitor-state.json"
+health_path = daemon_dir / "gh-monitor-health.json"
 request_log_path = os.environ.get("ATM_FAKE_GH_REQUEST_LOG")
 configured = os.environ.get("ATM_FAKE_GH_CONFIGURED", "1") == "1"
 enabled = os.environ.get("ATM_FAKE_GH_ENABLED", "1") == "1"
@@ -1552,6 +1552,54 @@ fn test_gh_monitor_list_human_output_has_one_line_rollups() {
     assert!(text.contains(
         "#102 [draft] [ci:BLOCKED — merge conflict] [merge:CONFLICT ⚠] [review:changes_requested]"
     ));
+}
+
+#[test]
+#[cfg(unix)]
+fn test_gh_pr_list_writes_budget_state_under_overridden_atm_home() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_test_team(&temp_dir, "test-team");
+    let workdir = temp_dir.path().join("workdir");
+    fs::create_dir_all(&workdir).unwrap();
+    write_repo_gh_monitor_config_with_owner(&workdir, "test-team", "acme", "agent-team-mail");
+    let gh_bin = write_fake_gh_cli_script(temp_dir.path(), "acme/agent-team-mail");
+    let path = format!(
+        "{}:{}",
+        gh_bin.display(),
+        std::env::var("PATH").unwrap_or_default()
+    );
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir, "test-team", false);
+    cmd.env("ATM_TEAM", "test-team")
+        .env("PATH", path)
+        .arg("gh")
+        .arg("--team")
+        .arg("test-team")
+        .arg("pr")
+        .arg("list")
+        .arg("--limit")
+        .arg("1")
+        .assert()
+        .success();
+
+    let state_path = temp_dir
+        .path()
+        .join(".atm/daemon/gh-monitor-repo-state.json");
+    assert!(
+        state_path.exists(),
+        "gh repo-state file must be written under overridden ATM_HOME"
+    );
+
+    let json: serde_json::Value = serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+    let record = json["records"]
+        .as_array()
+        .and_then(|records| records.first())
+        .expect("repo-state record");
+    assert_eq!(record["team"].as_str(), Some("test-team"));
+    assert_eq!(record["repo"].as_str(), Some("acme/agent-team-mail"));
+    assert_eq!(record["budget_limit_per_hour"].as_u64(), Some(100));
+    assert_eq!(record["budget_used_in_window"].as_u64(), Some(1));
 }
 
 #[test]

--- a/docs/observability/smoke-test-plan-phase-aw.md
+++ b/docs/observability/smoke-test-plan-phase-aw.md
@@ -127,15 +127,19 @@ echo "consumed by five parallel calls: $((R_before_b3 - R_after_b3))"
 ### B.4 — Monitor gate state written
 
 ```bash
-ATM_HOME="$(mktemp -d)/atm-b4-home" $AW_ATM gh pr list >/dev/null 2>&1 || true
-find "$ATM_HOME" -name '*.json' -path '*/gh-state/*' -print -exec cat {} \;
+B4_ATM_HOME="$(mktemp -d)/atm-b4-home"
+ATM_HOME="$B4_ATM_HOME" $AW_ATM gh pr list >/dev/null 2>&1 || true
+STATE_PATH="$B4_ATM_HOME/.atm/daemon/gh-monitor-repo-state.json"
+echo "state path: $STATE_PATH"
+test -f "$STATE_PATH" && cat "$STATE_PATH" || echo "FAIL: state file not found at $STATE_PATH"
 ```
 
 **PASS criteria**:
 
 - single-call consumption is bounded
 - five parallel calls do not produce unbounded amplification
-- GH state records include the budget/rate fields used by the gate
+- `$B4_ATM_HOME/.atm/daemon/gh-monitor-repo-state.json` is created after the single `atm gh pr list` call
+- repo-state JSON includes `budget_limit_per_hour` and `budget_used_in_window`
 
 ## Area C — OTel Log Field Correctness in Grafana
 


### PR DESCRIPTION
## Summary

- **Root cause**: Smoke test B.4 was checking a stale/wrong path for gh-state JSON. The budget gate already writes correctly to `$ATM_HOME/.atm/daemon/gh-monitor-repo-state.json`.
- Aligned smoke plan (Area B.4) to the correct state file path
- Canonicalized gh fixture names
- Added CLI + ci-monitor regression coverage asserting `budget_limit_per_hour`/`budget_used_in_window` fields present under overridden `ATM_HOME`

## Test plan
- [ ] `cargo test` passes with new regression tests
- [ ] `ATM_HOME=/tmp/atm-smoke-b4 atm gh pr list` smoke step now finds state file at correct path
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)