### PR TITLE
docs: Phase BA planning — CLI message management + plugin boundary

### DIFF
--- a/docs/cli/architecture.md
+++ b/docs/cli/architecture.md
@@ -151,8 +151,12 @@ The current codebase does not yet meet the target architecture:
 
 - `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
   directly from `agent_team_mail_daemon::plugins::ci_monitor`
+- `crates/atm/src/commands/doctor.rs` imports a direct
+  `agent_team_mail_ci_monitor` helper block for GH observer/ledger state
 - `crates/atm/src/commands/doctor.rs` imports a daemon-plugin-owned helper for
   GitHub execution
+- `crates/atm/src/main.rs` directly calls
+  `agent_team_mail_ci_monitor::flush_gh_observability_records()` on shutdown
 
 ### 6.2 Crate Dependency Coupling
 
@@ -160,6 +164,7 @@ The current codebase does not yet meet the target architecture:
 
 - `agent-team-mail-ci-monitor`
 - `agent-team-mail-daemon`
+- `agent-team-mail-daemon-launch`
 
 That means the CLI crate is compiled against plugin-host and plugin-specific
 implementation crates rather than purely neutral contracts.
@@ -170,15 +175,29 @@ Phase BA should repair the CLI boundary in two sprints:
 
 ### BA.3 — Command Boundary Extraction
 
-- extract neutral plugin capability and command contracts
+- extract neutral plugin capability and command contracts into `atm-core`
+  (recommended module family: `atm_core::plugin_contract` or
+  `atm_core::gh_command`)
 - remove direct daemon-plugin imports from the CLI
 - move CLI-needed plugin data shaping behind neutral shared contracts
+- move the current `doctor.rs` GH observer/ledger imports behind the same
+  neutral contract surface
+- resolve the `main.rs` shutdown flush path either by moving it behind an
+  `atm-core` lifecycle hook or explicitly documenting a narrow permitted
+  teardown exception
 - stop treating `atm gh` as a CLI-owned implementation surface
 
 ### BA.4 — Boundary Enforcement and UX
 
+- demote `agent-team-mail-daemon` and `agent-team-mail-ci-monitor` from
+  non-dev `crates/atm/Cargo.toml` dependencies after BA.3 so the compiler
+  enforces the boundary
 - wire plugin namespace availability from capability descriptors
 - add CI checks that forbid new CLI imports from daemon plugin modules
+- keep a secondary grep/lint gate as belt-and-suspenders after dep demotion
+- explicitly classify `agent-team-mail-daemon-launch` as either:
+  - a permitted CLI dependency for canonical launcher lifecycle wiring
+  - or a follow-on boundary violation to remove
 - document the absent/present/enabled plugin command states
 
 ## 8. Architectural Direction for Cross-Team Commands

--- a/docs/cli/architecture.md
+++ b/docs/cli/architecture.md
@@ -1,0 +1,192 @@
+# CLI Architecture
+
+**Status**: Planned (Phase BA)
+**Primary crate**: `atm`
+**See also**:
+- `docs/cli/requirements.md`
+- `docs/project-plan.md` (Phase BA)
+- `docs/arch-boundary.md`
+
+## 1. Architecture Goals
+
+- Keep CLI rendering and command dispatch thin and explicit.
+- Keep durable state, schemas, and neutral contracts in shared crates.
+- Prevent the CLI from depending directly on daemon plugin implementation code.
+- Make inbox/message-management behavior operationally sane for long-running
+  teammate workflows.
+
+## 2. Components
+
+### 2.1 `atm`
+
+Owns:
+
+- `clap` command tree and user-facing help
+- argument parsing
+- output formatting
+- human/JSON rendering
+- CLI-local UX flows
+
+Must not own:
+
+- plugin/provider business logic
+- provider-specific helper implementations
+- ad hoc daemon plugin imports for command semantics
+
+### 2.2 `atm-core`
+
+Owns neutral contracts:
+
+- inbox schema and file I/O
+- state schema
+- daemon-client request/response contracts
+- config discovery
+- shared command payload and capability metadata contracts
+
+### 2.3 `atm-daemon`
+
+Owns:
+
+- plugin registry
+- plugin lifecycle
+- plugin capability advertisement
+- plugin command execution behind neutral contracts
+
+### 2.4 Plugin/Provider Layer
+
+Owns:
+
+- plugin-specific command semantics
+- provider-specific execution
+- plugin capability descriptors
+
+The plugin/provider layer must not be imported directly by the CLI for normal
+command behavior.
+
+## 3. Target Command Flow
+
+### 3.1 Core Commands
+
+For core commands:
+
+1. CLI parses command.
+2. CLI calls neutral shared/core contract.
+3. Core/daemon performs work.
+4. CLI renders result.
+
+### 3.2 Plugin Commands
+
+For plugin commands:
+
+1. Plugin advertises its namespace and capabilities through a neutral contract.
+2. CLI exposes that namespace based on capability state.
+3. CLI forwards command intent through a neutral command request surface.
+4. Daemon/plugin executes the command.
+5. CLI renders the neutral response.
+
+This keeps the CLI as a router/render layer rather than a plugin
+implementation host.
+
+## 4. Plugin Availability Model
+
+The CLI must present plugin namespaces according to runtime state:
+
+| State | CLI behavior |
+|---|---|
+| Plugin absent | Namespace hidden from normal UX |
+| Plugin present but disabled | Only bootstrap / enable / status / management UX shown |
+| Plugin present and enabled | Full namespace shown |
+
+For `atm gh` specifically:
+
+- if the gh plugin/provider is absent, normal `atm gh` UX should not be
+  advertised
+- if it is present but not enabled, only bootstrap/management affordances should
+  appear
+- if it is enabled, the CLI may present the full namespace while still routing
+  execution through neutral plugin contracts
+
+## 5. Inbox and Task-Queue Architecture
+
+### 5.1 Queue Presentation
+
+The queue problem is primarily a presentation and lifecycle problem, not a raw
+transport problem.
+
+Target model:
+
+- unread actionable
+- pending acknowledgement
+- historical/collapsed
+
+`atm read` should derive these buckets from shared inbox state and reader-local
+presentation state.
+
+### 5.2 Cleanup
+
+Idle notifications are lifecycle chatter, not durable work items. The target
+architecture is:
+
+- suppress/dedupe them at write time
+- remove them by default in `atm inbox clear`
+- keep cleanup as a first-class CLI command rather than asking operators to
+  prune JSON manually
+
+### 5.3 Task Acknowledgement
+
+Task acknowledgement should become a single message-bound atomic action rather
+than today's split state/send workflow.
+
+Target flow:
+
+1. operator/agent chooses exact source `message-id`
+2. CLI performs one atomic `ack + reply`
+3. shared inbox state and visible conversation remain in sync
+
+## 6. Current Violations
+
+The current codebase does not yet meet the target architecture:
+
+### 6.1 CLI -> Plugin Coupling
+
+- `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
+  directly from `agent_team_mail_daemon::plugins::ci_monitor`
+- `crates/atm/src/commands/doctor.rs` imports a daemon-plugin-owned helper for
+  GitHub execution
+
+### 6.2 Crate Dependency Coupling
+
+`crates/atm/Cargo.toml` currently carries non-dev dependencies on:
+
+- `agent-team-mail-ci-monitor`
+- `agent-team-mail-daemon`
+
+That means the CLI crate is compiled against plugin-host and plugin-specific
+implementation crates rather than purely neutral contracts.
+
+## 7. Recommended Boundary Repair
+
+Phase BA should repair the CLI boundary in two sprints:
+
+### BA.3 — Command Boundary Extraction
+
+- extract neutral plugin capability and command contracts
+- remove direct daemon-plugin imports from the CLI
+- move CLI-needed plugin data shaping behind neutral shared contracts
+- stop treating `atm gh` as a CLI-owned implementation surface
+
+### BA.4 — Boundary Enforcement and UX
+
+- wire plugin namespace availability from capability descriptors
+- add CI checks that forbid new CLI imports from daemon plugin modules
+- document the absent/present/enabled plugin command states
+
+## 8. Architectural Direction for Cross-Team Commands
+
+Cross-team command routing should preserve fully-qualified identity at the UX
+boundary:
+
+- qualified sender identity is valid data
+- qualified destination identity is the routing contract
+- the CLI should help users respond to cross-team messages correctly rather than
+  silently collapsing the target back to the local team

--- a/docs/cli/requirements.md
+++ b/docs/cli/requirements.md
@@ -140,11 +140,26 @@ The current codebase still contains CLI/plugin coupling that Phase BA must
 remove:
 
 - `crates/atm/Cargo.toml` has non-dev dependencies on
-  `agent-team-mail-ci-monitor` and `agent-team-mail-daemon`
+  `agent-team-mail-ci-monitor`, `agent-team-mail-daemon`, and
+  `agent-team-mail-daemon-launch`
 - `crates/atm/src/commands/gh.rs` imports
   `agent_team_mail_daemon::plugins::ci_monitor::*`
+- `crates/atm/src/commands/doctor.rs` imports a direct
+  `agent_team_mail_ci_monitor` helper block for GH observer/ledger functions:
+  `GhCliObserverContext`, `RateLimitUpdate`, `emit_gh_info_denied`,
+  `emit_gh_info_live_refresh`, `emit_gh_info_requested`,
+  `emit_gh_info_served_from_cache`, `gh_repo_state_cache_age_secs`,
+  `new_gh_execution_call_id`, `new_gh_info_request_id`, `read_gh_repo_state`,
+  `update_gh_repo_state_rate_limit`
 - `crates/atm/src/commands/doctor.rs` imports the daemon-plugin-owned helper
   `run_attributed_gh_command_with_ids`
+- `crates/atm/src/main.rs` directly calls
+  `agent_team_mail_ci_monitor::flush_gh_observability_records()` during CLI
+  teardown
+- Phase AT closed the GitHub-behavior boundary (raw `gh` execution ownership)
+  but did not remove these CLI-to-plugin implementation couplings. BA therefore
+  addresses a post-AT boundary gap, not a reopening of AT’s completed raw-`gh`
+  elimination scope.
 
 These are boundary violations against the target command-ownership model above.
 
@@ -152,5 +167,18 @@ These are boundary violations against the target command-ownership model above.
 
 - BA.1: idle dedupe/suppression + explicit inbox-clear behavior
 - BA.2: queue-style `atm read` + atomic acknowledgement workflow
-- BA.3: CLI/plugin command-boundary extraction
-- BA.4: CLI boundary enforcement + plugin availability UX
+- BA.3: CLI/plugin command-boundary extraction via a neutral `atm-core`
+  contract module (for example `atm_core::plugin_contract` or
+  `atm_core::gh_command`) that owns:
+  - plugin capability descriptors
+  - `gh` namespace command request/response contracts
+  - any permitted CLI teardown lifecycle hook such as ledger flush
+- BA.4: CLI boundary enforcement + plugin availability UX, with:
+  - primary enforcement by demoting `agent-team-mail-daemon` and
+    `agent-team-mail-ci-monitor` from non-dev `crates/atm/Cargo.toml`
+    dependencies once BA.3 lands
+  - secondary CI grep/lint forbidding new CLI imports from daemon plugin
+    implementation modules
+  - explicit treatment of `agent-team-mail-daemon-launch` as either a permitted
+    CLI lifecycle dependency or a follow-on removal target; BA may not leave its
+    status implicit

--- a/docs/cli/requirements.md
+++ b/docs/cli/requirements.md
@@ -1,0 +1,156 @@
+# CLI Requirements
+
+**Status**: Planned (Phase BA)
+**Scope**: `atm` CLI, CLI-facing shared contracts in `atm-core`, inbox/message-management UX
+**See also**:
+- `docs/cli/architecture.md`
+- `docs/project-plan.md` (Phase BA)
+- `docs/requirements.md` (secondary requirements registry)
+
+## 1. Purpose
+
+Define the source-of-truth requirements for:
+
+- CLI command ownership and boundary rules
+- inbox/message-management behavior
+- plugin command advertisement and availability
+- task-acknowledgement workflow semantics
+
+This document exists to keep CLI policy separate from observability,
+daemon-spawn, and plugin-specific subsystem contracts.
+
+## 2. Command Ownership Contract
+
+### 2.1 Core vs Plugin Commands
+
+- Core ATM commands (`send`, `read`, `inbox`, `ack`, `teams`, `doctor`,
+  `daemon`, `status`, `cleanup`, `mcp`, `bridge`, `members`) are owned by the
+  `atm` CLI and the neutral contracts in `atm-core`.
+- Plugin-provided command namespaces are owned by the plugin/provider layer,
+  not by ad hoc CLI command implementations.
+- The CLI may provide generic routing, help, bootstrap, and availability UX for
+  plugin commands, but it must not embed plugin implementation logic.
+
+### 2.2 Plugin Command Advertisement
+
+- A plugin command namespace must be advertised through a neutral capability
+  contract.
+- If the plugin is not present in the build/runtime, the namespace must not
+  appear in standard CLI UX.
+- If the plugin is present but not enabled, only bootstrap/management commands
+  may appear.
+- If the plugin is present and enabled, the full namespace may appear.
+
+For the GitHub monitor stack specifically:
+
+- the gh plugin/provider layer owns GitHub command semantics
+- the CLI may route `atm gh ...` but must not directly depend on daemon plugin
+  implementation modules to do so
+
+### 2.3 CLI Boundary Rules
+
+- `atm` may depend on `atm-core` and other neutral contract crates.
+- `atm` must not depend on daemon plugin implementation modules for normal
+  command execution.
+- `atm` must not import provider-specific helper functions from daemon plugin
+  crates.
+- CLI-only UX concerns (rendering, `clap` routing, help text, summaries) must
+  remain in the CLI crate.
+- Product-layer command execution must cross the boundary via neutral request /
+  response contracts, not direct plugin helper imports.
+
+## 3. Inbox and Message-Management Requirements
+
+### 3.1 `atm send`
+
+- `atm send` must send the message and report the recipient's current state as
+  immediate feedback when that state is available.
+- `atm send` must not create notification subscriptions as an implicit side
+  effect.
+- The sender's own lifecycle state must be updated through explicit lifecycle
+  logic, not by piggybacking on recipient-idle subscription behavior.
+
+### 3.2 Lifecycle Notification Subscriptions
+
+- Busy/idle notifications for orchestration must be explicit and edge-triggered.
+- Subscription policy should be configured declaratively (for example in
+  `.atm.toml`) and must not be mutated by normal `atm send` calls.
+- Team-lead may subscribe to selected agents' state edges for orchestration.
+- Repeated steady-state idle reminders are forbidden; only transitions should
+  notify.
+
+### 3.3 Idle Notifications
+
+- An inbox must retain at most one idle notification per sender identity.
+- A newer idle notification supersedes older idle notifications from the same
+  sender.
+- Idle-notification suppression/deduplication should happen at write time where
+  possible, not solely through later cleanup.
+
+### 3.4 `atm inbox clear`
+
+- ATM must provide a first-class inbox cleanup command.
+- Users must not be expected to hand-edit inbox JSON files.
+- Default cleanup behavior must remove idle notifications without requiring a
+  dedicated idle-only flag.
+- Additional selectors such as `--acked` and `--older-than <duration>` may
+  further constrain cleanup scope.
+- `--idle-only` is allowed as a focused mode, but idle cleanup must not depend
+  on that flag.
+- Cleanup should support `--dry-run` before destructive execution.
+
+### 3.5 `atm read`
+
+- `atm read` must behave like a queue, not a flat replay dump.
+- Default output must prioritize:
+  1. unread actionable
+  2. read/pending-ack
+  3. historical entries only when explicitly requested
+- Within buckets, messages must be shown newest-first.
+- Focused filtering modes must exist for unread-only and pending-ack-only use.
+- Human and JSON output must include summary counts for each bucket.
+- Reader-local presentation state may be used to suppress already-presented
+  history without mutating the shared inbox schema.
+
+### 3.6 `atm ack`
+
+- Normal task acknowledgement must be message-id bound and explicit.
+- The target behavior is a single canonical acknowledgement path:
+  `atm ack <message-id> "<reply>"`
+- That action must be atomic:
+  - mark the specific source message acknowledged
+  - send the visible reply linked to that source message
+- If either step fails, neither side should commit.
+- Plain `atm send` must not count as acknowledging a task assignment.
+- Bulk maintenance operations may exist separately, but they must not be the
+  normal task-acceptance workflow.
+
+## 4. Cross-Team Messaging Requirements
+
+- Fully-qualified sender identities like `team-lead@src-dev` must be accepted
+  and preserved in inbox message records.
+- Cross-team responses must route back to the originating team identity rather
+  than silently defaulting to the responder's local team.
+- Cross-team task messages should carry explicit response guidance for runtimes
+  that cannot safely infer the proper ATM reply target on their own.
+
+## 5. Current Boundary Findings Driving Phase BA
+
+The current codebase still contains CLI/plugin coupling that Phase BA must
+remove:
+
+- `crates/atm/Cargo.toml` has non-dev dependencies on
+  `agent-team-mail-ci-monitor` and `agent-team-mail-daemon`
+- `crates/atm/src/commands/gh.rs` imports
+  `agent_team_mail_daemon::plugins::ci_monitor::*`
+- `crates/atm/src/commands/doctor.rs` imports the daemon-plugin-owned helper
+  `run_attributed_gh_command_with_ids`
+
+These are boundary violations against the target command-ownership model above.
+
+## 6. Phase BA Implementation Targets
+
+- BA.1: idle dedupe/suppression + explicit inbox-clear behavior
+- BA.2: queue-style `atm read` + atomic acknowledgement workflow
+- BA.3: CLI/plugin command-boundary extraction
+- BA.4: CLI boundary enforcement + plugin availability UX

--- a/docs/phase-ba-cli-message-boundary-planning.md
+++ b/docs/phase-ba-cli-message-boundary-planning.md
@@ -1,0 +1,153 @@
+# Phase BA Planning: CLI Message Management + Plugin Boundary
+
+**Status**: Planned
+**Primary docs**:
+- `docs/cli/requirements.md`
+- `docs/cli/architecture.md`
+
+## Goal
+
+Stabilize ATM as an operational task queue and clean command boundary:
+
+- remove idle-notification inbox bloat
+- make `atm read` act like a queue instead of replaying stale backlog forever
+- make task acknowledgement explicit, atomic, and message-bound
+- remove current CLI coupling to daemon plugin implementation code
+- establish plugin-advertised command namespaces instead of CLI-owned plugin
+  semantics
+
+## Problem Statement
+
+Current dogfood issues fall into two linked groups:
+
+### Message-management problems
+
+- idle notifications dominate inbox volume
+- `atm send` currently auto-subscribes the sender to recipient idle events,
+  creating hidden notification churn
+- `atm read` presents old pending-ack items as a flat oldest-first stream
+- task acknowledgement is split between inbox-state mutation and a separate
+  visible reply
+- there is no first-class operator-friendly inbox cleanup command
+
+### CLI boundary problems
+
+- `crates/atm/Cargo.toml` depends directly on `agent-team-mail-daemon` and
+  `agent-team-mail-ci-monitor`
+- `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
+- `crates/atm/src/commands/doctor.rs` imports a plugin-owned GitHub helper
+- plugin command ownership is blurred: the CLI effectively implements plugin
+  behavior instead of routing through plugin capability contracts
+
+## Sprint Map
+
+| Sprint | Focus | Primary issues / findings |
+|---|---|---|
+| BA.1 | Idle lifecycle hygiene + inbox clear | `#932`, `#933`, dogfood idle-notification growth |
+| BA.2 | Queue semantics + atomic ack workflow | `#927`, `#928`, `#929`, `#930`, `#931` |
+| BA.3 | CLI/plugin command-boundary extraction | current `atm -> daemon/ci-monitor` coupling audit |
+| BA.4 | Boundary enforcement + plugin availability UX | CI boundary gate + capability-advertised namespace behavior |
+
+The requested “sprint or two” for CLI/core/plugin boundary cleanup are BA.3 and
+BA.4.
+
+## BA.1 — Idle Lifecycle Hygiene + Inbox Clear
+
+**Issues**: `#932`, `#933`
+
+**Deliverables**:
+
+- remove implicit send-time idle subscription side effects from `atm send`
+- add automatic post-send idle lifecycle transition for non-Claude agents
+- dedupe/suppress idle notifications at write time so inboxes retain at most
+  one idle notification per sender
+- add first-class `atm inbox clear` UX with:
+  - default idle-notification removal
+  - `--acked`
+  - `--older-than <duration>`
+  - `--idle-only`
+  - `--dry-run`
+- preserve send-time recipient state feedback without hidden subscriptions
+
+**Acceptance**:
+
+- repeated idle notifications no longer accumulate in normal inboxes
+- `atm send` no longer creates recipient-idle subscriptions as a side effect
+- non-Claude agents transition busy -> idle after successful send completion
+- `atm inbox clear` removes idle notifications by default
+
+## BA.2 — Queue Semantics + Atomic Ack Workflow
+
+**Issues**: `#927`, `#928`, `#929`, `#930`, `#931`
+
+**Deliverables**:
+
+- unread / pending-ack / history queue buckets in `atm read`
+- newest-first ordering within buckets
+- `--unread-only` and `--pending-ack-only`
+- summary header + JSON bucket counts
+- reader-local history-collapse support
+- canonical message-bound task acknowledgement flow:
+  - `atm ack <message-id> "<reply>"`
+- visible task reply and inbox-state acknowledgement become one atomic action
+
+**Acceptance**:
+
+- long-running agent workflows surface new tasks ahead of stale backlog
+- replay noise is materially reduced on repeated reads
+- task acknowledgement is explicit, auditable, and message-id bound
+
+## BA.3 — CLI/Plugin Command-Boundary Extraction
+
+**Findings driving the sprint**:
+
+- `crates/atm/Cargo.toml` currently depends on `agent-team-mail-daemon`
+  and `agent-team-mail-ci-monitor`
+- `crates/atm/src/commands/gh.rs` imports
+  `agent_team_mail_daemon::plugins::ci_monitor::*`
+- `crates/atm/src/commands/doctor.rs` imports
+  `run_attributed_gh_command_with_ids` from the daemon plugin layer
+
+**Deliverables**:
+
+- define or extract neutral plugin capability / command contracts for CLI use
+- remove direct daemon plugin imports from `atm`
+- move CLI-facing GH command data shaping behind neutral contracts
+- document the command ownership rule:
+  - plugin owns semantics
+  - CLI owns routing/help/rendering
+
+**Acceptance**:
+
+- `atm` no longer imports daemon plugin implementation modules for GH command
+  behavior
+- direct CLI dependency on plugin implementation crates is removed or reduced to
+  neutral contract crates only
+- `atm gh` no longer depends on daemon plugin implementation helpers
+
+## BA.4 — Boundary Enforcement + Plugin Availability UX
+
+**Deliverables**:
+
+- capability-advertised plugin namespace model
+- absent / present-disabled / present-enabled UX rules for plugin commands
+- CI/lint gate that forbids new CLI imports from daemon plugin modules
+- docs/tests for plugin command availability and boundary enforcement
+
+**Acceptance**:
+
+- plugin namespaces are shown according to capability state, not hard-coded
+  implementation ownership
+- CI fails if the CLI reintroduces daemon-plugin implementation imports
+- the CLI availability model is documented and tested
+
+## Exit Criteria
+
+1. Idle-notification inbox growth is controlled by write-time suppression and
+   default cleanup.
+2. `atm send` no longer mutates notification subscriptions implicitly.
+3. `atm read` behaves like a task queue with bucketed visibility.
+4. Task acknowledgement is message-id bound and atomic.
+5. `atm` no longer depends directly on daemon plugin implementation code for GH
+   command behavior.
+6. Plugin namespace availability is capability-driven and covered by docs/tests.

--- a/docs/phase-ba-cli-message-boundary-planning.md
+++ b/docs/phase-ba-cli-message-boundary-planning.md
@@ -35,9 +35,29 @@ Current dogfood issues fall into two linked groups:
 - `crates/atm/Cargo.toml` depends directly on `agent-team-mail-daemon` and
   `agent-team-mail-ci-monitor`
 - `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
-- `crates/atm/src/commands/doctor.rs` imports a plugin-owned GitHub helper
+- `crates/atm/src/commands/doctor.rs` imports both:
+  - a direct `agent_team_mail_ci_monitor` helper block for GH observer/ledger
+    state
+  - a plugin-owned GitHub execution helper from
+    `agent_team_mail_daemon::plugins::ci_monitor`
+- `crates/atm/src/main.rs` directly calls
+  `agent_team_mail_ci_monitor::flush_gh_observability_records()`
 - plugin command ownership is blurred: the CLI effectively implements plugin
   behavior instead of routing through plugin capability contracts
+- `agent-team-mail-daemon-launch` is also a current CLI dependency and must be
+  classified explicitly during BA.3/BA.4 rather than left as an implicit
+  exception
+
+### Scope clarification vs Phase AT
+
+Phase AT closed the GitHub-behavior boundary: raw `gh` execution and provider
+ownership now live only in the owning gh plugin/provider layer. BA does not
+reopen that completed scope. Instead, BA addresses the remaining CLI-level
+coupling that AT did not eliminate:
+
+- CLI imports of plugin implementation helpers
+- CLI crate dependencies on plugin implementation crates
+- plugin namespace ownership/advertisement semantics at the CLI boundary
 
 ## Sprint Map
 
@@ -105,20 +125,44 @@ BA.4.
   and `agent-team-mail-ci-monitor`
 - `crates/atm/src/commands/gh.rs` imports
   `agent_team_mail_daemon::plugins::ci_monitor::*`
+- `crates/atm/src/commands/doctor.rs:3-8` imports the direct
+  `agent_team_mail_ci_monitor` helper block:
+  `GhCliObserverContext`, `RateLimitUpdate`, `emit_gh_info_denied`,
+  `emit_gh_info_live_refresh`, `emit_gh_info_requested`,
+  `emit_gh_info_served_from_cache`, `gh_repo_state_cache_age_secs`,
+  `new_gh_execution_call_id`, `new_gh_info_request_id`, `read_gh_repo_state`,
+  `update_gh_repo_state_rate_limit`
 - `crates/atm/src/commands/doctor.rs` imports
   `run_attributed_gh_command_with_ids` from the daemon plugin layer
+- `crates/atm/src/main.rs:352` directly calls
+  `flush_gh_observability_records()`
 
 **Deliverables**:
 
-- define or extract neutral plugin capability / command contracts for CLI use
+- define or extract neutral plugin capability / command contracts in `atm-core`
+  (recommended module: `atm_core::plugin_contract` or
+  `atm_core::gh_command`)
+- minimum new neutral surface:
+  - capability descriptor type
+  - `gh` namespace command request/response contracts
+  - any permitted CLI teardown lifecycle hook such as GH ledger flush
 - remove direct daemon plugin imports from `atm`
 - move CLI-facing GH command data shaping behind neutral contracts
+- move the direct `doctor.rs` ci-monitor helper block behind the same neutral
+  `atm-core` contract surface
+- resolve the `main.rs` ledger flush call either by moving it into the same
+  `atm-core` lifecycle contract or by documenting a narrow permitted teardown
+  exception with rationale
 - document the command ownership rule:
   - plugin owns semantics
   - CLI owns routing/help/rendering
 
 **Acceptance**:
 
+- BA.3 remediation explicitly covers all three known sites:
+  - `doctor.rs` ci-monitor helper block
+  - `doctor.rs` daemon plugin helper import
+  - `main.rs` teardown flush path
 - `atm` no longer imports daemon plugin implementation modules for GH command
   behavior
 - direct CLI dependency on plugin implementation crates is removed or reduced to
@@ -131,14 +175,22 @@ BA.4.
 
 - capability-advertised plugin namespace model
 - absent / present-disabled / present-enabled UX rules for plugin commands
-- CI/lint gate that forbids new CLI imports from daemon plugin modules
+- primary boundary gate: demote `agent-team-mail-daemon` and
+  `agent-team-mail-ci-monitor` from non-dev dependencies in `crates/atm/Cargo.toml`
+  after BA.3 lands
+- secondary CI/lint gate that forbids new CLI imports from daemon plugin modules
 - docs/tests for plugin command availability and boundary enforcement
+- explicit classification of `agent-team-mail-daemon-launch` as either:
+  - permitted CLI dependency for canonical launcher lifecycle ownership
+  - or follow-on removal target
 
 **Acceptance**:
 
 - plugin namespaces are shown according to capability state, not hard-coded
   implementation ownership
 - CI fails if the CLI reintroduces daemon-plugin implementation imports
+- the dependency gate is explicit rather than implied
+- `agent-team-mail-daemon-launch` is addressed explicitly
 - the CLI availability model is documented and tested
 
 ## Exit Criteria

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -182,8 +182,8 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | AK | Mandatory OTel Rollout | Superseded by Phase AV (logs rollout) and Phase AW (traces + metrics expansion) | SUPERSEDED |
 | AQ | Codebase Cleanup + Rogue Daemon Spawn Elimination | Remove cleanup debt from AN/AO/AP reviews, consolidate constants/dead code, and eliminate non-canonical test daemon spawn paths | COMPLETE |
 | AR | Smoke Follow-Up + Lifecycle Timing Corrections | Fix daemon harness flake, drain timeout regression, and EnvGuard::unset gap identified during smoke testing | COMPLETE (PR #795) |
-| AS | Backlog Gap-Filling + GH API Governance | 14 backlog bug/gap fixes + GH API hard firewall, ledgers, and explicit GitHub ownership requirements | ACTIVE |
-| AT | GitHub Boundary Elimination | Remove all remaining audited GitHub-boundary violations so only the gh plugin/provider layer owns GitHub behavior | PLANNED |
+| AS | Backlog Gap-Filling + GH API Governance | 14 backlog bug/gap fixes + GH API hard firewall, ledgers, and explicit GitHub ownership requirements | COMPLETE |
+| AT | GitHub Boundary Elimination | Remove all remaining audited GitHub-boundary violations so only the gh plugin/provider layer owns GitHub behavior | COMPLETE |
 | AV | OTel Collector Logs Rollout | Ship OTLP HTTP logs export, dogfood it against a Grafana-compatible receiver, and preserve fail-open local logging | COMPLETE |
 | AW | OTel Traces + Metrics Expansion | Add native traces and metrics, Grafana dashboards/smoke, and external repo rollout on top of AV | PLANNED |
 | BA | CLI Message Management + Plugin Boundary | Fix inbox lifecycle noise, add atomic queue/ack semantics, and remove current `atm -> daemon plugin` command coupling | PLANNED |

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -186,6 +186,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | AT | GitHub Boundary Elimination | Remove all remaining audited GitHub-boundary violations so only the gh plugin/provider layer owns GitHub behavior | PLANNED |
 | AV | OTel Collector Logs Rollout | Ship OTLP HTTP logs export, dogfood it against a Grafana-compatible receiver, and preserve fail-open local logging | COMPLETE |
 | AW | OTel Traces + Metrics Expansion | Add native traces and metrics, Grafana dashboards/smoke, and external repo rollout on top of AV | PLANNED |
+| BA | CLI Message Management + Plugin Boundary | Fix inbox lifecycle noise, add atomic queue/ack semantics, and remove current `atm -> daemon plugin` command coupling | PLANNED |
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -12,6 +12,8 @@ This primary requirements document registers secondary source-of-truth documents
 
 - Observability requirements: `docs/observability/requirements.md`
 - Observability architecture: `docs/observability/architecture.md`
+- CLI requirements: `docs/cli/requirements.md`
+- CLI architecture: `docs/cli/architecture.md`
 - sc-composer requirements: `docs/sc-composer/requirements.md`
 - sc-composer architecture: `docs/sc-composer/architecture.md`
 - CI monitoring requirements: `docs/ci-monitoring/requirements.md`


### PR DESCRIPTION
## Summary

- Phase BA planning docs: CLI message management + plugin boundary fixes
- Addresses 6 blocking QA findings (BA-ARCH-001..004, BA-ATM-001..002) identified by arch-qa + atm-qa
- Doc-only changes — no Rust code modified

## Changes

- `docs/phase-ba-cli-message-boundary-planning.md` — boundary violations fully enumerated (doctor.rs:3-9, main.rs:352), BA.3 target crate named (atm-core), BA.4 CI gate specified (Cargo dep demotion + grep), Phase AT scope clarification added
- `docs/cli/requirements.md` — boundary findings updated with all 3 violation sites
- `docs/cli/architecture.md` — aligned with planning doc
- `docs/project-plan.md` — Phase Overview table: AS=COMPLETE, AT=COMPLETE

## QA

- arch-qa: PASS (4/4 findings resolved at 02a7daa3)
- atm-qa: PASS (2/2 findings resolved at 02a7daa3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)