### PR TITLE
feat(BA.1): idle lifecycle hygiene + atm inbox clear

### DIFF
--- a/crates/atm-core/src/daemon_client.rs
+++ b/crates/atm-core/src/daemon_client.rs
@@ -1177,6 +1177,31 @@ pub fn subscribe_to_agent(
     query_daemon(&request)
 }
 
+/// Emit a best-effort non-Claude teammate idle lifecycle event to the daemon.
+///
+/// This is used by CLI sender paths that already know the caller runtime session
+/// and need to restore the sender to `idle` after a successful command. The
+/// call is silent when the daemon is unavailable.
+pub fn emit_teammate_idle_best_effort(
+    team: &str,
+    agent: &str,
+    session_id: &str,
+) -> anyhow::Result<Option<SocketResponse>> {
+    let request = SocketRequest {
+        version: PROTOCOL_VERSION,
+        request_id: new_request_id(),
+        command: "hook-event".to_string(),
+        payload: serde_json::json!({
+            "event": "teammate_idle",
+            "agent": agent,
+            "team": team,
+            "session_id": session_id,
+            "source": LifecycleSource::new(LifecycleSourceKind::AgentHook),
+        }),
+    };
+    query_daemon(&request)
+}
+
 /// Send an unsubscribe request to the daemon.
 ///
 /// Removes the subscription for `(subscriber, agent)`. This is a best-effort

--- a/crates/atm-core/src/schema/inbox_message.rs
+++ b/crates/atm-core/src/schema/inbox_message.rs
@@ -3,6 +3,8 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub const IDLE_NOTIFICATION_TYPE: &str = "idle_notification";
+
 /// Message in an agent's inbox
 ///
 /// Messages are stored in `~/.claude/teams/{team_name}/inboxes/{agent_name}.json`
@@ -60,6 +62,33 @@ impl InboxMessage {
 
     pub fn is_pending_action(&self) -> bool {
         !self.read || (self.pending_ack_at().is_some() && !self.is_acknowledged())
+    }
+
+    pub fn notification_type(&self) -> Option<&str> {
+        self.unknown_fields
+            .get("type")
+            .and_then(|value| value.as_str())
+    }
+
+    pub fn is_idle_notification(&self) -> bool {
+        self.notification_type() == Some(IDLE_NOTIFICATION_TYPE)
+    }
+
+    pub fn idle_notification_sender(&self) -> Option<&str> {
+        self.unknown_fields
+            .get("idleSender")
+            .and_then(|value| value.as_str())
+    }
+
+    pub fn mark_idle_notification(&mut self, sender: impl Into<String>) {
+        self.unknown_fields.insert(
+            "type".to_string(),
+            serde_json::Value::String(IDLE_NOTIFICATION_TYPE.to_string()),
+        );
+        self.unknown_fields.insert(
+            "idleSender".to_string(),
+            serde_json::Value::String(sender.into()),
+        );
     }
 
     pub fn mark_pending_ack(&mut self, timestamp: impl Into<String>) {
@@ -254,6 +283,30 @@ mod tests {
         msg.mark_acknowledged("2026-02-11T14:31:00.000Z");
         assert_eq!(msg.pending_ack_at(), None);
         assert_eq!(msg.acknowledged_at(), Some("2026-02-11T14:31:00.000Z"));
+    }
+
+    #[test]
+    fn test_idle_notification_helpers_roundtrip() {
+        let mut msg = InboxMessage {
+            from: "daemon".to_string(),
+            source_team: None,
+            text: "[AGENT STATE] arch-ctm is now idle".to_string(),
+            timestamp: "2026-02-11T14:30:00.000Z".to_string(),
+            read: false,
+            summary: Some("Agent arch-ctm → idle".to_string()),
+            message_id: Some("msg-1".to_string()),
+            unknown_fields: HashMap::new(),
+        };
+
+        msg.mark_idle_notification("arch-ctm");
+
+        assert!(msg.is_idle_notification());
+        assert_eq!(msg.idle_notification_sender(), Some("arch-ctm"));
+
+        let serialized = serde_json::to_string(&msg).unwrap();
+        let reparsed: InboxMessage = serde_json::from_str(&serialized).unwrap();
+        assert!(reparsed.is_idle_notification());
+        assert_eq!(reparsed.idle_notification_sender(), Some("arch-ctm"));
     }
 
     #[test]

--- a/crates/atm-daemon/src/plugins/worker_adapter/plugin.rs
+++ b/crates/atm-daemon/src/plugins/worker_adapter/plugin.rs
@@ -19,7 +19,7 @@ use crate::plugins::consts::{
 };
 use agent_team_mail_core::daemon_client::{LaunchConfig, LaunchResult};
 use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
-use agent_team_mail_core::io::inbox::inbox_append;
+use agent_team_mail_core::io::inbox::{inbox_append, inbox_update};
 use agent_team_mail_core::schema::InboxMessage;
 use chrono::Utc;
 use std::collections::HashMap;
@@ -786,7 +786,7 @@ impl WorkerAdapterPlugin {
 
         for subscriber in &subscribers {
             let notification_text = format!("[AGENT STATE] {} is now {}", agent, new_state);
-            let msg = InboxMessage {
+            let mut msg = InboxMessage {
                 from: "daemon".to_string(),
                 source_team: None,
                 text: notification_text,
@@ -796,8 +796,22 @@ impl WorkerAdapterPlugin {
                 message_id: Some(Uuid::new_v4().to_string()),
                 unknown_fields: HashMap::new(),
             };
+            if new_state == "idle" {
+                msg.mark_idle_notification(agent.to_string());
+            }
             let inbox_path = self.agent_inbox_path(ctx, team_name, subscriber);
-            if let Err(e) = inbox_append(&inbox_path, &msg, team_name, subscriber) {
+            let write_result = if msg.is_idle_notification() {
+                inbox_update(&inbox_path, team_name, subscriber, |messages| {
+                    messages.retain(|existing| {
+                        !(existing.is_idle_notification()
+                            && existing.idle_notification_sender() == Some(agent))
+                    });
+                    messages.push(msg.clone());
+                })
+            } else {
+                inbox_append(&inbox_path, &msg, team_name, subscriber).map(|_| ())
+            };
+            if let Err(e) = write_result {
                 warn!("Failed to deliver pubsub notification to {subscriber}: {e}");
             } else {
                 debug!("Delivered pubsub notification to {subscriber}: {agent} → {new_state}");
@@ -1420,11 +1434,36 @@ mod tests {
     use super::super::mock_backend::{MockCall, MockTmuxBackend};
     use super::*;
     use crate::daemon::session_registry::new_session_registry;
+    use crate::plugin::{MailService, PluginContext};
+    use crate::roster::RosterService;
+    use agent_team_mail_core::config::Config;
+    use agent_team_mail_core::context::{Platform, SystemContext};
+    use std::sync::Arc;
     use tempfile::TempDir;
 
     /// Helper to create a plugin that has a backend but no launch receiver.
     fn make_plugin_without_backend() -> WorkerAdapterPlugin {
         WorkerAdapterPlugin::new()
+    }
+
+    fn make_test_context(root: &std::path::Path) -> PluginContext {
+        let claude_root = root.join(".claude");
+        std::fs::create_dir_all(claude_root.join("teams/atm-dev/inboxes")).unwrap();
+        let system = SystemContext::new(
+            "test-host".to_string(),
+            Platform::Linux,
+            claude_root,
+            "0.1.0".to_string(),
+            "atm-dev".to_string(),
+        );
+        let mut config = Config::default();
+        config.core.default_team = "atm-dev".to_string();
+        PluginContext::new(
+            Arc::new(system),
+            Arc::new(MailService::new(root.to_path_buf())),
+            Arc::new(config),
+            Arc::new(RosterService::new(root.to_path_buf())),
+        )
     }
 
     #[tokio::test]
@@ -1447,6 +1486,36 @@ mod tests {
             msg.contains("backend"),
             "Expected error about backend: {msg}"
         );
+    }
+
+    #[test]
+    fn test_idle_pubsub_notifications_replace_prior_idle_for_same_sender() {
+        let temp = TempDir::new().unwrap();
+        let mut plugin = WorkerAdapterPlugin::new();
+        plugin.ctx = Some(make_test_context(temp.path()));
+        plugin
+            .pubsub
+            .lock()
+            .unwrap()
+            .subscribe("team-lead", "arch-ctm", vec!["idle".to_string()])
+            .unwrap();
+
+        plugin.deliver_pubsub_notifications("arch-ctm", "idle");
+        plugin.deliver_pubsub_notifications("arch-ctm", "idle");
+
+        let inbox_path = temp
+            .path()
+            .join(".claude/teams/atm-dev/inboxes/team-lead.json");
+        let messages: Vec<InboxMessage> =
+            serde_json::from_str(&std::fs::read_to_string(&inbox_path).unwrap()).unwrap();
+
+        assert_eq!(
+            messages.len(),
+            1,
+            "duplicate idle notifications must collapse"
+        );
+        assert!(messages[0].is_idle_notification());
+        assert_eq!(messages[0].idle_notification_sender(), Some("arch-ctm"));
     }
 
     #[tokio::test]

--- a/crates/atm/src/commands/inbox.rs
+++ b/crates/atm/src/commands/inbox.rs
@@ -1,10 +1,13 @@
-//! Inbox command implementation - show inbox summaries
+//! Inbox command implementation - show inbox summaries and targeted cleanup
 
 use agent_team_mail_core::config::{ConfigOverrides, resolve_config};
+use agent_team_mail_core::retention::parse_duration;
+use agent_team_mail_core::schema::InboxMessage;
 use agent_team_mail_core::schema::TeamConfig;
 use anyhow::Result;
-use chrono::DateTime;
-use clap::{ArgAction, Args};
+use chrono::{DateTime, Utc};
+use clap::{ArgAction, Args, Subcommand};
+use serde::Serialize;
 use std::path::Path;
 
 use crate::util::settings::{get_home_dir, teams_root_dir_for};
@@ -36,10 +39,69 @@ pub struct InboxArgs {
     /// Poll interval for --watch (milliseconds)
     #[arg(long, default_value_t = 200)]
     interval_ms: u64,
+
+    #[command(subcommand)]
+    command: Option<InboxCommand>,
+}
+
+#[derive(Subcommand, Debug)]
+enum InboxCommand {
+    /// Clear selected messages from an inbox
+    Clear(ClearArgs),
+}
+
+#[derive(Args, Debug)]
+struct ClearArgs {
+    /// Target agent inbox (defaults to current ATM identity)
+    agent: Option<String>,
+
+    /// Override default team
+    #[arg(long)]
+    team: Option<String>,
+
+    /// Remove acknowledged messages
+    #[arg(long)]
+    acked: bool,
+
+    /// Remove messages older than the given duration (e.g. 7d, 24h)
+    #[arg(long, value_name = "DURATION")]
+    older_than: Option<String>,
+
+    /// Only remove idle notifications
+    #[arg(long, conflicts_with = "acked", conflicts_with = "older_than")]
+    idle_only: bool,
+
+    /// Show what would be removed without mutating the inbox
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Output cleanup results as JSON
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Default, Clone, Serialize, PartialEq, Eq)]
+struct InboxClearResult {
+    team: String,
+    agent: String,
+    dry_run: bool,
+    inbox_path: String,
+    removed_total: usize,
+    remaining_total: usize,
+    removed_idle_notifications: usize,
+    removed_acked_messages: usize,
+    removed_older_than: usize,
 }
 
 /// Execute the inbox command
 pub fn execute(args: InboxArgs) -> Result<()> {
+    if let Some(InboxCommand::Clear(mut clear_args)) = args.command {
+        if clear_args.team.is_none() {
+            clear_args.team = args.team.clone();
+        }
+        return execute_clear(clear_args);
+    }
+
     let home_dir = get_home_dir()?;
     let current_dir = std::env::current_dir()?;
 
@@ -95,6 +157,57 @@ pub fn execute(args: InboxArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn execute_clear(args: ClearArgs) -> Result<()> {
+    let home_dir = get_home_dir()?;
+    let current_dir = std::env::current_dir()?;
+    let overrides = ConfigOverrides {
+        team: args.team.clone(),
+        ..Default::default()
+    };
+    let config = resolve_config(&overrides, &current_dir, &home_dir)?;
+    let team_name = args
+        .team
+        .clone()
+        .unwrap_or_else(|| config.core.default_team.clone());
+    let agent_name = args
+        .agent
+        .clone()
+        .unwrap_or_else(|| config.core.identity.clone());
+    let inbox_path = teams_root_dir_for(&home_dir)
+        .join(&team_name)
+        .join("inboxes")
+        .join(format!("{agent_name}.json"));
+
+    let result = clear_inbox_messages(&inbox_path, &team_name, &agent_name, &args)?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    } else if args.dry_run {
+        println!(
+            "Dry run - would remove {} message(s) from {}@{}",
+            result.removed_total, agent_name, team_name
+        );
+        print_clear_counts(&result);
+    } else {
+        println!(
+            "Cleared {} message(s) from {}@{}",
+            result.removed_total, agent_name, team_name
+        );
+        print_clear_counts(&result);
+    }
+
+    Ok(())
+}
+
+fn print_clear_counts(result: &InboxClearResult) {
+    println!(
+        "  idle_notifications: {}",
+        result.removed_idle_notifications
+    );
+    println!("  acked_messages: {}", result.removed_acked_messages);
+    println!("  older_than: {}", result.removed_older_than);
+    println!("  remaining_total: {}", result.remaining_total);
 }
 
 /// Show inbox summary for a single team
@@ -187,6 +300,86 @@ fn show_team_summary(home_dir: &Path, team_name: &str, use_since_last_seen: bool
     }
 
     Ok(())
+}
+
+fn clear_inbox_messages(
+    inbox_path: &Path,
+    team_name: &str,
+    agent_name: &str,
+    args: &ClearArgs,
+) -> Result<InboxClearResult> {
+    let messages: Vec<InboxMessage> = if inbox_path.exists() {
+        serde_json::from_str(&std::fs::read_to_string(inbox_path)?)?
+    } else {
+        Vec::new()
+    };
+    let older_than = match args.older_than.as_deref() {
+        Some(raw) => Some(parse_duration(raw)?),
+        None => None,
+    };
+    let now = Utc::now();
+    let mut result = InboxClearResult {
+        team: team_name.to_string(),
+        agent: agent_name.to_string(),
+        dry_run: args.dry_run,
+        inbox_path: inbox_path.display().to_string(),
+        ..Default::default()
+    };
+
+    let mut kept = Vec::with_capacity(messages.len());
+    for message in messages {
+        let idle_match = message.is_idle_notification();
+        let acked_match = args.acked && message.is_acknowledged();
+        let older_match = older_than
+            .as_ref()
+            .is_some_and(|duration| message_is_older_than(&message, *duration, now));
+        let should_remove = if args.idle_only {
+            idle_match
+        } else {
+            idle_match || acked_match || older_match
+        };
+
+        if should_remove {
+            result.removed_total += 1;
+            if idle_match {
+                result.removed_idle_notifications += 1;
+            }
+            if acked_match {
+                result.removed_acked_messages += 1;
+            }
+            if older_match {
+                result.removed_older_than += 1;
+            }
+        } else {
+            kept.push(message);
+        }
+    }
+
+    result.remaining_total = kept.len();
+
+    if !args.dry_run && result.removed_total > 0 {
+        agent_team_mail_core::io::inbox::inbox_update(
+            inbox_path,
+            team_name,
+            agent_name,
+            |stored| {
+                stored.clear();
+                stored.extend(kept.clone());
+            },
+        )?;
+    }
+
+    Ok(result)
+}
+
+fn message_is_older_than(
+    message: &InboxMessage,
+    max_age: chrono::Duration,
+    now: chrono::DateTime<Utc>,
+) -> bool {
+    DateTime::parse_from_rfc3339(&message.timestamp)
+        .map(|timestamp| now.signed_duration_since(timestamp.with_timezone(&Utc)) > max_age)
+        .unwrap_or(true)
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -318,17 +318,16 @@ pub fn execute(args: SendArgs) -> Result<()> {
         WriteOutcome::Success | WriteOutcome::ConflictResolved { .. }
     ) {
         let _ = touch_sender_session_heartbeat(&team_name, &config.core.identity);
+        if should_emit_post_send_idle_transition() {
+            if let Some(ref session_id) = sender_session_id {
+                let _ = agent_team_mail_core::daemon_client::emit_teammate_idle_best_effort(
+                    &team_name,
+                    &config.core.identity,
+                    session_id,
+                );
+            }
+        }
     }
-
-    // Auto-subscribe the sender to the target agent's idle event (upsert — refreshes TTL
-    // if a subscription already exists). This is best-effort: errors are silently ignored
-    // because the daemon may not be running.
-    let _ = agent_team_mail_core::daemon_client::subscribe_to_agent(
-        &config.core.identity,
-        &agent_name,
-        &team_name,
-        &["idle".to_string()],
-    );
 
     // Query the daemon for agent state to enrich the output (best-effort, silent fallback).
     let agent_state_info =
@@ -595,6 +594,16 @@ where
 {
     let _ = query(team, sender)?;
     Ok(())
+}
+
+fn should_emit_post_send_idle_transition() -> bool {
+    matches!(
+        std::env::var("ATM_RUNTIME")
+            .ok()
+            .map(|runtime| runtime.trim().to_ascii_lowercase()),
+        Some(runtime)
+            if matches!(runtime.as_str(), "codex" | "codex-cli" | "gemini" | "gemini-cli" | "opencode")
+    )
 }
 
 fn should_warn_self_send(

--- a/crates/atm/tests/integration_read.rs
+++ b/crates/atm/tests/integration_read.rs
@@ -1067,3 +1067,118 @@ fn test_read_does_not_mark_other_agents_messages() {
         "arch-ctm message must NOT be marked as read when team-lead runs `atm read arch-ctm`"
     );
 }
+
+#[test]
+fn test_inbox_clear_dry_run_defaults_to_idle_notifications_only() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "daemon",
+            "text": "[AGENT STATE] arch-ctm is now idle",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": false,
+            "summary": "Agent arch-ctm → idle",
+            "message_id": "idle-001",
+            "type": "idle_notification",
+            "idleSender": "arch-ctm"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "regular task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "message_id": "msg-002",
+            "acknowledgedAt": "2026-02-11T11:05:00Z"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    let assert = cmd
+        .env("ATM_TEAM", "test-team")
+        .arg("inbox")
+        .arg("clear")
+        .arg("test-agent")
+        .arg("--dry-run")
+        .arg("--json")
+        .assert()
+        .success();
+
+    let output: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("json output");
+    assert_eq!(output["removed_total"], 1);
+    assert_eq!(output["removed_idle_notifications"], 1);
+    assert_eq!(output["removed_acked_messages"], 0);
+    assert_eq!(output["remaining_total"], 1);
+
+    let inbox_path = team_dir.join("inboxes/test-agent.json");
+    let content = fs::read_to_string(&inbox_path).unwrap();
+    let persisted: Vec<serde_json::Value> = serde_json::from_str(&content).unwrap();
+    assert_eq!(persisted.len(), 2, "dry-run must not mutate the inbox");
+}
+
+#[test]
+fn test_inbox_clear_removes_idle_acked_and_old_messages() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "daemon",
+            "text": "[AGENT STATE] arch-ctm is now idle",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": false,
+            "summary": "Agent arch-ctm → idle",
+            "message_id": "idle-001",
+            "type": "idle_notification",
+            "idleSender": "arch-ctm"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "old acknowledged task",
+            "timestamp": "2025-01-01T10:00:00Z",
+            "read": true,
+            "message_id": "msg-acked-old",
+            "acknowledgedAt": "2025-01-01T10:05:00Z"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "still relevant",
+            "timestamp": "2026-03-15T12:00:00Z",
+            "read": false,
+            "message_id": "msg-keep"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    let assert = cmd
+        .env("ATM_TEAM", "test-team")
+        .arg("inbox")
+        .arg("clear")
+        .arg("test-agent")
+        .arg("--acked")
+        .arg("--older-than")
+        .arg("30d")
+        .arg("--json")
+        .assert()
+        .success();
+
+    let output: serde_json::Value =
+        serde_json::from_slice(&assert.get_output().stdout).expect("json output");
+    assert_eq!(output["removed_total"], 2);
+    assert_eq!(output["removed_idle_notifications"], 1);
+    assert_eq!(output["removed_acked_messages"], 1);
+    assert_eq!(output["removed_older_than"], 2);
+    assert_eq!(output["remaining_total"], 1);
+
+    let inbox_path = team_dir.join("inboxes/test-agent.json");
+    let persisted: Vec<serde_json::Value> =
+        serde_json::from_str(&fs::read_to_string(&inbox_path).unwrap()).unwrap();
+    assert_eq!(persisted.len(), 1);
+    assert_eq!(persisted[0]["message_id"], "msg-keep");
+}

--- a/crates/atm/tests/integration_send.rs
+++ b/crates/atm/tests/integration_send.rs
@@ -281,6 +281,116 @@ fn start_fake_unknown_register_hint_daemon(home: &Path) -> Child {
 }
 
 #[cfg(unix)]
+fn write_fake_request_logging_daemon_script(home: &Path) -> PathBuf {
+    let script = home.join("fake-request-logging-daemon.py");
+    let body = r#"#!/usr/bin/env python3
+import json
+import os
+import signal
+import socket
+from pathlib import Path
+
+home = Path(os.environ["ATM_HOME"])
+daemon_dir = home / ".atm" / "daemon"
+daemon_dir.mkdir(parents=True, exist_ok=True)
+
+sock_path = daemon_dir / "atm-daemon.sock"
+pid_path = daemon_dir / "atm-daemon.pid"
+log_path = daemon_dir / "requests.jsonl"
+if sock_path.exists():
+    sock_path.unlink()
+pid_path.write_text(str(os.getpid()))
+
+running = True
+def _stop(_signum, _frame):
+    global running
+    running = False
+
+signal.signal(signal.SIGTERM, _stop)
+signal.signal(signal.SIGINT, _stop)
+
+srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+srv.bind(str(sock_path))
+srv.listen(16)
+srv.settimeout(0.2)
+
+while running:
+    try:
+        conn, _ = srv.accept()
+    except TimeoutError:
+        continue
+    except OSError:
+        break
+    with conn:
+        data = b""
+        while b"\n" not in data:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+        try:
+            req = json.loads(data.decode().strip() or "{}")
+        except Exception:
+            req = {}
+        with log_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(req) + "\n")
+
+        request_id = req.get("request_id", "req")
+        command = req.get("command", "")
+        payload = req.get("payload", {}) or {}
+        if command in ("session-query-team", "session-for-team"):
+            response_payload = {
+                "session_id": "live-session",
+                "process_id": os.getpid(),
+                "alive": True,
+                "runtime": "codex",
+                "agent": payload.get("name", "unknown"),
+                "team": payload.get("team", "unknown"),
+            }
+        elif command == "agent-state":
+            response_payload = {
+                "state": "idle",
+                "last_transition": "2026-02-11T10:00:00Z",
+            }
+        else:
+            response_payload = {}
+
+        resp = {
+            "version": 1,
+            "request_id": request_id,
+            "status": "ok",
+            "payload": response_payload,
+        }
+        conn.sendall((json.dumps(resp) + "\n").encode())
+
+try:
+    srv.close()
+finally:
+    try:
+        sock_path.unlink()
+    except FileNotFoundError:
+        pass
+    try:
+        pid_path.unlink()
+    except FileNotFoundError:
+        pass
+"#;
+    fs::write(&script, body).unwrap();
+    let mut perms = fs::metadata(&script).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&script, perms).unwrap();
+    script
+}
+
+#[cfg(unix)]
+fn start_fake_request_logging_daemon(home: &Path) -> (Child, PathBuf) {
+    let script = write_fake_request_logging_daemon_script(home);
+    let child = spawn_python_script(&script, home);
+    wait_for_daemon_socket(home);
+    (child, home.join(".atm/daemon/requests.jsonl"))
+}
+
+#[cfg(unix)]
 fn start_fake_claude_process(home: &Path) -> Child {
     let sleep_bin = Path::new("/bin/sleep");
     assert!(
@@ -1066,4 +1176,50 @@ fn test_send_warns_and_continues_when_register_hint_is_unsupported() {
     let _ = daemon.wait();
     let _ = fake_claude.kill();
     let _ = fake_claude.wait();
+}
+
+#[cfg(unix)]
+#[test]
+fn test_send_emits_post_send_idle_without_subscribe_side_effect() {
+    let temp_dir = TempDir::new().unwrap();
+    let _team_dir = setup_test_team(&temp_dir, "test-team");
+    let (mut daemon, request_log) = start_fake_request_logging_daemon(temp_dir.path());
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    cmd.env("ATM_TEAM", "test-team")
+        .env("ATM_RUNTIME", "codex")
+        .env("ATM_SESSION_ID", "codex-session-123")
+        .arg("send")
+        .arg("test-agent")
+        .arg("codex should return to idle")
+        .assert()
+        .success();
+
+    let requests: Vec<serde_json::Value> = fs::read_to_string(&request_log)
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+
+    let commands: Vec<&str> = requests
+        .iter()
+        .filter_map(|request| request["command"].as_str())
+        .collect();
+    assert!(
+        !commands.contains(&"subscribe"),
+        "send must not auto-subscribe sender to idle events; commands={commands:?}"
+    );
+    let hook_event = requests
+        .iter()
+        .find(|request| request["command"] == "hook-event")
+        .expect("post-send idle hook-event should be emitted");
+    assert_eq!(hook_event["payload"]["event"], "teammate_idle");
+    assert_eq!(hook_event["payload"]["agent"], "team-lead");
+    assert_eq!(hook_event["payload"]["team"], "test-team");
+    assert_eq!(hook_event["payload"]["session_id"], "codex-session-123");
+    assert_eq!(hook_event["payload"]["source"]["kind"], "agent_hook");
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
 }


### PR DESCRIPTION
## Summary

- Remove implicit send-time idle subscription side effects from `atm send`
- Add automatic post-send idle lifecycle transition for non-Claude agents
- Dedupe/suppress idle notifications at write time (one per sender, replace not append)
- Add `atm inbox clear` subcommand with `--acked`, `--older-than`, `--idle-only`, `--dry-run`, `--json`
- New test coverage for inbox clear and idle-suppression behaviors

## Phase BA Sprint 1

Fixes: #932, #933

CI: cargo clippy --all-targets -- -D warnings PASS; cargo test --workspace PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)