### PR TITLE
AY.4: spool/inbox reliability — filename uniqueness, fsync on conflict write, removal logging

### DIFF
--- a/crates/atm-core/Cargo.toml
+++ b/crates/atm-core/Cargo.toml
@@ -30,6 +30,7 @@ toml = { version = "0.8", features = ["parse"] }
 
 # For hostname detection
 hostname = "0.4"
+rand = "0.8"
 
 # For URL parsing (git remote URL parsing)
 url = "2.5"

--- a/crates/atm-core/src/io/inbox.rs
+++ b/crates/atm-core/src/io/inbox.rs
@@ -154,24 +154,7 @@ where
         source: e,
     })?;
 
-    {
-        let mut tmp_file = fs::File::create(&tmp_path).map_err(|e| InboxError::Io {
-            path: tmp_path.clone(),
-            source: e,
-        })?;
-
-        tmp_file
-            .write_all(&new_content)
-            .map_err(|e| InboxError::Io {
-                path: tmp_path.clone(),
-                source: e,
-            })?;
-
-        tmp_file.sync_all().map_err(|e| InboxError::Io {
-            path: tmp_path.clone(),
-            source: e,
-        })?;
-    }
+    write_synced_file(&tmp_path, &new_content)?;
 
     // Step 5: Atomic swap
     if !inbox_path.exists() {
@@ -210,10 +193,7 @@ where
             source: e,
         })?;
 
-        fs::write(&tmp_path, &merged_content).map_err(|e| InboxError::Io {
-            path: tmp_path.clone(),
-            source: e,
-        })?;
+        write_synced_file(&tmp_path, &merged_content)?;
 
         // Re-swap
         atomic_swap(inbox_path, &tmp_path)?;
@@ -230,6 +210,25 @@ where
     let _ = fs::remove_file(&tmp_path); // Ignore errors on cleanup
 
     Ok(outcome)
+}
+
+fn write_synced_file(path: &Path, content: &[u8]) -> Result<(), InboxError> {
+    let mut file = fs::File::create(path).map_err(|e| InboxError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    file.write_all(content).map_err(|e| InboxError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    file.sync_all().map_err(|e| InboxError::Io {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    Ok(())
 }
 
 fn parse_inbox_messages_tolerant(

--- a/crates/atm-core/src/io/spool.rs
+++ b/crates/atm-core/src/io/spool.rs
@@ -105,7 +105,8 @@ fn spool_message_with_base(
 
     let now = chrono::Utc::now();
     let timestamp = now.timestamp();
-    let filename = format!("{timestamp}-{agent}@{team}.json");
+    let nonce = rand::random::<u32>();
+    let filename = format!("{timestamp}-{nonce:08x}-{agent}@{team}.json");
     let spool_path = spool_dir.join(&filename);
 
     let spooled = SpooledMessage {
@@ -184,7 +185,9 @@ pub fn spool_drain_with_base(
             match process_spooled_message(&path, inbox_base, &failed_dir) {
                 Ok(true) => {
                     // Message delivered - delete spool file
-                    let _ = fs::remove_file(&path); // Ignore cleanup errors
+                    if let Err(error) = fs::remove_file(&path) {
+                        warn!("failed to remove spool file {path:?}: {error}");
+                    }
                     delivered += 1;
                 }
                 Ok(false) => {


### PR DESCRIPTION
## Summary
Fixes 3 confirmed reliability issues in `crates/atm-core/src/io/`:

- **#891** (`spool.rs`): spool filename used 1-second timestamp only — added random nonce suffix to prevent same-second collision/overwrite
- **#892** (`inbox.rs`): conflict-resolution merged write used `fs::write` without `sync_all()` while initial write path correctly synced — added `sync_all()` to match
- **#893** (`spool.rs`): spool file removal after delivery used `let _ = fs::remove_file(...)` silently — changed to log `warn!` on failure

All 3 findings CONFIRMED by arch-ctm before fixing.

## Test plan
- [ ] QA: rust-qa + atm-qa
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)