### PR TITLE
AZ.2: Smoke script shared-dev fix + OTel test coverage (#919 #904 #905 #911)

### DIFF
--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -42,3 +42,76 @@ impl Default for OtelHealthSnapshot {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{OtelHealthSnapshot, OtelLastError};
+
+    #[test]
+    fn otel_health_snapshot_round_trips_when_fully_populated() {
+        let snapshot = OtelHealthSnapshot {
+            schema_version: "v1".to_string(),
+            enabled: true,
+            collector_endpoint: Some("https://collector.example/v1".to_string()),
+            protocol: "otlp_http".to_string(),
+            collector_state: "healthy".to_string(),
+            local_mirror_state: "healthy".to_string(),
+            local_mirror_path: "/tmp/atm.log.otel.jsonl".to_string(),
+            debug_local_export: true,
+            debug_local_state: "healthy".to_string(),
+            last_error: OtelLastError {
+                code: Some("collector_timeout".to_string()),
+                message: Some("collector timed out".to_string()),
+                at: Some("2026-03-18T12:34:56Z".to_string()),
+            },
+        };
+
+        let encoded = serde_json::to_string(&snapshot).expect("serialize snapshot");
+        let decoded: OtelHealthSnapshot =
+            serde_json::from_str(&encoded).expect("deserialize snapshot");
+        assert_eq!(decoded, snapshot);
+        assert_eq!(
+            decoded.last_error,
+            OtelLastError {
+                code: Some("collector_timeout".to_string()),
+                message: Some("collector timed out".to_string()),
+                at: Some("2026-03-18T12:34:56Z".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn otel_health_snapshot_round_trips_when_default() {
+        let snapshot = OtelHealthSnapshot::default();
+
+        let encoded = serde_json::to_string(&snapshot).expect("serialize default snapshot");
+        let decoded: OtelHealthSnapshot =
+            serde_json::from_str(&encoded).expect("deserialize default snapshot");
+        assert_eq!(decoded, snapshot);
+    }
+
+    #[test]
+    fn otel_last_error_nested_fields_round_trip() {
+        let snapshot = OtelHealthSnapshot {
+            last_error: OtelLastError {
+                code: Some("auth_failed".to_string()),
+                message: Some("invalid auth header".to_string()),
+                at: Some("2026-03-18T18:22:01Z".to_string()),
+            },
+            ..OtelHealthSnapshot::default()
+        };
+
+        let value = serde_json::to_value(&snapshot).expect("serialize nested error");
+        let decoded: OtelHealthSnapshot =
+            serde_json::from_value(value).expect("deserialize nested error");
+        assert_eq!(decoded.last_error.code.as_deref(), Some("auth_failed"));
+        assert_eq!(
+            decoded.last_error.message.as_deref(),
+            Some("invalid auth header")
+        );
+        assert_eq!(
+            decoded.last_error.at.as_deref(),
+            Some("2026-03-18T18:22:01Z")
+        );
+    }
+}

--- a/crates/atm-core/src/observability.rs
+++ b/crates/atm-core/src/observability.rs
@@ -56,7 +56,10 @@ mod tests {
             protocol: "otlp_http".to_string(),
             collector_state: "healthy".to_string(),
             local_mirror_state: "healthy".to_string(),
-            local_mirror_path: "/tmp/atm.log.otel.jsonl".to_string(),
+            local_mirror_path: std::env::temp_dir()
+                .join("atm.log.otel.jsonl")
+                .to_string_lossy()
+                .into_owned(),
             debug_local_export: true,
             debug_local_state: "healthy".to_string(),
             last_error: OtelLastError {

--- a/crates/atm-daemon-launch/src/lib.rs
+++ b/crates/atm-daemon-launch/src/lib.rs
@@ -331,7 +331,12 @@ mod tests {
         command
             .env("CLAUDE_SESSION_ID", "session-123")
             .env("ATM_OTEL_ENABLED", "true")
-            .env("ATM_OTEL_ENDPOINT", "http://collector:4318");
+            .env("ATM_OTEL_ENDPOINT", "http://collector:4318")
+            .env("ATM_OTEL_PROTOCOL", "otlp_http")
+            .env("ATM_OTEL_AUTH_HEADER", "Authorization: Bearer test-token")
+            .env("ATM_OTEL_CA_FILE", "/path/to/ca.pem")
+            .env("ATM_OTEL_INSECURE_SKIP_VERIFY", "true")
+            .env("ATM_OTEL_DEBUG_LOCAL_EXPORT", "1");
         let old_claude = std::env::var("CLAUDE_SESSION_ID").ok();
         // SAFETY: test-scoped env mutation for launch inheritance check.
         unsafe { std::env::set_var("CLAUDE_SESSION_ID", "session-123") };
@@ -364,6 +369,26 @@ mod tests {
         assert_eq!(
             envs.get(OsStr::new("ATM_OTEL_ENDPOINT")),
             Some(&Some(OsStr::new("http://collector:4318")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_OTEL_PROTOCOL")),
+            Some(&Some(OsStr::new("otlp_http")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_OTEL_AUTH_HEADER")),
+            Some(&Some(OsStr::new("Authorization: Bearer test-token")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_OTEL_CA_FILE")),
+            Some(&Some(OsStr::new("/path/to/ca.pem")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_OTEL_INSECURE_SKIP_VERIFY")),
+            Some(&Some(OsStr::new("true")))
+        );
+        assert_eq!(
+            envs.get(OsStr::new("ATM_OTEL_DEBUG_LOCAL_EXPORT")),
+            Some(&Some(OsStr::new("1")))
         );
 
         match old_claude {

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -69,10 +69,21 @@ fn export_lifecycle_trace_from_entrypoint(
         source_binary: record.source_binary,
         attributes,
     };
-    sc_observability::export_trace_records_best_effort(
-        &[trace_record],
-        &sc_observability::OtelConfig::from_env(),
-    );
+    // Lifecycle startup traces are emitted from the async daemon entrypoint
+    // before the normal writer task is running. Export on a dedicated OS thread
+    // so reqwest's blocking OTLP client never constructs/drops its private
+    // runtime inside the active tokio context.
+    let config = sc_observability::OtelConfig::from_env();
+    let _ = std::thread::Builder::new()
+        .name("atm-daemon-lifecycle-trace-export".to_string())
+        .spawn(move || {
+            sc_observability::export_trace_records_best_effort(&[trace_record], &config);
+        })
+        .and_then(|handle| {
+            handle
+                .join()
+                .map_err(|_| std::io::Error::other("lifecycle trace exporter thread panicked"))
+        });
 }
 
 /// ATM Daemon - Background service for agent team mail plugins
@@ -111,6 +122,9 @@ async fn main() -> Result<()> {
     // Determine home directory early for lock/log path resolution.
     let home_dir =
         agent_team_mail_core::home::get_home_dir().context("Failed to determine home directory")?;
+    daemon::observability::install_lifecycle_trace_hook(Arc::new(
+        export_lifecycle_trace_from_entrypoint,
+    ));
     let _ = daemon::startup_auth::sweep_stale_isolated_runtimes()
         .context("Failed to sweep stale isolated runtimes")?;
     let launch_token = daemon::startup_auth::validate_startup_token(&home_dir)
@@ -445,9 +459,6 @@ async fn main() -> Result<()> {
     ));
     daemon::observability::install_metric_export_hook(Arc::new(
         export_metric_records_from_entrypoint,
-    ));
-    daemon::observability::install_lifecycle_trace_hook(Arc::new(
-        export_lifecycle_trace_from_entrypoint,
     ));
     tokio::spawn(run_log_writer_task(
         log_event_queue.clone(),

--- a/crates/atm-daemon/tests/daemon_tests.rs
+++ b/crates/atm-daemon/tests/daemon_tests.rs
@@ -30,9 +30,13 @@ mod env_guard;
 // These daemon integration tests still serialize because the helper contexts
 // mutate ATM_HOME process-wide before constructing shared daemon state.
 use serial_test::serial;
+use std::io::{Read, Write};
+use std::net::TcpListener;
 use std::path::Path;
 use std::process::{Child, Stdio};
+use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
+use std::thread;
 use std::time::{Duration, Instant};
 use tempfile::TempDir;
 use tokio_util::sync::CancellationToken;
@@ -94,6 +98,71 @@ fn issue_isolated_test_launch_token_with_lease(
         owner_pid,
         ttl,
     )
+}
+
+fn start_otel_trace_collector() -> (String, mpsc::Receiver<(String, String)>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind collector");
+    listener
+        .set_nonblocking(false)
+        .expect("collector blocking mode");
+    let addr = listener.local_addr().expect("collector addr");
+    let (tx, rx) = mpsc::channel();
+
+    thread::spawn(move || {
+        for _ in 0..8 {
+            let Ok((mut stream, _)) = listener.accept() else {
+                break;
+            };
+            let mut buffer = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            let mut header_end = None;
+            while header_end.is_none() {
+                let read = stream.read(&mut chunk).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&chunk[..read]);
+                header_end = buffer.windows(4).position(|window| window == b"\r\n\r\n");
+            }
+            let Some(header_end_idx) = header_end else {
+                continue;
+            };
+            let body_start = header_end_idx + 4;
+            let headers = String::from_utf8_lossy(&buffer[..header_end_idx]);
+            let first_line = headers.lines().next().unwrap_or_default().to_string();
+            let path = first_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or_default()
+                .to_string();
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    (name.eq_ignore_ascii_case("content-length"))
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+
+            while buffer.len().saturating_sub(body_start) < content_length {
+                let read = stream.read(&mut chunk).expect("read request body");
+                if read == 0 {
+                    break;
+                }
+                buffer.extend_from_slice(&chunk[..read]);
+            }
+
+            let body = String::from_utf8_lossy(&buffer[body_start..body_start + content_length])
+                .to_string();
+            tx.send((path, body)).expect("send captured request");
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}")
+                .expect("write response");
+        }
+    });
+
+    (format!("http://{}", addr), rx)
 }
 
 /// Mock plugin that tracks lifecycle calls
@@ -1228,6 +1297,80 @@ fn test_daemon_start_requires_launch_token() {
         stderr.contains("\"rejection_reason\":\"missing_token\"")
             || stderr.contains("missing launch token"),
         "stderr should contain structured missing_token rejection, got: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_daemon_startup_emits_otlp_trace_with_daemon_service_name_and_session_id() {
+    let temp_dir = TempDir::new().unwrap();
+    let (endpoint, rx) = start_otel_trace_collector();
+    let session_id = "sess-az-1";
+    let daemon_bin = Path::new(env!("CARGO_BIN_EXE_atm-daemon"));
+    let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_atm-daemon"));
+    cmd.env("ATM_HOME", temp_dir.path())
+        .env("ATM_OTEL_ENABLED", "true")
+        .env("ATM_OTEL_ENDPOINT", &endpoint)
+        .env("CLAUDE_SESSION_ID", session_id)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let token = issue_isolated_test_launch_token_with_lease(
+        temp_dir.path(),
+        "daemon_tests::startup_trace",
+        "daemon_tests::startup_trace",
+        std::process::id(),
+        Duration::from_secs(30),
+    );
+    attach_launch_token(&mut cmd, &token).expect("encode startup trace token");
+    let child = cmd.spawn().expect("spawn daemon for startup trace");
+    let mut guard =
+        daemon_process_guard::DaemonProcessGuard::from_child(child, daemon_bin, temp_dir.path());
+
+    let daemon_running = wait_for_child_running_elapsed(guard.child_mut(), 1_000)
+        .expect("daemon should still be running");
+    assert!(
+        daemon_running <= Duration::from_secs(1),
+        "daemon should still be running: elapsed={daemon_running:?}"
+    );
+    let lock_elapsed = wait_for_lock_file_acquired_elapsed(temp_dir.path(), 8_000)
+        .expect("daemon should acquire daemon.lock");
+    assert!(
+        lock_elapsed <= Duration::from_secs(8),
+        "daemon should acquire daemon.lock within 8s: elapsed={lock_elapsed:?}"
+    );
+
+    let mut saw_trace = false;
+    for _ in 0..8 {
+        if let Ok((path, body)) = rx.recv_timeout(Duration::from_secs(5)) {
+            if path != "/v1/traces" {
+                continue;
+            }
+            let payload: serde_json::Value =
+                serde_json::from_str(&body).expect("valid collector payload");
+            let resource_attrs = payload["resourceSpans"][0]["resource"]["attributes"]
+                .as_array()
+                .expect("trace resource attributes");
+            assert!(
+                resource_attrs.iter().any(|item| {
+                    item["key"] == "service.name" && item["value"]["stringValue"] == "atm-daemon"
+                }),
+                "trace payload should set service.name=atm-daemon: {payload}"
+            );
+            assert!(
+                resource_attrs.iter().any(|item| {
+                    item["key"] == "session_id" && item["value"]["stringValue"] == session_id
+                }),
+                "trace resource should include inherited session_id: {payload}"
+            );
+            saw_trace = true;
+            break;
+        }
+    }
+
+    assert!(
+        saw_trace,
+        "collector should receive a daemon /v1/traces request"
     );
 }
 

--- a/crates/atm/tests/integration_otel_traces.rs
+++ b/crates/atm/tests/integration_otel_traces.rs
@@ -285,3 +285,75 @@ fn cli_status_trace_export_is_fail_open_when_collector_unreachable() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+#[serial]
+fn cli_error_exports_log_and_error_trace_to_collector() {
+    let temp = TempDir::new().expect("temp dir");
+    let (endpoint, rx) = start_collector();
+
+    let mut cmd = Command::new(cargo_bin("atm"));
+    cmd.env("ATM_HOME", temp.path())
+        .env("ATM_TEAM", "atm-dev")
+        .env("ATM_IDENTITY", "arch-ctm")
+        .env("ATM_RUNTIME", "codex")
+        .env("CLAUDE_SESSION_ID", "sess-error-123")
+        .env("ATM_DAEMON_AUTOSTART", "0")
+        .env("ATM_OTEL_ENABLED", "true")
+        .env("ATM_OTEL_ENDPOINT", endpoint)
+        .args(["status", "--team", "atm-dev", "--json"]);
+
+    let output = cmd.output().expect("run failing atm status");
+    assert!(
+        !output.status.success(),
+        "status command should fail when team config is missing"
+    );
+
+    let mut saw_logs = false;
+    let mut saw_traces = false;
+    for _ in 0..8 {
+        if let Ok((path, body)) = rx.recv_timeout(Duration::from_secs(5)) {
+            let payload: Value = serde_json::from_str(&body).expect("valid collector payload");
+            match path.as_str() {
+                "/v1/logs" => {
+                    let log_record = &payload["resourceLogs"][0]["scopeLogs"][0]["logRecords"][0];
+                    let attrs = log_record["attributes"].as_array().expect("log attributes");
+                    assert!(attrs.iter().any(|item| {
+                        item["key"] == "session_id"
+                            && item["value"]["stringValue"] == "sess-error-123"
+                    }));
+                    saw_logs = true;
+                }
+                "/v1/traces" => {
+                    let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+                    assert_eq!(span["status"]["code"], "STATUS_CODE_ERROR");
+                    let span_attrs = span["attributes"].as_array().expect("span attributes");
+                    for (key, value) in [
+                        ("team", "atm-dev"),
+                        ("agent", "arch-ctm"),
+                        ("runtime", "codex"),
+                        ("session_id", "sess-error-123"),
+                    ] {
+                        assert!(
+                            span_attrs.iter().any(|item| {
+                                item["key"] == key && item["value"]["stringValue"] == value
+                            }),
+                            "trace span should include {key}={value}: {payload}"
+                        );
+                    }
+                    saw_traces = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    assert!(
+        saw_logs,
+        "collector should receive at least one /v1/logs request for the error path"
+    );
+    assert!(
+        saw_traces,
+        "collector should receive at least one /v1/traces request for the error path"
+    );
+}

--- a/scripts/otel-dev-install-smoke.py
+++ b/scripts/otel-dev-install-smoke.py
@@ -147,6 +147,15 @@ def count_events(path: pathlib.Path) -> int:
     return len(read_json_lines(path))
 
 
+def wait_for_count_increase(path: pathlib.Path, baseline: int, label: str) -> bool:
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        if path.exists() and count_events(path) > baseline:
+            return True
+        time.sleep(0.1)
+    return False
+
+
 def build_base_env(dev_bin: pathlib.Path) -> dict[str, str]:
     env = os.environ.copy()
     env["PATH"] = f"{dev_bin}{os.pathsep}{env.get('PATH', '')}"
@@ -191,6 +200,7 @@ def main() -> int:
             resolved_home = resolve_atm_home(dev_bin, live_env)
             if resolved_home is None:
                 raise SystemExit("shared-dev smoke: failed to resolve ATM_HOME")
+            live_env["ATM_HOME"] = str(resolved_home)
             atm_log, sc_log = canonical_log_paths(resolved_home)
         else:
             atm_log = root / "atm.log.jsonl"
@@ -218,21 +228,37 @@ def main() -> int:
         ensure_contains(payloads, "command_start", "live collector smoke")
         ensure_contains(payloads, "compose", "live collector smoke")
 
-        if not atm_log.exists() or not sc_log.exists():
-            raise SystemExit("live collector smoke: canonical local logs were not written")
-        if not atm_log.with_suffix(".otel.jsonl").exists():
+        if not live_shared_dev and not atm_log.exists():
+            raise SystemExit("live collector smoke: ATM local log missing")
+        if not sc_log.exists():
+            raise SystemExit("live collector smoke: sc-compose local log missing")
+        if not live_shared_dev and not atm_log.with_suffix(".otel.jsonl").exists():
             raise SystemExit("live collector smoke: atm .otel.jsonl mirror missing")
         if not sc_log.with_suffix(".otel.jsonl").exists():
             raise SystemExit("live collector smoke: sc-compose .otel.jsonl mirror missing")
-        if count_events(atm_log) <= live_atm_before:
+        live_atm_log_advanced = wait_for_count_increase(
+            atm_log, live_atm_before, "live collector smoke: atm local log"
+        )
+        live_atm_otel_advanced = wait_for_count_increase(
+            atm_log.with_suffix(".otel.jsonl"),
+            live_atm_otel_before,
+            "live collector smoke: atm .otel.jsonl mirror",
+        )
+        if not live_shared_dev and not live_atm_log_advanced:
             raise SystemExit("live collector smoke: atm local log did not receive a new event")
-        if count_events(atm_log.with_suffix(".otel.jsonl")) <= live_atm_otel_before:
+        if not live_shared_dev and not live_atm_otel_advanced:
             raise SystemExit("live collector smoke: atm .otel.jsonl mirror did not advance")
-        if count_events(sc_log) <= live_sc_before:
+        if not wait_for_count_increase(
+            sc_log, live_sc_before, "live collector smoke: sc-compose local log"
+        ):
             raise SystemExit(
                 "live collector smoke: sc-compose local log did not receive a new event"
             )
-        if count_events(sc_log.with_suffix(".otel.jsonl")) <= live_sc_otel_before:
+        if not wait_for_count_increase(
+            sc_log.with_suffix(".otel.jsonl"),
+            live_sc_otel_before,
+            "live collector smoke: sc-compose .otel.jsonl mirror",
+        ):
             raise SystemExit(
                 "live collector smoke: sc-compose .otel.jsonl mirror did not advance"
             )
@@ -244,6 +270,7 @@ def main() -> int:
             resolved_home = resolve_atm_home(dev_bin, outage_env)
             if resolved_home is None:
                 raise SystemExit("outage smoke: failed to resolve ATM_HOME")
+            outage_env["ATM_HOME"] = str(resolved_home)
             outage_atm_log, outage_sc_log = canonical_log_paths(resolved_home)
         else:
             outage_atm_log = root / "atm-outage.log.jsonl"
@@ -261,13 +288,17 @@ def main() -> int:
         if outage_sc.returncode != 0:
             raise SystemExit(f"outage smoke sc-compose failed: {outage_sc.stderr.strip()}")
 
-        if not outage_atm_log.exists():
+        if not outage_shared_dev and not outage_atm_log.exists():
             raise SystemExit("outage smoke: ATM local log missing")
         if not outage_sc_log.exists():
             raise SystemExit("outage smoke: sc-compose local log missing")
-        if count_events(outage_atm_log) <= outage_atm_before:
+        if not outage_shared_dev and not wait_for_count_increase(
+            outage_atm_log, outage_atm_before, "outage smoke: ATM local log"
+        ):
             raise SystemExit("outage smoke: ATM local log did not receive a new event")
-        if count_events(outage_sc_log) <= outage_sc_before:
+        if not wait_for_count_increase(
+            outage_sc_log, outage_sc_before, "outage smoke: sc-compose local log"
+        ):
             raise SystemExit("outage smoke: sc-compose local log did not receive a new event")
 
         summary = {

--- a/scripts/otel-dev-install-smoke.py
+++ b/scripts/otel-dev-install-smoke.py
@@ -26,6 +26,7 @@ import time
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 DEFAULT_DEV_BIN = pathlib.Path.home() / ".local" / "atm-dev" / "bin"
+DEFAULT_SHARED_HOME = pathlib.Path.home() / ".local" / "share" / "atm-dev" / "home"
 
 
 def resolve_dev_bin() -> pathlib.Path:
@@ -118,6 +119,34 @@ def ensure_contains(payloads: list[str], needle: str, label: str) -> None:
         raise SystemExit(f"{label}: missing `{needle}` in collector payloads")
 
 
+def resolve_atm_home(dev_bin: pathlib.Path, env: dict[str, str]) -> pathlib.Path | None:
+    atm_home = env.get("ATM_HOME", "").strip()
+    if atm_home:
+        return pathlib.Path(atm_home).expanduser().resolve()
+    if dev_bin.resolve() == DEFAULT_DEV_BIN.resolve():
+        return DEFAULT_SHARED_HOME
+    return None
+
+
+def shared_dev_mode(dev_bin: pathlib.Path, env: dict[str, str]) -> bool:
+    resolved_home = resolve_atm_home(dev_bin, env)
+    if "ATM_HOME" in env and env["ATM_HOME"].strip():
+        return resolved_home == DEFAULT_SHARED_HOME.resolve()
+    return dev_bin.resolve() == DEFAULT_DEV_BIN.resolve()
+
+
+def canonical_log_paths(home_dir: pathlib.Path) -> tuple[pathlib.Path, pathlib.Path]:
+    atm_log = home_dir / ".config" / "atm" / "logs" / "atm" / "atm.log.jsonl"
+    sc_compose_log = (
+        home_dir / ".config" / "sc-compose" / "logs" / "sc-compose.log"
+    )
+    return atm_log, sc_compose_log
+
+
+def count_events(path: pathlib.Path) -> int:
+    return len(read_json_lines(path))
+
+
 def build_base_env(dev_bin: pathlib.Path) -> dict[str, str]:
     env = os.environ.copy()
     env["PATH"] = f"{dev_bin}{os.pathsep}{env.get('PATH', '')}"
@@ -157,8 +186,21 @@ def main() -> int:
 
         live_env = build_base_env(dev_bin)
         live_env["ATM_OTEL_ENDPOINT"] = collector.endpoint
-        live_env["ATM_LOG_FILE"] = str(root / "atm.log.jsonl")
-        live_env["SC_COMPOSE_LOG_FILE"] = str(root / "sc-compose.log")
+        live_shared_dev = shared_dev_mode(dev_bin, live_env)
+        if live_shared_dev:
+            resolved_home = resolve_atm_home(dev_bin, live_env)
+            if resolved_home is None:
+                raise SystemExit("shared-dev smoke: failed to resolve ATM_HOME")
+            atm_log, sc_log = canonical_log_paths(resolved_home)
+        else:
+            atm_log = root / "atm.log.jsonl"
+            sc_log = root / "sc-compose.log"
+            live_env["ATM_LOG_FILE"] = str(atm_log)
+            live_env["SC_COMPOSE_LOG_FILE"] = str(sc_log)
+        live_atm_before = count_events(atm_log)
+        live_atm_otel_before = count_events(atm_log.with_suffix(".otel.jsonl"))
+        live_sc_before = count_events(sc_log)
+        live_sc_otel_before = count_events(sc_log.with_suffix(".otel.jsonl"))
 
         atm_result = run([str(atm_bin), "config", "--json"], live_env)
         sc_compose_result = run_sc_compose(sc_compose_bin, live_env, root)
@@ -176,19 +218,40 @@ def main() -> int:
         ensure_contains(payloads, "command_start", "live collector smoke")
         ensure_contains(payloads, "compose", "live collector smoke")
 
-        atm_log = root / "atm.log.jsonl"
-        sc_log = root / "sc-compose.log"
         if not atm_log.exists() or not sc_log.exists():
             raise SystemExit("live collector smoke: canonical local logs were not written")
         if not atm_log.with_suffix(".otel.jsonl").exists():
             raise SystemExit("live collector smoke: atm .otel.jsonl mirror missing")
         if not sc_log.with_suffix(".otel.jsonl").exists():
             raise SystemExit("live collector smoke: sc-compose .otel.jsonl mirror missing")
+        if count_events(atm_log) <= live_atm_before:
+            raise SystemExit("live collector smoke: atm local log did not receive a new event")
+        if count_events(atm_log.with_suffix(".otel.jsonl")) <= live_atm_otel_before:
+            raise SystemExit("live collector smoke: atm .otel.jsonl mirror did not advance")
+        if count_events(sc_log) <= live_sc_before:
+            raise SystemExit(
+                "live collector smoke: sc-compose local log did not receive a new event"
+            )
+        if count_events(sc_log.with_suffix(".otel.jsonl")) <= live_sc_otel_before:
+            raise SystemExit(
+                "live collector smoke: sc-compose .otel.jsonl mirror did not advance"
+            )
 
         outage_env = build_base_env(dev_bin)
         outage_env["ATM_OTEL_ENDPOINT"] = closed_local_endpoint()
-        outage_env["ATM_LOG_FILE"] = str(root / "atm-outage.log.jsonl")
-        outage_env["SC_COMPOSE_LOG_FILE"] = str(root / "sc-compose-outage.log")
+        outage_shared_dev = shared_dev_mode(dev_bin, outage_env)
+        if outage_shared_dev:
+            resolved_home = resolve_atm_home(dev_bin, outage_env)
+            if resolved_home is None:
+                raise SystemExit("outage smoke: failed to resolve ATM_HOME")
+            outage_atm_log, outage_sc_log = canonical_log_paths(resolved_home)
+        else:
+            outage_atm_log = root / "atm-outage.log.jsonl"
+            outage_sc_log = root / "sc-compose-outage.log"
+            outage_env["ATM_LOG_FILE"] = str(outage_atm_log)
+            outage_env["SC_COMPOSE_LOG_FILE"] = str(outage_sc_log)
+        outage_atm_before = count_events(outage_atm_log)
+        outage_sc_before = count_events(outage_sc_log)
 
         outage_atm = run([str(atm_bin), "config", "--json"], outage_env)
         outage_sc = run_sc_compose(sc_compose_bin, outage_env, root)
@@ -198,10 +261,14 @@ def main() -> int:
         if outage_sc.returncode != 0:
             raise SystemExit(f"outage smoke sc-compose failed: {outage_sc.stderr.strip()}")
 
-        if not pathlib.Path(outage_env["ATM_LOG_FILE"]).exists():
+        if not outage_atm_log.exists():
             raise SystemExit("outage smoke: ATM local log missing")
-        if not pathlib.Path(outage_env["SC_COMPOSE_LOG_FILE"]).exists():
+        if not outage_sc_log.exists():
             raise SystemExit("outage smoke: sc-compose local log missing")
+        if count_events(outage_atm_log) <= outage_atm_before:
+            raise SystemExit("outage smoke: ATM local log did not receive a new event")
+        if count_events(outage_sc_log) <= outage_sc_before:
+            raise SystemExit("outage smoke: sc-compose local log did not receive a new event")
 
         summary = {
             "collector_endpoint": collector.endpoint,


### PR DESCRIPTION
Fix otel-dev-install-smoke.py to detect shared-dev mode and read logs from canonical ATM_HOME path (#919). Extend daemon-launch OTel env-var test to cover all 5 ATM_OTEL_* vars (#904). Add CLI error-path OTel integration test (#905). Add serde round-trip tests for OtelHealthSnapshot/OtelLastError (#911). Closes #919 #904 #905 #911