### PR TITLE
AY.1: Live signal correctness — smoke doc updates, backend-specific auth, canonical metrics

### DIFF
--- a/docs/observability/smoke-test-plan-phase-aw.md
+++ b/docs/observability/smoke-test-plan-phase-aw.md
@@ -11,6 +11,21 @@ This plan intentionally expands beyond the AW.5 automated Loki smoke:
 - This manual plan adds the missing daemon trace/metric verification and the Grafana read-path checks that AW.5 did not automate.
 - Grafana Cloud reads use backend-specific Basic auth. Use the exact per-backend instance IDs from `~/.zshrc` or `.private/grafana-otel-config.md`; do not guess or reuse one precomputed read header across Loki, Tempo, and Mimir.
 
+## AY.1 Verification Results
+
+- Loki: `FAIL`
+  - live Grafana query returned `0` streams for `service_name="atm"`
+  - root cause: CLI commands are not wiring the OTel log pipeline for all
+    command paths; follow-up is in `AY.2`
+- Tempo: `FAIL`
+  - Grafana Cloud Tempo search does not accept `session_id` as a searchable
+    top-level identifier
+  - shared-runtime stop/start smoke still returned `0` `atm-daemon` traces
+  - follow-up is in `AY.2`
+- Mimir: `PASS`
+  - canonical series are present, including `atm_commands_count_total` and
+    `atm_messages_sent_count_total`
+
 ## Preconditions
 
 - `develop` contains the merged AW work.
@@ -169,7 +184,7 @@ curl -s -G "$ATM_LOKI_URL/loki/api/v1/query_range" \
   -H "$ATM_LOKI_READ_AUTH" \
   --data-urlencode "query={service_name=\"atm\"} | logfmt | session_id=\"$SESSION_TAG\"" \
   --data-urlencode "limit=20" \
-  --data-urlencode "start=$(python3 -c 'import time; print(int((time.time()-180)*1e9))')" \
+  --data-urlencode "start=$(python3 -c 'import time; print(int((time.time()-600)*1e9))')" \
   | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -241,6 +256,13 @@ Stop any existing daemon and force a fresh daemon-owned flow before the query:
 ```bash
 DAEMON_SESSION_TAG="aw-smoke-daemon-$(date +%s)"
 $AW_ATM daemon stop >/dev/null 2>&1 || true
+
+export ATM_OTEL_ENABLED=true
+export ATM_OTEL_ENDPOINT=https://otlp-gateway-prod-us-west-0.grafana.net/otlp
+export ATM_OTEL_PROTOCOL=otlp_http
+export ATM_OTEL_AUTH_HEADER="Authorization: Basic <grafana-write-header>"
+
+$AW_ATM daemon start >/dev/null 2>&1
 
 CLAUDE_SESSION_ID="$DAEMON_SESSION_TAG" \
 ATM_TEAM=atm-dev \
@@ -371,3 +393,7 @@ print(json.dumps(d.get('otel_health',{}), indent=2))
 - Use backend-specific read credentials for Loki/Tempo/Mimir queries. Do not reuse the OTLP write header or a single shared Basic username across read APIs.
 - Grafana Cloud read APIs do not require `X-Scope-OrgID` when valid backend-specific Basic auth is used.
 - `sc-compose` remains part of the logs rollout, but the AW trace/metric smoke for this phase should focus on the signals actually emitted today by `atm` and `atm-daemon`.
+- AY.1 live verification outcome on this branch is intentionally mixed:
+  - Loki `FAIL`
+  - Tempo `FAIL`
+  - Mimir `PASS`

--- a/docs/observability/smoke-test-plan-phase-aw.md
+++ b/docs/observability/smoke-test-plan-phase-aw.md
@@ -9,7 +9,7 @@ This plan intentionally expands beyond the AW.5 automated Loki smoke:
 
 - `scripts/grafana-verify-smoke.py` remains the lowest-friction log-path check.
 - This manual plan adds the missing daemon trace/metric verification and the Grafana read-path checks that AW.5 did not automate.
-- Grafana Cloud read endpoints must be operator-supplied. Do not hardcode guessed Tempo or Mimir hostnames in the live run.
+- Grafana Cloud reads use backend-specific Basic auth. Use the exact per-backend instance IDs from `~/.zshrc` or `.private/grafana-otel-config.md`; do not guess or reuse one precomputed read header across Loki, Tempo, and Mimir.
 
 ## Preconditions
 
@@ -39,15 +39,20 @@ export ATM_OTEL_AUTH_HEADER="Authorization: Basic <grafana-write-header>"
 Export the read/query path separately:
 
 ```bash
-export ATM_LOKI_ENDPOINT="https://logs-prod-us-west-0.grafana.net/loki/v1/query_range"
-export ATM_LOKI_AUTH_HEADER="Authorization: Basic <grafana-read-header>"
+export ATM_GRAFANA_READ_TOKEN="<access-policy-token with logs:read,traces:read,metrics:read>"
 
-# Confirm these from Grafana Cloud -> Connections -> Data sources before use.
-export ATM_TEMPO_SEARCH_ENDPOINT="<tempo-search-endpoint>"
-export ATM_TEMPO_AUTH_HEADER="Authorization: Basic <grafana-read-header>"
-export ATM_MIMIR_QUERY_ENDPOINT="<mimir-query-endpoint>"
-export ATM_MIMIR_AUTH_HEADER="Authorization: Basic <grafana-read-header>"
-export ATM_MIMIR_SCOPE_ORGID="1551041"
+# Backend-specific Grafana Cloud instance IDs.
+export ATM_LOKI_INSTANCE_ID="1508830"
+export ATM_TEMPO_INSTANCE_ID="1503135"
+export ATM_MIMIR_INSTANCE_ID="3026310"
+
+export ATM_LOKI_URL="https://logs-prod-021.grafana.net"
+export ATM_TEMPO_SEARCH_ENDPOINT="https://tempo-prod-15-prod-us-west-0.grafana.net/tempo"
+export ATM_MIMIR_QUERY_ENDPOINT="https://prometheus-prod-67-prod-us-west-0.grafana.net/api/prom"
+
+export ATM_LOKI_READ_AUTH="Authorization: Basic $(printf '%s' \"$ATM_LOKI_INSTANCE_ID:$ATM_GRAFANA_READ_TOKEN\" | base64)"
+export ATM_TEMPO_READ_AUTH="Authorization: Basic $(printf '%s' \"$ATM_TEMPO_INSTANCE_ID:$ATM_GRAFANA_READ_TOKEN\" | base64)"
+export ATM_MIMIR_READ_AUTH="Authorization: Basic $(printf '%s' \"$ATM_MIMIR_INSTANCE_ID:$ATM_GRAFANA_READ_TOKEN\" | base64)"
 ```
 
 ## Area A — No Rogue Daemon Spawns
@@ -160,9 +165,9 @@ sleep 10
 ### C.2 — Query Loki with the read endpoint
 
 ```bash
-curl -s -G "$ATM_LOKI_ENDPOINT" \
-  -H "$ATM_LOKI_AUTH_HEADER" \
-  --data-urlencode "query={service_name=\"atm\",team=\"atm-dev\",agent=\"arch-ctm\",runtime=\"codex\",session_id=\"$SESSION_TAG\"} | json" \
+curl -s -G "$ATM_LOKI_URL/loki/api/v1/query_range" \
+  -H "$ATM_LOKI_READ_AUTH" \
+  --data-urlencode "query={service_name=\"atm\"} | logfmt | session_id=\"$SESSION_TAG\"" \
   --data-urlencode "limit=20" \
   --data-urlencode "start=$(python3 -c 'import time; print(int((time.time()-180)*1e9))')" \
   | python3 -c "
@@ -181,7 +186,7 @@ for s in streams[:3]:
 
 - at least one ATM log stream is returned
 - the event exposes `service_name=atm` via label or detected field
-- the event exposes `team`, `agent`, `runtime`, and `session_id`
+- the event exposes `team`, `agent`, `runtime`, and `session_id` as labels or detected fields
 - the event exposes a concrete level mapping rather than `unknown`
 
 ## Area D — Traces and Metrics in Grafana
@@ -191,17 +196,13 @@ for s in streams[:3]:
 ### D.1 — Emit CLI and daemon-backed signals
 
 ```bash
-SESSION_TAG="aw-smoke-signals-$(date +%s)"
+SESSION_TAG="aw-smoke-cli-$(date +%s)"
 export CLAUDE_SESSION_ID="$SESSION_TAG"
 export ATM_TEAM=atm-dev
 export ATM_IDENTITY=arch-ctm
 export ATM_RUNTIME=codex
 
 $AW_ATM status --json >/dev/null
-$AW_ATM send arch-ctm "aw smoke $SESSION_TAG" >/dev/null 2>&1 || true
-$AW_ATM read >/dev/null 2>&1 || true
-
-sleep 20
 ```
 
 This sequence is intended to cover:
@@ -214,9 +215,9 @@ This sequence is intended to cover:
 ### D.2 — Query Tempo for CLI traces
 
 ```bash
-curl -s -G "$ATM_TEMPO_SEARCH_ENDPOINT" \
-  -H "$ATM_TEMPO_AUTH_HEADER" \
-  --data-urlencode 'q={ resource.service.name = "atm" && session_id = "'"$SESSION_TAG"'" && name =~ "atm.command.(status|send|read)" }' \
+curl -s -G "$ATM_TEMPO_SEARCH_ENDPOINT/api/search" \
+  -H "$ATM_TEMPO_READ_AUTH" \
+  --data-urlencode 'q={ resource.service.name = "atm" && name =~ "atm.command.(status|send|read)" }' \
   --data-urlencode "limit=20" \
   | python3 -c "
 import json,sys
@@ -224,6 +225,8 @@ d=json.load(sys.stdin)
 print(json.dumps(d, indent=2)[:2000])
 "
 ```
+
+Note: current Grafana Cloud Tempo search rejects `session_id` as a top-level TraceQL identifier. For live verification, search on `resource.service.name` plus span name and inspect returned attributes if you need session confirmation.
 
 **PASS criteria**:
 
@@ -233,10 +236,33 @@ print(json.dumps(d, indent=2)[:2000])
 
 ### D.3 — Query Tempo for daemon traces
 
+Stop any existing daemon and force a fresh daemon-owned flow before the query:
+
 ```bash
-curl -s -G "$ATM_TEMPO_SEARCH_ENDPOINT" \
-  -H "$ATM_TEMPO_AUTH_HEADER" \
-  --data-urlencode 'q={ resource.service.name = "atm-daemon" && session_id = "'"$SESSION_TAG"'" && name =~ "atm-daemon.(dispatch_message|plugin..*)" }' \
+DAEMON_SESSION_TAG="aw-smoke-daemon-$(date +%s)"
+$AW_ATM daemon stop >/dev/null 2>&1 || true
+
+CLAUDE_SESSION_ID="$DAEMON_SESSION_TAG" \
+ATM_TEAM=atm-dev \
+ATM_IDENTITY=arch-ctm \
+ATM_RUNTIME=codex \
+$AW_ATM send arch-ctm "aw smoke $DAEMON_SESSION_TAG" >/dev/null 2>&1 || true
+
+CLAUDE_SESSION_ID="$DAEMON_SESSION_TAG" \
+ATM_TEAM=atm-dev \
+ATM_IDENTITY=arch-ctm \
+ATM_RUNTIME=codex \
+$AW_ATM read >/dev/null 2>&1 || true
+
+sleep 20
+```
+
+Query Tempo:
+
+```bash
+curl -s -G "$ATM_TEMPO_SEARCH_ENDPOINT/api/search" \
+  -H "$ATM_TEMPO_READ_AUTH" \
+  --data-urlencode 'q={ resource.service.name = "atm-daemon" && name =~ "atm-daemon.(dispatch_message|plugin..*)" }' \
   --data-urlencode "limit=20" \
   | python3 -c "
 import json,sys
@@ -245,9 +271,11 @@ print(json.dumps(d, indent=2)[:2000])
 "
 ```
 
+Note: current Grafana Cloud Tempo search rejects `session_id` as a top-level TraceQL identifier. If session scoping is needed, inspect returned span/resource attributes rather than assuming `session_id` is directly searchable.
+
 **PASS criteria**:
 
-- at least one trace is returned for `resource.service.name="atm-daemon"`
+- at least one trace is returned for `resource.service.name="atm-daemon"` after the stop/start sequence
 - a daemon-owned span such as `atm-daemon.dispatch_message` is present
 
 ### D.4 — Query Mimir for metrics
@@ -255,9 +283,8 @@ print(json.dumps(d, indent=2)[:2000])
 Use the confirmed Mimir metric names directly.
 
 ```bash
-curl -s -G "$ATM_MIMIR_QUERY_ENDPOINT" \
-  -H "$ATM_MIMIR_AUTH_HEADER" \
-  -H "X-Scope-OrgID: $ATM_MIMIR_SCOPE_ORGID" \
+curl -s -G "$ATM_MIMIR_QUERY_ENDPOINT/api/v1/query" \
+  -H "$ATM_MIMIR_READ_AUTH" \
   --data-urlencode 'query={__name__=~"(atm_command_duration_ms_milliseconds_(bucket|count|sum)|atm_commands_count_total|atm_dropped_events_total_count|atm_messages_read_count_total|atm_messages_sent_count_total|atm_spool_file_count|atm_daemon_request_count_total|atm_daemon_request_duration_ms_milliseconds_(bucket|count|sum))",session_id="'"$SESSION_TAG"'"}' \
   | python3 -c "
 import json,sys
@@ -310,10 +337,10 @@ ATM_OTEL_AUTH_HEADER="Authorization: Basic deliberately-bad" \
 $AW_ATM status --json >/tmp/aw-failopen-auth.json
 ```
 
-Then inspect logging health:
+Then inspect OTel health from status:
 
 ```bash
-$AW_ATM logging-health --json | python3 -c "
+$AW_ATM status --json | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
 print(json.dumps(d.get('otel_health',{}), indent=2))
@@ -341,6 +368,6 @@ print(json.dumps(d.get('otel_health',{}), indent=2))
 
 ## Known Constraints
 
-- The Loki read endpoint is documented in `.private/grafana-otel-config.md`; Tempo and Mimir read endpoints must be confirmed from Grafana Cloud before running D.2-D.4.
-- Use read credentials for Loki/Tempo/Mimir queries. Do not reuse the OTLP write header for read APIs.
+- Use backend-specific read credentials for Loki/Tempo/Mimir queries. Do not reuse the OTLP write header or a single shared Basic username across read APIs.
+- Grafana Cloud read APIs do not require `X-Scope-OrgID` when valid backend-specific Basic auth is used.
 - `sc-compose` remains part of the logs rollout, but the AW trace/metric smoke for this phase should focus on the signals actually emitted today by `atm` and `atm-daemon`.

--- a/docs/phase-ay-grafana-dogfood-readiness.md
+++ b/docs/phase-ay-grafana-dogfood-readiness.md
@@ -1,0 +1,63 @@
+# Phase AY Planning: OTel Grafana Dogfood Readiness
+
+**Status**: Planned
+**Prerequisites**:
+- Phase AV complete and merged
+- Phase AW complete and merged
+- `develop` baseline includes `ec94e2e1` (AW smoke follow-up merges, including
+  the B.4 state-path fix and Loki/metric shaping work)
+- Phase AS is independent of AY. AY does not depend on the GH governance/firewall
+  work from AS and may proceed once the required `develop` baseline is present.
+
+## Goal
+
+Take the working AW-era OTel stack and close the live Grafana gaps uncovered by
+real smoke testing so ATM can:
+
+- query Loki by `service_name="atm"` for live CLI logs
+- query Tempo for fresh `atm-daemon` traces after a controlled daemon start
+- query Mimir using the real exported ATM metric names
+- install and restart the shared dev daemon in a way that preserves OTel config
+- begin live Grafana dogfooding with confidence
+
+## Scope
+
+1. Prove the Loki `service_name` fix end-to-end on live Grafana data.
+2. Make daemon-trace verification reliable by ensuring shared daemon startup
+   inherits or resolves canonical OTel config.
+3. Lock Grafana query recipes to the actual exported metric names and signal
+   owners.
+4. Get the dev-install/shared-daemon path into a state where live Grafana
+   dogfooding is practical and repeatable.
+
+## Sprint Map
+
+| Sprint | Focus | Deliverables |
+|---|---|---|
+| AY.0 | Flaky test hardening | Parallel with AY.1. Small reliability fixes for already-known flaky tests uncovered during AW smoke/CI so AY implementation work stops paying incidental test fallout |
+| AY.1 | Live signal correctness | Runs in parallel with AY.0. Verify Loki `service_name=\"atm\"` on live data, verify daemon traces after a fresh OTel-configured start, align smoke/docs/scripts to backend-specific read auth and canonical metric names, and close any remaining signal-shaping gaps discovered during that verification |
+| AY.2 | Shared dev-daemon dogfood readiness | Sequential after AY.1. Make canonical shared daemon/dev-install startup preserve OTel config, add an operator-safe dogfood smoke for live Grafana data, and document the exact install/start/query flow needed for ongoing dogfooding |
+| AY.3a | OTel struct and operator-smoke cleanup | Small follow-up boundary cleanup: move mirror structs into `atm-core` and add the operator `otel-dev-install-smoke.py` script |
+| AY.3b | OTel type/boundary extraction | Medium follow-up boundary work: create `sc-observability-types` and relocate `otlp_adapter` wiring to entry-point crates |
+| AY.4 | Spool/inbox reliability | Verify and fix spool filename collision risk, merged-write durability, and spool cleanup diagnostics |
+
+## AY.1 Acceptance
+
+- Loki returns at least one recent ATM log stream under `service_name="atm"`
+  for an AY session tag in a `10m` window using the documented LogQL/curl flow.
+- Tempo returns at least one recent `atm-daemon` trace after the smoke-controlled
+  daemon stop/start sequence.
+- Mimir returns at least one canonical ATM metric series using the documented
+  PromQL query pattern.
+- All read-path smoke commands use backend-specific instance IDs and the shared
+  read token correctly.
+
+## AY.2 Acceptance
+
+- A fresh shared dev daemon started through the canonical dev-install flow emits
+  live Grafana telemetry without manual post-start patching.
+- The live Grafana dogfood smoke passes with:
+  - one CLI log visible in Loki
+  - one daemon trace visible in Tempo
+  - one canonical metric visible in Mimir
+- The dogfood smoke is documented and repeatable on `develop`.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1648,7 +1648,36 @@ keeping transport concerns isolated in `sc-observability-otlp`.
 
 ---
 
-## 17.21 Phase AM: CI Monitor Subsystem Refactor
+## 17.22 Phase AY: Grafana Dogfood Readiness
+
+**Goal**: Close the live-signal and shared-daemon gaps uncovered by AW smoke so
+Grafana-backed ATM dogfooding is practical and repeatable on `develop`.
+
+**Planning doc**: `docs/phase-ay-grafana-dogfood-readiness.md`
+**Requirements**: `docs/observability/requirements.md`
+**Architecture**: `docs/observability/architecture.md`
+
+### Planned Sprint Map
+| Sprint | Focus | Primary Deliverable | Status |
+|---|---|---|---|
+| AY.0 | Flaky test hardening | small reliability fixes for known flaky tests surfaced by AW smoke/CI | PLANNED |
+| AY.1 | Live signal correctness | verify Loki/Tempo/Mimir live results and align smoke/docs/scripts to real signal ownership | PLANNED |
+| AY.2 | Shared dev-daemon dogfood readiness | preserve OTel config through canonical shared daemon/dev-install startup and add live dogfood smoke | PLANNED |
+| AY.3a | Struct and operator-smoke cleanup | move OTel mirror structs into `atm-core` and add operator smoke script | PLANNED |
+| AY.3b | Boundary extraction | create `sc-observability-types` and relocate `otlp_adapter` wiring to entry-point crates | PLANNED |
+| AY.4 | Spool/inbox reliability | fix spool filename collision risk, merged-write durability, and spool cleanup diagnostics | PLANNED |
+
+### Exit Criteria
+1. Loki returns recent ATM CLI logs under `service_name="atm"` in live Grafana.
+2. Tempo returns fresh `atm-daemon` traces after a smoke-controlled daemon
+   stop/start sequence.
+3. Mimir queries use and document the canonical exported ATM metric names.
+4. The shared dev-daemon/dev-install flow preserves OTel config well enough for
+   repeatable Grafana dogfooding.
+
+---
+
+## 17.23 Phase AM: CI Monitor Subsystem Refactor
 
 **Goal**: Refactor CI monitoring into a dedicated daemon subsystem so
 `socket.rs` remains transport glue while provider-neutral orchestration,


### PR DESCRIPTION
## Summary
- Updates `docs/observability/smoke-test-plan-phase-aw.md` with per-backend instance IDs (Loki=1508830, Tempo=1503135, Mimir=3026310), no X-Scope-OrgID, canonical metric names, explicit daemon stop/start sequence
- Live backend verification results documented

## Backend Results
- **Loki**: FAIL — 0 streams for `service_name=atm` in 10m window; local probe also produced no log event for `atm config --json`, indicating a **producer/log-emission gap** (CLI commands not wiring OTel log pipeline)
- **Tempo**: FAIL — Grafana Cloud Tempo rejects `session_id` as unknown identifier; 0 daemon traces after stop/start on shared runtime path
- **Mimir**: PASS — canonical series present (`atm_commands_count_total`, `atm_messages_sent_count_total`)

## Known Gaps (AY.2 scope)
- Loki: CLI log emission to OTel pipeline not wired for all command paths
- Tempo: `session_id` span attribute not indexed or incorrect tag name in Grafana Cloud

## Test plan
- [ ] QA: rust-qa + atm-qa on worktree
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)