### PR TITLE
AY.3a: OTel struct cleanup — consolidate mirror structs into atm-core, add otel-dev-install-smoke.py

### DIFF
--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod log_reader;
 pub mod logging;
 pub mod logging_event;
 pub mod model_registry;
+pub mod observability;
 pub mod pid;
 pub mod retention;
 pub mod schema;

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -1,0 +1,44 @@
+//! Neutral observability contracts shared across ATM crates.
+//!
+//! These types intentionally live in `atm-core` so entry-point crates can pass
+//! OTel health state around without taking a direct dependency on
+//! `sc-observability`.
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
+pub struct OtelLastError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    pub at: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct OtelHealthSnapshot {
+    pub schema_version: String,
+    pub enabled: bool,
+    pub collector_endpoint: Option<String>,
+    pub protocol: String,
+    pub collector_state: String,
+    pub local_mirror_state: String,
+    pub local_mirror_path: String,
+    pub debug_local_export: bool,
+    pub debug_local_state: String,
+    pub last_error: OtelLastError,
+}
+
+impl Default for OtelHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: None,
+            protocol: "otlp_http".to_string(),
+            collector_state: "not_configured".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: String::new(),
+            debug_local_export: false,
+            debug_local_state: "disabled".to_string(),
+            last_error: OtelLastError::default(),
+        }
+    }
+}

--- a/crates/atm-daemon/src/daemon/event_loop.rs
+++ b/crates/atm-daemon/src/daemon/event_loop.rs
@@ -1791,7 +1791,7 @@ fn build_otel_health(ctx: &PluginContext) -> OtelHealth {
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
     let canonical_log_path = agent_team_mail_core::logging_event::configured_log_path(&home_dir);
-    crate::daemon::observability::current_otel_health(&canonical_log_path).into()
+    crate::daemon::observability::current_otel_health(&canonical_log_path)
 }
 
 fn derive_logging_state(

--- a/crates/atm-daemon/src/daemon/observability.rs
+++ b/crates/atm-daemon/src/daemon/observability.rs
@@ -1,4 +1,5 @@
 use agent_team_mail_core::logging_event::LogEventV1;
+pub use agent_team_mail_core::observability::{OtelHealthSnapshot, OtelLastError};
 use std::path::Path;
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -9,44 +10,6 @@ pub const SOCKET_ERROR_INTERNAL_ERROR: &str = "INTERNAL_ERROR";
 
 pub type OtelExportHook = Arc<dyn Fn(&Path, &LogEventV1) + Send + Sync>;
 pub type OtelHealthHook = Arc<dyn Fn(&Path) -> OtelHealthSnapshot + Send + Sync>;
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
-pub struct OtelLastError {
-    pub code: Option<String>,
-    pub message: Option<String>,
-    pub at: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct OtelHealthSnapshot {
-    pub schema_version: String,
-    pub enabled: bool,
-    pub collector_endpoint: Option<String>,
-    pub protocol: String,
-    pub collector_state: String,
-    pub local_mirror_state: String,
-    pub local_mirror_path: String,
-    pub debug_local_export: bool,
-    pub debug_local_state: String,
-    pub last_error: OtelLastError,
-}
-
-impl Default for OtelHealthSnapshot {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: "otlp_http".to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
-}
 
 pub fn install_otel_export_hook(hook: OtelExportHook) {
     *otel_export_hook_slot()

--- a/crates/atm-daemon/src/daemon/status.rs
+++ b/crates/atm-daemon/src/daemon/status.rs
@@ -6,6 +6,7 @@
 use agent_team_mail_core::daemon_client::{
     DaemonTouchEntry, DaemonTouchSnapshot, RuntimeOwnerMetadata, daemon_touch_path_for,
 };
+pub use agent_team_mail_core::observability::{OtelHealthSnapshot as OtelHealth, OtelLastError};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -58,66 +59,6 @@ pub struct LoggingHealth {
 }
 
 /// OTel exporter health snapshot.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub struct OtelHealth {
-    pub schema_version: String,
-    pub enabled: bool,
-    pub collector_endpoint: Option<String>,
-    pub protocol: String,
-    pub collector_state: String,
-    pub local_mirror_state: String,
-    pub local_mirror_path: String,
-    pub debug_local_export: bool,
-    pub debug_local_state: String,
-    pub last_error: OtelLastError,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub struct OtelLastError {
-    pub code: Option<String>,
-    pub message: Option<String>,
-    pub at: Option<String>,
-}
-
-impl Default for OtelHealth {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: "otlp_http".to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
-}
-
-impl From<crate::daemon::observability::OtelHealthSnapshot> for OtelHealth {
-    fn from(value: crate::daemon::observability::OtelHealthSnapshot) -> Self {
-        Self {
-            schema_version: value.schema_version,
-            enabled: value.enabled,
-            collector_endpoint: value.collector_endpoint,
-            protocol: value.protocol,
-            collector_state: value.collector_state,
-            local_mirror_state: value.local_mirror_state,
-            local_mirror_path: value.local_mirror_path,
-            debug_local_export: value.debug_local_export,
-            debug_local_state: value.debug_local_state,
-            last_error: OtelLastError {
-                code: value.last_error.code,
-                message: value.last_error.message,
-                at: value.last_error.at,
-            },
-        }
-    }
-}
-
 impl Default for LoggingHealth {
     fn default() -> Self {
         Self {

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -27,25 +27,7 @@ fn export_otel_from_entrypoint(
 fn current_otel_health_from_entrypoint(
     log_path: &std::path::Path,
 ) -> agent_team_mail_daemon::daemon::observability::OtelHealthSnapshot {
-    let health = sc_observability::current_otel_health(log_path);
-    // Intentional mirror of sc_observability::OtelHealthSnapshot — sc-observability
-    // imports are confined to entry-point main.rs per ARCH-BOUNDARY-002.
-    agent_team_mail_daemon::daemon::observability::OtelHealthSnapshot {
-        schema_version: health.schema_version,
-        enabled: health.enabled,
-        collector_endpoint: health.collector_endpoint,
-        protocol: health.protocol,
-        collector_state: health.collector_state,
-        local_mirror_state: health.local_mirror_state,
-        local_mirror_path: health.local_mirror_path,
-        debug_local_export: health.debug_local_export,
-        debug_local_state: health.debug_local_state,
-        last_error: agent_team_mail_daemon::daemon::observability::OtelLastError {
-            code: health.last_error.code,
-            message: health.last_error.message,
-            at: health.last_error.at,
-        },
-    }
+    sc_observability::current_otel_health(log_path)
 }
 
 /// ATM Daemon - Background service for agent team mail plugins

--- a/crates/atm/src/commands/logging_health.rs
+++ b/crates/atm/src/commands/logging_health.rs
@@ -4,6 +4,9 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use agent_team_mail_core::daemon_client::daemon_status_path_for;
+pub(crate) use agent_team_mail_core::observability::{
+    OtelHealthSnapshot, OtelHealthSnapshot as OtelHealthContract,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -31,47 +34,8 @@ impl Default for LoggingHealthSnapshot {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(default)]
-pub(crate) struct OtelHealthSnapshot {
-    pub(crate) schema_version: String,
-    pub(crate) enabled: bool,
-    pub(crate) collector_endpoint: Option<String>,
-    pub(crate) protocol: String,
-    pub(crate) collector_state: String,
-    pub(crate) local_mirror_state: String,
-    pub(crate) local_mirror_path: String,
-    pub(crate) debug_local_export: bool,
-    pub(crate) debug_local_state: String,
-    pub(crate) last_error: OtelLastError,
-}
-
-impl Default for OtelHealthSnapshot {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: "otlp_http".to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct LastError {
-    pub(crate) code: Option<String>,
-    pub(crate) message: Option<String>,
-    pub(crate) at: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub(crate) struct OtelLastError {
     pub(crate) code: Option<String>,
     pub(crate) message: Option<String>,
     pub(crate) at: Option<String>,
@@ -88,37 +52,6 @@ pub(crate) struct LoggingHealthContract {
     pub(crate) spool_file_count: u64,
     pub(crate) oldest_spool_age_seconds: Option<u64>,
     pub(crate) last_error: LastError,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct OtelHealthContract {
-    pub(crate) schema_version: String,
-    pub(crate) enabled: bool,
-    pub(crate) collector_endpoint: Option<String>,
-    pub(crate) protocol: String,
-    pub(crate) collector_state: String,
-    pub(crate) local_mirror_state: String,
-    pub(crate) local_mirror_path: String,
-    pub(crate) debug_local_export: bool,
-    pub(crate) debug_local_state: String,
-    pub(crate) last_error: OtelLastError,
-}
-
-impl Default for OtelHealthContract {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: "otlp_http".to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
 }
 
 impl Default for LoggingHealthContract {
@@ -185,18 +118,7 @@ pub(crate) fn build_logging_health_contract(
 }
 
 pub(crate) fn build_otel_health_contract(otel: &OtelHealthSnapshot) -> OtelHealthContract {
-    OtelHealthContract {
-        schema_version: otel.schema_version.clone(),
-        enabled: otel.enabled,
-        collector_endpoint: otel.collector_endpoint.clone(),
-        protocol: otel.protocol.clone(),
-        collector_state: otel.collector_state.clone(),
-        local_mirror_state: otel.local_mirror_state.clone(),
-        local_mirror_path: otel.local_mirror_path.clone(),
-        debug_local_export: otel.debug_local_export,
-        debug_local_state: otel.debug_local_state.clone(),
-        last_error: otel.last_error.clone(),
-    }
+    otel.clone()
 }
 
 pub(crate) fn logging_remediation(state: &str) -> Option<&'static str> {

--- a/crates/sc-observability/src/health.rs
+++ b/crates/sc-observability/src/health.rs
@@ -1,45 +1,8 @@
 use crate::{OTEL_PROTOCOL_HTTP, OtelConfig, OtelError, OtelExporterKind, default_otel_path};
+use agent_team_mail_core::observability::{OtelHealthSnapshot, OtelLastError};
 use chrono::{SecondsFormat, Utc};
 use std::path::Path;
 use std::sync::{Mutex, OnceLock};
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Default)]
-pub struct OtelLastError {
-    pub code: Option<String>,
-    pub message: Option<String>,
-    pub at: Option<String>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
-pub struct OtelHealthSnapshot {
-    pub schema_version: String,
-    pub enabled: bool,
-    pub collector_endpoint: Option<String>,
-    pub protocol: String,
-    pub collector_state: String,
-    pub local_mirror_state: String,
-    pub local_mirror_path: String,
-    pub debug_local_export: bool,
-    pub debug_local_state: String,
-    pub last_error: OtelLastError,
-}
-
-impl Default for OtelHealthSnapshot {
-    fn default() -> Self {
-        Self {
-            schema_version: "v1".to_string(),
-            enabled: true,
-            collector_endpoint: None,
-            protocol: OTEL_PROTOCOL_HTTP.to_string(),
-            collector_state: "not_configured".to_string(),
-            local_mirror_state: "healthy".to_string(),
-            local_mirror_path: String::new(),
-            debug_local_export: false,
-            debug_local_state: "disabled".to_string(),
-            last_error: OtelLastError::default(),
-        }
-    }
-}
 
 #[derive(Debug, Default)]
 struct OtelRuntimeHealth {
@@ -183,7 +146,11 @@ pub fn current_otel_health(log_path: &Path) -> OtelHealthSnapshot {
         schema_version: "v1".to_string(),
         enabled: config.enabled,
         collector_endpoint: config.endpoint.clone(),
-        protocol: config.protocol.clone(),
+        protocol: if config.protocol.trim().is_empty() {
+            OTEL_PROTOCOL_HTTP.to_string()
+        } else {
+            config.protocol.clone()
+        },
         collector_state,
         local_mirror_state: health_state(
             local_mirror_configured,

--- a/crates/sc-observability/src/lib.rs
+++ b/crates/sc-observability/src/lib.rs
@@ -20,7 +20,8 @@ mod metrics;
 mod otlp_adapter;
 mod trace;
 
-pub use health::{OtelHealthSnapshot, OtelLastError, current_otel_health};
+pub use agent_team_mail_core::observability::{OtelHealthSnapshot, OtelLastError};
+pub use health::current_otel_health;
 pub use metrics::{MetricKind, MetricRecord, export_metric_records_best_effort};
 pub use trace::{TraceRecord, TraceStatus, export_trace_records_best_effort};
 

--- a/docs/observability/grafana-rollout-smoke.md
+++ b/docs/observability/grafana-rollout-smoke.md
@@ -127,10 +127,18 @@ Verify:
 
 ### 7. Dogfood Dev Install
 
-Deferred: A dedicated dev-install OTel smoke script
-(`scripts/otel-dev-install-smoke.py`) is planned for a future sprint. See
-GH-878 for tracking. Until then, use `scripts/grafana-verify-smoke.py` (Area C
-of the AW smoke test plan) to verify OTel log field correctness end-to-end.
+The installed-binary dev channel now has a dedicated operator smoke:
+`scripts/otel-dev-install-smoke.py`.
+
+Use it after `scripts/dev-install` when you need to verify that the shared dev
+channel binaries still:
+
+- export to a live OTLP collector,
+- preserve the canonical local log plus `.otel.jsonl` mirror, and
+- stay fail-open when the collector is unavailable.
+
+`scripts/grafana-verify-smoke.py` remains the broader backend verification
+smoke; `otel-dev-install-smoke.py` specifically covers the dev-install flow.
 
 ## Grafana Acceptance
 


### PR DESCRIPTION
## Summary
- Mirror/duplicate OTel config structs consolidated into atm-core (entry-point crates import from atm-core)
- scripts/otel-dev-install-smoke.py added: operator script for dev-install flow (verifies ~/.local/atm-dev/current, starts daemon with inherited ATM_OTEL_*, queries Loki/Tempo/Mimir)
- OTel observer hook registration deduplication across entry-point crates

## Constraints
- No direct sc-observability dependency added to atm-core

## References
- Phase AY plan: docs/phase-ay-grafana-dogfood-readiness.md (AY.3a row)
- Sequential after AY.2 (#903)
- AY.3b (OTel type/boundary extraction) is a separate sprint, excluded from AY merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)