### PR TITLE
feat(BA.2): queue semantics + atomic ack workflow

### DIFF
--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -1,26 +1,36 @@
 use agent_team_mail_core::config::{ConfigOverrides, resolve_config};
 use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
-use anyhow::Result;
+use agent_team_mail_core::io::atomic::atomic_swap;
+use agent_team_mail_core::io::error::InboxError;
+use agent_team_mail_core::io::lock::acquire_lock;
+use agent_team_mail_core::schema::{InboxMessage, TeamConfig};
+use agent_team_mail_core::text::{DEFAULT_MAX_MESSAGE_BYTES, validate_message_text};
+use anyhow::{Context, Result};
 use chrono::Utc;
 use clap::Args;
-use std::collections::HashSet;
+use std::collections::HashMap;
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use uuid::Uuid;
 
+use crate::commands::send::generate_summary;
+use crate::util::addressing::parse_address;
 use crate::util::hook_identity::read_hook_file_identity;
-use crate::util::settings::get_home_dir;
+use crate::util::settings::{get_home_dir, teams_root_dir_for};
 
-/// Acknowledge previously-read ATM messages as actioned/completed.
+/// Acknowledge a single ATM task message and send a visible reply atomically.
 #[derive(Args, Debug)]
 pub struct AckArgs {
-    /// Message IDs to acknowledge in your own inbox
-    message_ids: Vec<String>,
+    /// Message ID to acknowledge in your own inbox
+    message_id: String,
+
+    /// Visible reply to send back to the original sender
+    reply: String,
 
     /// Override default team
     #[arg(long)]
     team: Option<String>,
-
-    /// Acknowledge all pending messages in your own inbox
-    #[arg(long)]
-    all_pending: bool,
 
     /// Override reader identity (default: hook file → ATM_IDENTITY → .atm.toml → reject)
     #[arg(long = "as", value_name = "NAME")]
@@ -32,6 +42,12 @@ pub struct AckArgs {
 }
 
 pub fn execute(args: AckArgs) -> Result<()> {
+    if args.reply.trim().is_empty() {
+        anyhow::bail!("Reply text cannot be empty");
+    }
+    validate_message_text(&args.reply, DEFAULT_MAX_MESSAGE_BYTES)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+
     let home_dir = get_home_dir()?;
     let current_dir = std::env::current_dir()?;
     let overrides = ConfigOverrides {
@@ -58,47 +74,112 @@ pub fn execute(args: AckArgs) -> Result<()> {
         }
     }
 
-    if !args.all_pending && args.message_ids.is_empty() {
-        anyhow::bail!("Provide at least one message ID or use --all-pending");
-    }
-
     let team_name = config.core.default_team.clone();
     let agent_name = config.core.identity.clone();
-    let team_dir = home_dir.join(".claude/teams").join(&team_name);
+    let teams_root = teams_root_dir_for(&home_dir);
+    let team_dir = teams_root.join(&team_name);
     let inbox_path = team_dir.join("inboxes").join(format!("{agent_name}.json"));
 
     if !inbox_path.exists() {
         anyhow::bail!("Inbox not found for {agent_name}@{team_name}");
     }
 
-    let ids: HashSet<String> = args.message_ids.iter().cloned().collect();
-    let acknowledged_at = Utc::now().to_rfc3339();
-    let mut matched = 0usize;
-    let mut changed = 0usize;
+    let (source_exists, source_original_bytes, mut source_messages) =
+        load_inbox_messages(&inbox_path)
+            .with_context(|| format!("load {agent_name}@{team_name}"))?;
 
-    agent_team_mail_core::io::inbox::inbox_update(&inbox_path, &team_name, &agent_name, |msgs| {
-        for msg in msgs.iter_mut() {
-            let selected = if args.all_pending {
-                msg.is_pending_action()
-            } else {
-                msg.message_id
-                    .as_ref()
-                    .is_some_and(|message_id| ids.contains(message_id))
-            };
+    let source_message = source_messages
+        .iter()
+        .find(|message| message.message_id.as_deref() == Some(args.message_id.as_str()))
+        .cloned()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Message ID {} not found in {agent_name}@{team_name}",
+                args.message_id
+            )
+        })?;
 
-            if selected {
-                matched += 1;
-                if !msg.is_acknowledged() {
-                    msg.read = true;
-                    msg.mark_acknowledged(acknowledged_at.clone());
-                    changed += 1;
-                }
-            }
-        }
-    })?;
+    if source_message.is_acknowledged() {
+        anyhow::bail!("Message {} is already acknowledged", args.message_id);
+    }
 
-    if !args.all_pending && matched == 0 {
-        anyhow::bail!("No matching message IDs found in {agent_name}@{team_name}");
+    let (target_agent, target_team) =
+        resolve_reply_target(&source_message, &team_name).context("resolve reply target")?;
+    let target_team_dir = teams_root.join(&target_team);
+    if !target_team_dir.exists() {
+        anyhow::bail!("Reply target team '{target_team}' not found");
+    }
+    let target_config_path = target_team_dir.join("config.json");
+    if !target_config_path.exists() {
+        anyhow::bail!("Reply target team config not found at {target_config_path:?}");
+    }
+
+    let target_config: TeamConfig =
+        serde_json::from_str(&fs::read_to_string(&target_config_path)?)?;
+    if !target_config
+        .members
+        .iter()
+        .any(|member| member.name == target_agent)
+    {
+        anyhow::bail!("Reply target '{target_agent}' not found in team '{target_team}'");
+    }
+
+    let target_inbox_path = target_team_dir
+        .join("inboxes")
+        .join(format!("{target_agent}.json"));
+    if let Some(parent) = target_inbox_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let (target_exists, target_original_bytes, mut target_messages) =
+        load_inbox_messages(&target_inbox_path)
+            .with_context(|| format!("load {target_agent}@{target_team}"))?;
+
+    let source_lock_path = inbox_path.with_extension("lock");
+    let target_lock_path = target_inbox_path.with_extension("lock");
+    if source_lock_path <= target_lock_path {
+        let _source_lock = acquire_lock(&source_lock_path, 5)?;
+        let _target_lock = if target_lock_path != source_lock_path {
+            Some(acquire_lock(&target_lock_path, 5)?)
+        } else {
+            None
+        };
+        apply_ack_transaction(
+            &inbox_path,
+            source_exists,
+            &source_original_bytes,
+            &mut source_messages,
+            &args.message_id,
+            &target_inbox_path,
+            target_exists,
+            &target_original_bytes,
+            &mut target_messages,
+            build_reply_message(
+                agent_name.clone(),
+                team_name.clone(),
+                args.reply.clone(),
+                args.message_id.clone(),
+            ),
+        )?;
+    } else {
+        let _target_lock = acquire_lock(&target_lock_path, 5)?;
+        let _source_lock = acquire_lock(&source_lock_path, 5)?;
+        apply_ack_transaction(
+            &inbox_path,
+            source_exists,
+            &source_original_bytes,
+            &mut source_messages,
+            &args.message_id,
+            &target_inbox_path,
+            target_exists,
+            &target_original_bytes,
+            &mut target_messages,
+            build_reply_message(
+                agent_name.clone(),
+                team_name.clone(),
+                args.reply.clone(),
+                args.message_id.clone(),
+            ),
+        )?;
     }
 
     emit_event_best_effort(EventFields {
@@ -110,7 +191,9 @@ pub fn execute(args: AckArgs) -> Result<()> {
         agent_id: Some(agent_name.clone()),
         agent_name: Some(agent_name.clone()),
         result: Some("ok".to_string()),
-        count: Some(changed as u64),
+        message_id: Some(args.message_id.clone()),
+        target: Some(format!("{target_agent}@{target_team}")),
+        message_text: Some(args.reply.clone()),
         ..Default::default()
     });
 
@@ -121,18 +204,181 @@ pub fn execute(args: AckArgs) -> Result<()> {
                 "action": "ack",
                 "team": team_name,
                 "agent": agent_name,
-                "matched": matched,
-                "acknowledged": changed,
-                "allPending": args.all_pending,
+                "message_id": args.message_id,
+                "reply_sent": true,
+                "reply_target": format!("{target_agent}@{target_team}"),
             }))?
         );
-    } else if args.all_pending {
-        println!("Acknowledged {changed} pending message(s) for {agent_name}@{team_name}");
     } else {
         println!(
-            "Acknowledged {changed} of {matched} selected message(s) for {agent_name}@{team_name}"
+            "Acknowledged {} for {}@{} and sent reply to {}@{}",
+            args.message_id, agent_name, team_name, target_agent, target_team
         );
     }
 
+    Ok(())
+}
+
+fn resolve_reply_target(message: &InboxMessage, current_team: &str) -> Result<(String, String)> {
+    let fallback_team = message
+        .source_team
+        .clone()
+        .unwrap_or_else(|| current_team.to_string());
+    let (agent, team) = parse_address(&message.from, &Some(fallback_team), current_team)?;
+    Ok((agent, team))
+}
+
+fn build_reply_message(
+    from: String,
+    source_team: String,
+    text: String,
+    acked_message_id: String,
+) -> InboxMessage {
+    let mut unknown_fields = HashMap::new();
+    unknown_fields.insert(
+        "acknowledgesMessageId".to_string(),
+        serde_json::Value::String(acked_message_id),
+    );
+
+    InboxMessage {
+        from,
+        source_team: Some(source_team),
+        text: text.clone(),
+        timestamp: Utc::now().to_rfc3339(),
+        read: false,
+        summary: Some(generate_summary(&text)),
+        message_id: Some(Uuid::new_v4().to_string()),
+        unknown_fields,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn apply_ack_transaction(
+    source_inbox_path: &Path,
+    source_exists: bool,
+    source_original_bytes: &[u8],
+    source_messages: &mut [InboxMessage],
+    source_message_id: &str,
+    target_inbox_path: &Path,
+    target_exists: bool,
+    target_original_bytes: &[u8],
+    target_messages: &mut Vec<InboxMessage>,
+    reply_message: InboxMessage,
+) -> Result<()> {
+    let acknowledged_at = Utc::now().to_rfc3339();
+
+    let source_entry = source_messages
+        .iter_mut()
+        .find(|message| message.message_id.as_deref() == Some(source_message_id))
+        .ok_or_else(|| anyhow::anyhow!("Message {source_message_id} disappeared during ack"))?;
+    source_entry.read = true;
+    source_entry.mark_acknowledged(acknowledged_at);
+
+    if source_inbox_path == target_inbox_path {
+        let source_vec = source_messages
+            .iter()
+            .cloned()
+            .chain(std::iter::once(reply_message))
+            .collect::<Vec<_>>();
+        persist_inbox_atomic(
+            source_inbox_path,
+            source_exists,
+            source_original_bytes,
+            &source_vec,
+        )?;
+        return Ok(());
+    }
+
+    target_messages.push(reply_message);
+    let source_vec = source_messages.to_vec();
+
+    persist_inbox_atomic(
+        target_inbox_path,
+        target_exists,
+        target_original_bytes,
+        target_messages,
+    )?;
+
+    if let Err(error) = persist_inbox_atomic(
+        source_inbox_path,
+        source_exists,
+        source_original_bytes,
+        &source_vec,
+    ) {
+        let _ = restore_inbox(target_inbox_path, target_exists, target_original_bytes);
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+fn load_inbox_messages(path: &Path) -> Result<(bool, Vec<u8>, Vec<InboxMessage>)> {
+    if !path.exists() {
+        return Ok((false, b"[]".to_vec(), Vec::new()));
+    }
+
+    let bytes = fs::read(path).map_err(|source| InboxError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    let messages =
+        serde_json::from_slice::<Vec<InboxMessage>>(&bytes).map_err(|source| InboxError::Json {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    Ok((true, bytes, messages))
+}
+
+fn persist_inbox_atomic(
+    path: &Path,
+    path_exists: bool,
+    _original_bytes: &[u8],
+    messages: &[InboxMessage],
+) -> Result<()> {
+    let tmp_path = path.with_extension("acktmp");
+    let content = serde_json::to_vec_pretty(messages)?;
+    write_synced_file(&tmp_path, &content)?;
+
+    if path_exists {
+        atomic_swap(path, &tmp_path)?;
+        let _ = fs::remove_file(&tmp_path);
+    } else {
+        fs::rename(&tmp_path, path).map_err(|source| InboxError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+
+    Ok(())
+}
+
+fn restore_inbox(path: &Path, path_exists: bool, original_bytes: &[u8]) -> Result<()> {
+    if path_exists {
+        let rollback_path = path.with_extension("rollback");
+        write_synced_file(&rollback_path, original_bytes)?;
+        atomic_swap(path, &rollback_path)?;
+        let _ = fs::remove_file(&rollback_path);
+    } else if path.exists() {
+        fs::remove_file(path).map_err(|source| InboxError::Io {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    }
+    Ok(())
+}
+
+fn write_synced_file(path: &Path, content: &[u8]) -> Result<()> {
+    let mut file = fs::File::create(path).map_err(|source| InboxError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    file.write_all(content).map_err(|source| InboxError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    file.sync_all().map_err(|source| InboxError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
     Ok(())
 }

--- a/crates/atm/src/commands/ack.rs
+++ b/crates/atm/src/commands/ack.rs
@@ -335,7 +335,7 @@ fn persist_inbox_atomic(
     _original_bytes: &[u8],
     messages: &[InboxMessage],
 ) -> Result<()> {
-    let tmp_path = path.with_extension("acktmp");
+    let tmp_path = path.with_extension("json.tmp");
     let content = serde_json::to_vec_pretty(messages)?;
     write_synced_file(&tmp_path, &content)?;
 
@@ -354,7 +354,7 @@ fn persist_inbox_atomic(
 
 fn restore_inbox(path: &Path, path_exists: bool, original_bytes: &[u8]) -> Result<()> {
     if path_exists {
-        let rollback_path = path.with_extension("rollback");
+        let rollback_path = path.with_extension("json.rollback");
         write_synced_file(&rollback_path, original_bytes)?;
         atomic_swap(path, &rollback_path)?;
         let _ = fs::remove_file(&rollback_path);

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -2,7 +2,7 @@
 
 use agent_team_mail_core::config::{ConfigOverrides, resolve_config, resolve_identity};
 use agent_team_mail_core::event_log::{EventFields, emit_event_best_effort};
-use agent_team_mail_core::schema::TeamConfig;
+use agent_team_mail_core::schema::{InboxMessage, TeamConfig};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use clap::{ArgAction, Args};
@@ -17,9 +17,9 @@ use super::wait::{WaitResult, wait_for_message};
 
 /// Read messages from an inbox
 ///
-/// By default, shows pending-action messages from your own inbox and marks them as read.
-/// Messages remain pending until explicitly acknowledged with `atm ack`.
-/// Use --no-mark to read without marking, or --all to include already-acknowledged messages.
+/// By default, shows unread and pending-ack queue items from your own inbox and
+/// collapses history to a count line. Messages remain pending until explicitly
+/// acknowledged with `atm ack <message-id> "<reply>"`.
 #[derive(Args, Debug)]
 pub struct ReadArgs {
     /// Target agent (name or name@team), omit to read own inbox
@@ -29,19 +29,31 @@ pub struct ReadArgs {
     #[arg(long)]
     team: Option<String>,
 
-    /// Show all messages (not just pending-action messages)
+    /// Show all messages, including history
     #[arg(long)]
     all: bool,
+
+    /// Show only unread messages
+    #[arg(long, conflicts_with_all = ["pending_ack_only", "history", "all"])]
+    unread_only: bool,
+
+    /// Show only read-but-pending-ack messages
+    #[arg(long, conflicts_with_all = ["unread_only", "history", "all"])]
+    pending_ack_only: bool,
+
+    /// Show only historical messages (acknowledged or read-only)
+    #[arg(long, conflicts_with_all = ["unread_only", "pending_ack_only"])]
+    history: bool,
 
     /// Show messages since last seen (default: true)
     #[arg(long, default_value_t = true)]
     since_last_seen: bool,
 
-    /// Disable since-last-seen filtering
+    /// Disable since-last-seen filtering and watermark updates
     #[arg(long = "no-since-last-seen", action = ArgAction::SetTrue, overrides_with = "since_last_seen")]
     no_since_last_seen: bool,
 
-    /// Don't mark messages as read
+    /// Don't mark unread messages as read/pending-ack
     #[arg(long)]
     no_mark: bool,
 
@@ -49,7 +61,7 @@ pub struct ReadArgs {
     #[arg(long)]
     no_update_seen: bool,
 
-    /// Show only last N messages (`--count` accepted as compatibility alias)
+    /// Show only last N displayed messages (`--count` accepted as compatibility alias)
     #[arg(long, visible_alias = "count")]
     limit: Option<usize>,
 
@@ -76,7 +88,6 @@ pub struct ReadArgs {
 
 /// Execute the read command
 pub fn execute(args: ReadArgs) -> Result<()> {
-    // Resolve configuration
     let home_dir = get_home_dir()?;
     let current_dir = std::env::current_dir()?;
 
@@ -87,11 +98,6 @@ pub fn execute(args: ReadArgs) -> Result<()> {
 
     let mut config = resolve_config(&overrides, &current_dir, &home_dir)?;
 
-    // Identity resolution order:
-    // 1. --as <name> wins (explicit reader override)
-    // 2. hook file (when identity is still the default "human" sentinel)
-    // 3. ATM_IDENTITY / .atm.toml (already resolved to non-"human" in config)
-    // 4. Reject — no silent fallback
     if let Some(ref name) = args.reader_as {
         config.core.identity = name.clone();
     } else if config.core.identity == "human" {
@@ -117,7 +123,6 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         }
     }
 
-    // Determine agent and team
     let (agent_name, team_name) = if let Some(ref agent_addr) = args.agent {
         let (parsed_agent, parsed_team) =
             parse_address(agent_addr, &args.team, &config.core.default_team)?;
@@ -130,24 +135,22 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         }
         (resolved, parsed_team)
     } else {
-        // Read own inbox
         (
             config.core.identity.clone(),
             config.core.default_team.clone(),
         )
     };
+
     let caller_session_id =
         resolve_caller_session_id_optional(Some(&team_name), Some(&config.core.identity))
             .ok()
             .flatten();
 
-    // Resolve team directory
     let team_dir = teams_root_dir_for(&home_dir).join(&team_name);
     if !team_dir.exists() {
         anyhow::bail!("Team '{team_name}' not found (directory {team_dir:?} doesn't exist)");
     }
 
-    // Load team config to verify agent exists
     let team_config_path = team_dir.join("config.json");
     if !team_config_path.exists() {
         anyhow::bail!("Team config not found at {team_config_path:?}");
@@ -156,52 +159,30 @@ pub fn execute(args: ReadArgs) -> Result<()> {
     let team_config: TeamConfig =
         serde_json::from_str(&std::fs::read_to_string(&team_config_path)?)?;
 
-    // Verify target agent exists in team.
-    // For transient identities reading their own inbox (`atm read --as <name>`),
-    // remain fail-open and return an empty inbox instead of hard-failing.
     let agent_exists = team_config.members.iter().any(|m| m.name == agent_name);
     if !agent_exists && args.agent.is_some() {
         anyhow::bail!("Agent '{agent_name}' not found in team '{team_name}'");
     }
 
-    // Extract hostname registry from config (if bridge is configured)
     let hostname_registry = extract_hostname_registry(&config);
-
-    // Read inbox messages (merged from local + all origin files)
-    let messages = agent_team_mail_core::io::inbox::inbox_read_merged(
+    let mut filtered_messages = agent_team_mail_core::io::inbox::inbox_read_merged(
         &team_dir,
         &agent_name,
         hostname_registry.as_ref(),
     )?;
 
-    // Apply filters
-    let mut filtered_messages = messages.clone();
-
-    // Resolve last-seen state (if enabled)
     let use_since_last_seen = args.since_last_seen && !args.no_since_last_seen;
-    let last_seen = if use_since_last_seen && !args.all {
+    let last_seen = if use_since_last_seen {
         let state = load_seen_state().unwrap_or_default();
         get_last_seen(&state, &team_name, &agent_name)
     } else {
         None
     };
 
-    // Visibility filter:
-    // - Default mode: pending-action only (unacknowledged, whether read or unread)
-    // - Since-last-seen mode: pending-action OR newer-than-last-seen
-    apply_visibility_filter(
-        &mut filtered_messages,
-        args.all,
-        use_since_last_seen,
-        last_seen.as_ref(),
-    );
-
-    // Filter by sender
     if let Some(ref from_name) = args.from {
         filtered_messages.retain(|m| m.from == *from_name);
     }
 
-    // Filter by timestamp
     if let Some(ref since_ts) = args.since {
         let since_dt = DateTime::parse_from_rfc3339(since_ts)
             .map_err(|e| anyhow::anyhow!("Invalid timestamp format: {e}"))?;
@@ -214,19 +195,14 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         });
     }
 
-    // Apply limit
-    if let Some(limit) = args.limit {
-        let start = filtered_messages.len().saturating_sub(limit);
-        filtered_messages = filtered_messages[start..].to_vec();
-    }
+    let mut buckets = bucket_messages(filtered_messages.clone());
+    let mut displayed_messages = select_display_messages(&buckets, &args);
+    apply_limit(&mut displayed_messages, args.limit);
 
-    // If timeout specified and no messages found, wait for new messages
-    if filtered_messages.is_empty()
+    if displayed_messages.is_empty()
         && let Some(timeout_secs) = args.timeout
     {
         let inboxes_dir = team_dir.join("inboxes");
-
-        // Extract hostnames for bridge-synced messages
         let hostnames: Option<Vec<String>> = hostname_registry
             .as_ref()
             .map(|reg| reg.remotes().map(|r| r.hostname.clone()).collect());
@@ -235,22 +211,11 @@ pub fn execute(args: ReadArgs) -> Result<()> {
 
         match wait_for_message(&inboxes_dir, &agent_name, timeout_secs, hostnames.as_ref())? {
             WaitResult::MessageReceived => {
-                // Re-read messages and apply filters
-                let new_messages = agent_team_mail_core::io::inbox::inbox_read_merged(
+                let mut new_filtered = agent_team_mail_core::io::inbox::inbox_read_merged(
                     &team_dir,
                     &agent_name,
                     hostname_registry.as_ref(),
                 )?;
-
-                let mut new_filtered = new_messages.clone();
-
-                // Re-apply the same filters
-                apply_visibility_filter(
-                    &mut new_filtered,
-                    args.all,
-                    use_since_last_seen,
-                    last_seen.as_ref(),
-                );
 
                 if let Some(ref from_name) = args.from {
                     new_filtered.retain(|m| m.from == *from_name);
@@ -268,13 +233,10 @@ pub fn execute(args: ReadArgs) -> Result<()> {
                     });
                 }
 
-                if let Some(limit) = args.limit {
-                    let start = new_filtered.len().saturating_sub(limit);
-                    new_filtered = new_filtered[start..].to_vec();
-                }
-
-                // Use the new filtered messages
                 filtered_messages = new_filtered;
+                buckets = bucket_messages(filtered_messages.clone());
+                displayed_messages = select_display_messages(&buckets, &args);
+                apply_limit(&mut displayed_messages, args.limit);
             }
             WaitResult::Timeout => {
                 if args.json {
@@ -284,6 +246,11 @@ pub fn execute(args: ReadArgs) -> Result<()> {
                         "team": team_name,
                         "messages": [],
                         "count": 0,
+                        "bucket_counts": {
+                            "unread": 0,
+                            "pending_ack": 0,
+                            "history": 0,
+                        },
                         "timeout": true,
                     });
                     println!("{}", serde_json::to_string_pretty(&output)?);
@@ -306,29 +273,21 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         }
     }
 
-    // Determine the calling identity so we never touch another agent's read flags.
     let calling_identity = config.core.identity.clone();
-
-    // Mark messages as read (unless --no-mark specified)
-    // Only mark when the caller is reading their own inbox — peeking at another
-    // agent's inbox must never alter that agent's read state.
     let mut marked_count: u64 = 0;
-    if !args.no_mark && !filtered_messages.is_empty() && agent_name == calling_identity {
-        // Find message IDs that need to be marked
-        let filtered_ids: Vec<String> = filtered_messages
+    if !args.no_mark && !displayed_messages.is_empty() && agent_name == calling_identity {
+        let filtered_ids: Vec<String> = displayed_messages
             .iter()
+            .filter(|m| !m.read)
             .filter_map(|m| m.message_id.clone())
             .collect();
-
-        let filtered_timestamps: Vec<String> = filtered_messages
+        let filtered_timestamps: Vec<String> = displayed_messages
             .iter()
+            .filter(|m| !m.read)
             .map(|m| m.timestamp.clone())
             .collect();
-
         let pending_timestamp = Utc::now().to_rfc3339();
 
-        // Atomically update LOCAL inbox to mark messages as read
-        // Note: we only mark in the local inbox, not in origin files
         let local_inbox_path = team_dir.join("inboxes").join(format!("{agent_name}.json"));
         if local_inbox_path.exists() {
             agent_team_mail_core::io::inbox::inbox_update(
@@ -340,7 +299,6 @@ pub fn execute(args: ReadArgs) -> Result<()> {
                         let should_mark = if let Some(ref msg_id) = msg.message_id {
                             filtered_ids.contains(msg_id) && !msg.read
                         } else {
-                            // Fallback: match by timestamp
                             filtered_timestamps.contains(&msg.timestamp) && !msg.read
                         };
 
@@ -355,10 +313,9 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         }
     }
 
-    // Update last-seen state (unless disabled)
     if use_since_last_seen
         && !args.no_update_seen
-        && let Some(latest) = filtered_messages
+        && let Some(latest) = displayed_messages
             .iter()
             .filter_map(|m| DateTime::parse_from_rfc3339(&m.timestamp).ok())
             .max()
@@ -377,7 +334,7 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         agent_id: Some(agent_name.clone()),
         agent_name: Some(agent_name.clone()),
         result: Some("ok".to_string()),
-        count: Some(filtered_messages.len() as u64),
+        count: Some(displayed_messages.len() as u64),
         ..Default::default()
     });
     if marked_count > 0 {
@@ -395,46 +352,48 @@ pub fn execute(args: ReadArgs) -> Result<()> {
         });
     }
 
-    // Output results
     if args.json {
         let output = serde_json::json!({
             "action": "read",
             "agent": agent_name,
             "team": team_name,
-            "messages": filtered_messages,
-            "count": filtered_messages.len(),
+            "messages": displayed_messages,
+            "count": displayed_messages.len(),
+            "bucket_counts": {
+                "unread": buckets.unread.len(),
+                "pending_ack": buckets.pending_ack.len(),
+                "history": buckets.history.len(),
+            },
+            "history_collapsed": !args.history && !args.all,
         });
         println!("{}", serde_json::to_string_pretty(&output)?);
-    } else if filtered_messages.is_empty() {
+    } else if displayed_messages.is_empty() {
         println!("No messages found for {agent_name}@{team_name}");
     } else {
-        println!("Messages for {agent_name}@{team_name}:\n");
-        for msg in &filtered_messages {
-            let time_ago = format_relative_time(&msg.timestamp);
-            let summary = msg.summary.as_deref().unwrap_or("[no summary]");
-            let status = if msg.is_acknowledged() {
-                "[acknowledged]"
-            } else if msg.read {
-                if msg.is_pending_action() {
-                    "[read, pending ack]"
-                } else {
-                    "[read]"
-                }
-            } else {
-                "[unread, pending ack]"
-            };
+        println!("Queue for {agent_name}@{team_name}");
+        println!(
+            "Unread: {} | Pending Ack: {} | History: {}\n",
+            buckets.unread.len(),
+            buckets.pending_ack.len(),
+            buckets.history.len()
+        );
 
-            println!("From: {} | {} | {} {}", msg.from, time_ago, summary, status);
-            if msg.is_pending_action()
-                && let Some(message_id) = msg.message_id.as_deref()
-            {
-                println!("Message ID: {message_id}");
-            }
-            println!("{}\n", msg.text);
+        let bucket_views = display_bucket_views(&displayed_messages);
+        print_bucket("Unread", &bucket_views.unread);
+        print_bucket("Pending Ack", &bucket_views.pending_ack);
+        if args.history || args.all {
+            print_bucket("History", &bucket_views.history);
+        } else if !buckets.history.is_empty() {
+            println!(
+                "{} historical message(s) hidden (use --history to expand)\n",
+                buckets.history.len()
+            );
         }
-        println!("Total: {} message(s)", filtered_messages.len());
+
+        println!("Total displayed: {} message(s)", displayed_messages.len());
     }
 
+    let _ = last_seen;
     Ok(())
 }
 
@@ -461,31 +420,124 @@ fn format_relative_time(timestamp_str: &str) -> String {
     }
 }
 
-fn apply_visibility_filter(
-    messages: &mut Vec<agent_team_mail_core::schema::InboxMessage>,
-    show_all: bool,
-    use_since_last_seen: bool,
-    last_seen: Option<&DateTime<Utc>>,
-) {
-    if show_all {
+struct MessageBuckets {
+    unread: Vec<InboxMessage>,
+    pending_ack: Vec<InboxMessage>,
+    history: Vec<InboxMessage>,
+}
+
+struct DisplayBuckets {
+    unread: Vec<InboxMessage>,
+    pending_ack: Vec<InboxMessage>,
+    history: Vec<InboxMessage>,
+}
+
+fn bucket_messages(messages: Vec<InboxMessage>) -> MessageBuckets {
+    let mut buckets = MessageBuckets {
+        unread: Vec::new(),
+        pending_ack: Vec::new(),
+        history: Vec::new(),
+    };
+
+    for message in messages {
+        if !message.read {
+            buckets.unread.push(message);
+        } else if message.pending_ack_at().is_some() && !message.is_acknowledged() {
+            buckets.pending_ack.push(message);
+        } else {
+            buckets.history.push(message);
+        }
+    }
+
+    sort_bucket_newest_first(&mut buckets.unread);
+    sort_bucket_newest_first(&mut buckets.pending_ack);
+    sort_bucket_newest_first(&mut buckets.history);
+    buckets
+}
+
+fn sort_bucket_newest_first(messages: &mut [InboxMessage]) {
+    messages.sort_by(|a, b| {
+        b.timestamp.cmp(&a.timestamp).then_with(|| {
+            b.message_id
+                .as_deref()
+                .unwrap_or_default()
+                .cmp(a.message_id.as_deref().unwrap_or_default())
+        })
+    });
+}
+
+fn select_display_messages(buckets: &MessageBuckets, args: &ReadArgs) -> Vec<InboxMessage> {
+    let mut displayed = Vec::new();
+
+    if args.all || args.unread_only {
+        displayed.extend(buckets.unread.clone());
+    }
+    if args.all || args.pending_ack_only {
+        displayed.extend(buckets.pending_ack.clone());
+    }
+    if args.history || args.all {
+        displayed.extend(buckets.history.clone());
+    }
+    if !args.all && !args.unread_only && !args.pending_ack_only && !args.history {
+        displayed.extend(buckets.unread.clone());
+        displayed.extend(buckets.pending_ack.clone());
+    }
+
+    displayed
+}
+
+fn apply_limit(displayed_messages: &mut Vec<InboxMessage>, limit: Option<usize>) {
+    if let Some(limit) = limit {
+        displayed_messages.truncate(limit);
+    }
+}
+
+fn display_bucket_views(displayed_messages: &[InboxMessage]) -> DisplayBuckets {
+    let mut buckets = DisplayBuckets {
+        unread: Vec::new(),
+        pending_ack: Vec::new(),
+        history: Vec::new(),
+    };
+
+    for message in displayed_messages {
+        if !message.read {
+            buckets.unread.push(message.clone());
+        } else if message.pending_ack_at().is_some() && !message.is_acknowledged() {
+            buckets.pending_ack.push(message.clone());
+        } else {
+            buckets.history.push(message.clone());
+        }
+    }
+
+    buckets
+}
+
+fn print_bucket(name: &str, messages: &[InboxMessage]) {
+    if messages.is_empty() {
         return;
     }
 
-    if use_since_last_seen {
-        if let Some(last_seen_dt) = last_seen {
-            messages.retain(|m| {
-                m.is_pending_action()
-                    || DateTime::parse_from_rfc3339(&m.timestamp)
-                        .map(|dt| dt.with_timezone(&Utc) > *last_seen_dt)
-                        .unwrap_or(false)
-            });
+    println!("{name}:\n");
+    for msg in messages {
+        let time_ago = format_relative_time(&msg.timestamp);
+        let summary = msg.summary.as_deref().unwrap_or("[no summary]");
+        let status = if msg.is_acknowledged() {
+            "[acknowledged]"
+        } else if msg.read {
+            if msg.pending_ack_at().is_some() {
+                "[read, pending ack]"
+            } else {
+                "[read]"
+            }
         } else {
-            // First run with no watermark should show actionable work, not dump
-            // the full historical inbox.
-            messages.retain(|m| m.is_pending_action());
+            "[unread]"
+        };
+
+        println!("From: {} | {} | {} {}", msg.from, time_ago, summary, status);
+        if let Some(message_id) = msg.message_id.as_deref() {
+            println!("Message ID: {message_id}");
         }
-    } else {
-        messages.retain(|m| m.is_pending_action());
+        println!("{}\n", msg.text);
     }
 }
 
@@ -497,24 +549,19 @@ fn extract_hostname_registry(
 ) -> Option<agent_team_mail_core::config::HostnameRegistry> {
     use agent_team_mail_core::config::BridgeConfig;
 
-    // Check if bridge plugin config exists
     let bridge_table = config.plugins.get("bridge")?;
-
-    // Parse bridge config
     let bridge_config: BridgeConfig = match bridge_table.clone().try_into() {
         Ok(cfg) => cfg,
         Err(_) => return None,
     };
 
-    // Check if bridge is enabled
     if !bridge_config.enabled {
         return None;
     }
 
-    // Build hostname registry from remotes
     let mut registry = agent_team_mail_core::config::HostnameRegistry::new();
     for remote in bridge_config.remotes {
-        let _ = registry.register(remote); // Ignore errors
+        let _ = registry.register(remote);
     }
 
     Some(registry)
@@ -526,7 +573,6 @@ mod tests {
 
     #[test]
     fn test_format_relative_time_seconds() {
-        // Note: This test is approximate and may be flaky
         let now = Utc::now();
         let ts = now - chrono::Duration::seconds(30);
         let formatted = format_relative_time(&ts.to_rfc3339());

--- a/crates/atm/src/commands/read.rs
+++ b/crates/atm/src/commands/read.rs
@@ -426,11 +426,7 @@ struct MessageBuckets {
     history: Vec<InboxMessage>,
 }
 
-struct DisplayBuckets {
-    unread: Vec<InboxMessage>,
-    pending_ack: Vec<InboxMessage>,
-    history: Vec<InboxMessage>,
-}
+type DisplayBuckets = MessageBuckets;
 
 fn bucket_messages(messages: Vec<InboxMessage>) -> MessageBuckets {
     let mut buckets = MessageBuckets {
@@ -469,18 +465,20 @@ fn sort_bucket_newest_first(messages: &mut [InboxMessage]) {
 fn select_display_messages(buckets: &MessageBuckets, args: &ReadArgs) -> Vec<InboxMessage> {
     let mut displayed = Vec::new();
 
-    if args.all || args.unread_only {
+    if args.unread_only {
         displayed.extend(buckets.unread.clone());
+        return displayed;
     }
-    if args.all || args.pending_ack_only {
+
+    if args.pending_ack_only {
         displayed.extend(buckets.pending_ack.clone());
+        return displayed;
     }
+
+    displayed.extend(buckets.unread.clone());
+    displayed.extend(buckets.pending_ack.clone());
     if args.history || args.all {
         displayed.extend(buckets.history.clone());
-    }
-    if !args.all && !args.unread_only && !args.pending_ack_only && !args.history {
-        displayed.extend(buckets.unread.clone());
-        displayed.extend(buckets.pending_ack.clone());
     }
 
     displayed
@@ -493,23 +491,7 @@ fn apply_limit(displayed_messages: &mut Vec<InboxMessage>, limit: Option<usize>)
 }
 
 fn display_bucket_views(displayed_messages: &[InboxMessage]) -> DisplayBuckets {
-    let mut buckets = DisplayBuckets {
-        unread: Vec::new(),
-        pending_ack: Vec::new(),
-        history: Vec::new(),
-    };
-
-    for message in displayed_messages {
-        if !message.read {
-            buckets.unread.push(message.clone());
-        } else if message.pending_ack_at().is_some() && !message.is_acknowledged() {
-            buckets.pending_ack.push(message.clone());
-        } else {
-            buckets.history.push(message.clone());
-        }
-    }
-
-    buckets
+    bucket_messages(displayed_messages.to_vec())
 }
 
 fn print_bucket(name: &str, messages: &[InboxMessage]) {
@@ -570,6 +552,32 @@ fn extract_hostname_registry(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
+
+    fn inbox_message(
+        message_id: &str,
+        timestamp: &str,
+        read: bool,
+        pending_ack: bool,
+    ) -> InboxMessage {
+        let mut unknown_fields = HashMap::new();
+        if pending_ack {
+            unknown_fields.insert(
+                "pendingAckAt".to_string(),
+                serde_json::Value::String("2026-02-11T11:05:00Z".to_string()),
+            );
+        }
+        InboxMessage {
+            from: "team-lead".to_string(),
+            source_team: None,
+            text: format!("message {message_id}"),
+            timestamp: timestamp.to_string(),
+            read,
+            summary: None,
+            message_id: Some(message_id.to_string()),
+            unknown_fields,
+        }
+    }
 
     #[test]
     fn test_format_relative_time_seconds() {
@@ -607,5 +615,62 @@ mod tests {
     fn test_format_relative_time_invalid() {
         let formatted = format_relative_time("invalid-timestamp");
         assert_eq!(formatted, "unknown");
+    }
+
+    #[test]
+    fn sort_bucket_newest_first_orders_by_timestamp_then_message_id_desc() {
+        let mut messages = vec![
+            inbox_message("msg-001", "2026-02-11T10:00:00Z", false, false),
+            inbox_message("msg-003", "2026-02-11T11:00:00Z", false, false),
+            inbox_message("msg-002", "2026-02-11T11:00:00Z", false, false),
+        ];
+
+        sort_bucket_newest_first(&mut messages);
+
+        let ids: Vec<&str> = messages
+            .iter()
+            .map(|message| message.message_id.as_deref().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["msg-003", "msg-002", "msg-001"]);
+    }
+
+    #[test]
+    fn history_flag_expands_active_view_instead_of_filtering() {
+        let buckets = MessageBuckets {
+            unread: vec![inbox_message(
+                "msg-u1",
+                "2026-02-11T12:00:00Z",
+                false,
+                false,
+            )],
+            pending_ack: vec![inbox_message("msg-p1", "2026-02-11T11:00:00Z", true, true)],
+            history: vec![inbox_message("msg-h1", "2026-02-11T10:00:00Z", true, false)],
+        };
+
+        let args = ReadArgs {
+            agent: None,
+            team: None,
+            all: false,
+            unread_only: false,
+            pending_ack_only: false,
+            history: true,
+            since_last_seen: false,
+            no_since_last_seen: true,
+            no_mark: true,
+            no_update_seen: true,
+            limit: None,
+            since: None,
+            from: None,
+            json: false,
+            timeout: None,
+            reader_as: None,
+        };
+
+        let displayed = select_display_messages(&buckets, &args);
+        let ids: Vec<&str> = displayed
+            .iter()
+            .map(|message| message.message_id.as_deref().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["msg-u1", "msg-p1", "msg-h1"]);
     }
 }

--- a/crates/atm/src/commands/send.rs
+++ b/crates/atm/src/commands/send.rs
@@ -543,7 +543,7 @@ where
 }
 
 /// Generate summary from message text (first ~100 chars)
-fn generate_summary(text: &str) -> String {
+pub(crate) fn generate_summary(text: &str) -> String {
     let trimmed = text.trim();
     if trimmed.chars().count() <= MESSAGE_MAX_LEN {
         trimmed.to_string()

--- a/crates/atm/tests/integration_conflict_tests.rs
+++ b/crates/atm/tests/integration_conflict_tests.rs
@@ -676,8 +676,9 @@ fn test_read_skips_malformed_records_and_legacy_content_alias() {
     let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let messages = parsed["messages"].as_array().expect("messages array");
     assert_eq!(messages.len(), 2);
-    assert_eq!(messages[0]["text"], "good");
-    assert_eq!(messages[1]["text"], "legacy content");
+    assert_eq!(messages[0]["text"], "legacy content");
+    assert_eq!(messages[1]["text"], "good");
+    assert_eq!(parsed["bucket_counts"]["unread"], 2);
     assert_eq!(messages[1]["read"], false);
 }
 

--- a/crates/atm/tests/integration_read.rs
+++ b/crates/atm/tests/integration_read.rs
@@ -208,7 +208,7 @@ fn test_read_default_buckets_hide_history() {
 }
 
 #[test]
-fn test_read_history_filter_shows_history_only() {
+fn test_read_history_expands_active_view_with_full_history() {
     let temp_dir = TempDir::new().unwrap();
     let team_dir = setup_test_team(&temp_dir, "test-team");
 
@@ -248,8 +248,98 @@ fn test_read_history_filter_shows_history_only() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Historical note"))
+        .stdout(predicate::str::contains("Unread task"))
+        .stdout(predicate::str::contains("Pending task"));
+}
+
+#[test]
+fn test_read_unread_only_filter_shows_only_unread_bucket() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Unread task",
+            "timestamp": "2026-02-11T12:00:00Z",
+            "read": false,
+            "message_id": "msg-u1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Pending task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "pendingAckAt": "2026-02-11T11:05:00Z",
+            "message_id": "msg-p1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Historical note",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": true,
+            "message_id": "msg-h1"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("read")
+        .arg("--no-since-last-seen")
+        .arg("--unread-only")
+        .arg("test-agent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Unread task"))
+        .stdout(predicate::str::contains("Pending task").not())
+        .stdout(predicate::str::contains("Historical note").not());
+}
+
+#[test]
+fn test_read_pending_ack_only_filter_shows_only_pending_ack_bucket() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Unread task",
+            "timestamp": "2026-02-11T12:00:00Z",
+            "read": false,
+            "message_id": "msg-u1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Pending task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "pendingAckAt": "2026-02-11T11:05:00Z",
+            "message_id": "msg-p1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Historical note",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": true,
+            "message_id": "msg-h1"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("read")
+        .arg("--no-since-last-seen")
+        .arg("--pending-ack-only")
+        .arg("test-agent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Pending task"))
         .stdout(predicate::str::contains("Unread task").not())
-        .stdout(predicate::str::contains("Pending task").not());
+        .stdout(predicate::str::contains("Historical note").not());
 }
 
 #[test]

--- a/crates/atm/tests/integration_read.rs
+++ b/crates/atm/tests/integration_read.rs
@@ -159,6 +159,153 @@ fn test_read_all_messages() {
 }
 
 #[test]
+fn test_read_default_buckets_hide_history() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Unread task",
+            "timestamp": "2026-02-11T12:00:00Z",
+            "read": false,
+            "message_id": "msg-u1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Pending task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "pendingAckAt": "2026-02-11T11:05:00Z",
+            "message_id": "msg-p1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Historical note",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": true,
+            "message_id": "msg-h1"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("read")
+        .arg("--no-since-last-seen")
+        .arg("test-agent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Queue for test-agent@test-team"))
+        .stdout(predicate::str::contains(
+            "Unread: 1 | Pending Ack: 1 | History: 1",
+        ))
+        .stdout(predicate::str::contains("Unread task"))
+        .stdout(predicate::str::contains("Pending task"))
+        .stdout(predicate::str::contains("Historical note").not())
+        .stdout(predicate::str::contains("1 historical message(s) hidden"));
+}
+
+#[test]
+fn test_read_history_filter_shows_history_only() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Unread task",
+            "timestamp": "2026-02-11T12:00:00Z",
+            "read": false,
+            "message_id": "msg-u1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Pending task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "pendingAckAt": "2026-02-11T11:05:00Z",
+            "message_id": "msg-p1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Historical note",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": true,
+            "message_id": "msg-h1"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("read")
+        .arg("--no-since-last-seen")
+        .arg("--history")
+        .arg("test-agent")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Historical note"))
+        .stdout(predicate::str::contains("Unread task").not())
+        .stdout(predicate::str::contains("Pending task").not());
+}
+
+#[test]
+fn test_read_json_reports_bucket_counts() {
+    let temp_dir = TempDir::new().unwrap();
+    let team_dir = setup_test_team(&temp_dir, "test-team");
+
+    let messages = vec![
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Unread task",
+            "timestamp": "2026-02-11T12:00:00Z",
+            "read": false,
+            "message_id": "msg-u1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Pending task",
+            "timestamp": "2026-02-11T11:00:00Z",
+            "read": true,
+            "pendingAckAt": "2026-02-11T11:05:00Z",
+            "message_id": "msg-p1"
+        }),
+        serde_json::json!({
+            "from": "team-lead",
+            "text": "Historical note",
+            "timestamp": "2026-02-11T10:00:00Z",
+            "read": true,
+            "message_id": "msg-h1"
+        }),
+    ];
+    create_test_inbox(&team_dir, "test-agent", messages);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir);
+    let output = cmd
+        .env("ATM_TEAM", "test-team")
+        .arg("read")
+        .arg("--no-since-last-seen")
+        .arg("--json")
+        .arg("test-agent")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["bucket_counts"]["unread"], 1);
+    assert_eq!(json["bucket_counts"]["pending_ack"], 1);
+    assert_eq!(json["bucket_counts"]["history"], 1);
+    assert_eq!(json["history_collapsed"], true);
+    assert_eq!(json["count"], 2);
+}
+
+#[test]
 fn test_read_no_mark() {
     let temp_dir = TempDir::new().unwrap();
     let team_dir = setup_test_team(&temp_dir, "test-team");
@@ -267,9 +414,12 @@ fn test_read_keeps_message_visible_until_acknowledged() {
         .env("ATM_IDENTITY", "test-agent")
         .arg("ack")
         .arg("msg-001")
+        .arg("Acknowledged and working it now.")
         .assert()
         .success()
-        .stdout(predicate::str::contains("Acknowledged 1 of 1 selected"));
+        .stdout(predicate::str::contains(
+            "Acknowledged msg-001 for test-agent@test-team and sent reply to team-lead@test-team",
+        ));
 
     let inbox_path = team_dir.join("inboxes/test-agent.json");
     let content = fs::read_to_string(&inbox_path).unwrap();
@@ -277,6 +427,17 @@ fn test_read_keeps_message_visible_until_acknowledged() {
     assert_eq!(messages[0]["read"], true);
     assert!(messages[0]["acknowledgedAt"].is_string());
     assert!(messages[0].get("pendingAckAt").is_none());
+
+    let lead_inbox_path = team_dir.join("inboxes/team-lead.json");
+    let lead_content = fs::read_to_string(&lead_inbox_path).unwrap();
+    let lead_messages: Vec<serde_json::Value> = serde_json::from_str(&lead_content).unwrap();
+    assert_eq!(lead_messages.len(), 1);
+    assert_eq!(lead_messages[0]["from"], "test-agent");
+    assert_eq!(lead_messages[0]["text"], "Acknowledged and working it now.");
+    assert_eq!(
+        lead_messages[0]["acknowledgesMessageId"],
+        serde_json::Value::String("msg-001".to_string())
+    );
 
     let mut final_read = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut final_read, &temp_dir);
@@ -292,69 +453,39 @@ fn test_read_keeps_message_visible_until_acknowledged() {
 }
 
 #[test]
-fn test_ack_all_pending_clears_all_pending_messages() {
+fn test_ack_uses_source_team_for_cross_team_reply() {
     let temp_dir = TempDir::new().unwrap();
-    let team_dir = setup_test_team(&temp_dir, "test-team");
+    let src_team_dir = setup_test_team(&temp_dir, "src-team");
+    let dst_team_dir = setup_test_team(&temp_dir, "dst-team");
 
-    let messages = vec![
-        serde_json::json!({
-            "from": "team-lead",
-            "text": "Pending task one",
-            "timestamp": "2026-02-11T10:00:00Z",
-            "read": true,
-            "pendingAckAt": "2026-02-11T10:05:00Z",
-            "message_id": "msg-201"
-        }),
-        serde_json::json!({
-            "from": "team-lead",
-            "text": "Pending task two",
-            "timestamp": "2026-02-11T11:00:00Z",
-            "read": false,
-            "message_id": "msg-202"
-        }),
-        serde_json::json!({
-            "from": "team-lead",
-            "text": "Already acknowledged",
-            "timestamp": "2026-02-11T12:00:00Z",
-            "read": true,
-            "acknowledgedAt": "2026-02-11T12:05:00Z",
-            "message_id": "msg-203"
-        }),
-    ];
-    create_test_inbox(&team_dir, "test-agent", messages);
+    let cross_team_messages = vec![serde_json::json!({
+        "from": "team-lead",
+        "source_team": "src-team",
+        "text": "Cross-team task",
+        "timestamp": "2026-02-11T10:00:00Z",
+        "read": false,
+        "message_id": "msg-cross-1"
+    })];
+    create_test_inbox(&dst_team_dir, "test-agent", cross_team_messages);
 
     let mut ack = cargo::cargo_bin_cmd!("atm");
     set_home_env(&mut ack, &temp_dir);
-    ack.env("ATM_TEAM", "test-team")
+    ack.env("ATM_TEAM", "dst-team")
         .env("ATM_IDENTITY", "test-agent")
         .arg("ack")
-        .arg("--all-pending")
+        .arg("msg-cross-1")
+        .arg("Cross-team reply")
         .assert()
         .success()
-        .stdout(predicate::str::contains(
-            "Acknowledged 2 pending message(s)",
-        ));
+        .stdout(predicate::str::contains("sent reply to team-lead@src-team"));
 
-    let inbox_path = team_dir.join("inboxes/test-agent.json");
-    let content = fs::read_to_string(&inbox_path).unwrap();
-    let messages: Vec<serde_json::Value> = serde_json::from_str(&content).unwrap();
-
-    assert!(messages[0]["acknowledgedAt"].is_string());
-    assert!(messages[0].get("pendingAckAt").is_none());
-    assert!(messages[1]["acknowledgedAt"].is_string());
-    assert!(messages[1].get("pendingAckAt").is_none());
-    assert_eq!(messages[2]["acknowledgedAt"], "2026-02-11T12:05:00Z");
-
-    let mut read = cargo::cargo_bin_cmd!("atm");
-    set_home_env(&mut read, &temp_dir);
-    read.env("ATM_TEAM", "test-team")
-        .env("ATM_IDENTITY", "test-agent")
-        .arg("read")
-        .arg("--no-since-last-seen")
-        .arg("test-agent")
-        .assert()
-        .success()
-        .stdout(predicate::str::contains("No messages found"));
+    let src_inbox_path = src_team_dir.join("inboxes/team-lead.json");
+    let src_content = fs::read_to_string(&src_inbox_path).unwrap();
+    let src_messages: Vec<serde_json::Value> = serde_json::from_str(&src_content).unwrap();
+    assert_eq!(src_messages.len(), 1);
+    assert_eq!(src_messages[0]["from"], "test-agent");
+    assert_eq!(src_messages[0]["source_team"], "dst-team");
+    assert_eq!(src_messages[0]["text"], "Cross-team reply");
 }
 
 #[test]
@@ -621,16 +752,15 @@ fn test_read_since_last_seen_default() {
         .arg("test-agent")
         .assert()
         .success()
-        .stdout(predicates::str::contains("New message"))
-        .stdout(predicates::str::contains("Old message").not());
+        .stdout(predicates::str::contains("No messages found"));
 
-    // Verify last-seen updated to latest message
+    // Pure history no longer appears in the default queue view, so last-seen remains unchanged.
     let updated = fs::read_to_string(&state_path).unwrap();
     let updated_json: serde_json::Value = serde_json::from_str(&updated).unwrap();
     let ts = updated_json["last_seen"]["test-team"]["test-agent"]
         .as_str()
         .unwrap();
-    assert!(ts.starts_with("2026-02-11T11:00:00"));
+    assert!(ts.starts_with("2026-02-11T10:30:00"));
 }
 
 #[test]
@@ -804,6 +934,7 @@ fn test_read_no_update_seen() {
     cmd.env("ATM_TEAM", "test-team")
         .arg("read")
         .arg("test-agent")
+        .arg("--history")
         .arg("--no-update-seen")
         .assert()
         .success()
@@ -860,6 +991,7 @@ fn test_read_updates_last_seen_from_displayed_messages_only() {
     cmd.env("ATM_TEAM", "test-team")
         .arg("read")
         .arg("test-agent")
+        .arg("--history")
         .arg("--from")
         .arg("team-lead")
         .assert()

--- a/crates/atm/tests/integration_read_timeout.rs
+++ b/crates/atm/tests/integration_read_timeout.rs
@@ -381,5 +381,6 @@ fn test_read_timeout_with_explicit_agent_overrides_default_identity() {
     cmd.assert()
         .success()
         .stdout(predicate::str::contains("message for explicit target"))
-        .stdout(predicate::str::contains("Messages for arch-ctm@test-team"));
+        .stdout(predicate::str::contains("Queue for arch-ctm@test-team"))
+        .stdout(predicate::str::contains("Unread: 1 | Pending Ack: 0 | History: 0"));
 }

--- a/crates/atm/tests/integration_read_timeout.rs
+++ b/crates/atm/tests/integration_read_timeout.rs
@@ -382,5 +382,7 @@ fn test_read_timeout_with_explicit_agent_overrides_default_identity() {
         .success()
         .stdout(predicate::str::contains("message for explicit target"))
         .stdout(predicate::str::contains("Queue for arch-ctm@test-team"))
-        .stdout(predicate::str::contains("Unread: 1 | Pending Ack: 0 | History: 0"));
+        .stdout(predicate::str::contains(
+            "Unread: 1 | Pending Ack: 0 | History: 0",
+        ));
 }

--- a/docs/agent-team-api.md
+++ b/docs/agent-team-api.md
@@ -1100,7 +1100,7 @@ Approve or reject agent's implementation plan.
 | `read` | Set to `true` immediately when the receiving agent process is **running** at delivery time (regardless of busy/idle state). Set to `false` when the recipient is **offline** (process not running). NOT a reliable indicator the agent has processed or acted on the message. | Both |
 | `message_id` | UUID for ATM CLI messages (`atm send`). `null` for Claude Code `SendMessage` tool messages. | ATM CLI only |
 | `pendingAckAt` | Set by `atm read` when the ATM CLI agent reads a message. Not set by Claude Code's file watcher or `SendMessage` tool. Messages delivered while the agent is offline remain `null`. | ATM CLI only |
-| `acknowledgedAt` | Set when the agent explicitly acknowledges the message (`atm ack <message_id>` for CLI agents). Claude Code `SendMessage` agents currently do not appear to set this field via any observed mechanism. | ATM CLI only |
+| `acknowledgedAt` | Set when the agent explicitly acknowledges the message (`atm ack <message_id> "<reply>"` for CLI agents). Claude Code `SendMessage` agents currently do not appear to set this field via any observed mechanism. | ATM CLI only |
 | `summary` | Optional 5–10 word preview. `null` for system/idle messages. | Both |
 | `source_team` | Team name from which the message was routed. `null` on many messages. | ATM CLI |
 
@@ -1110,7 +1110,7 @@ Approve or reject agent's implementation plan.
 Delivery   → read: true (running) or false (offline), pendingAckAt: null, acknowledgedAt: null
               ↓ (agent runs atm read)
 Pending    → read: true, pendingAckAt: <timestamp>, acknowledgedAt: null
-              ↓ (agent runs atm ack <message_id>)
+              ↓ (agent runs atm ack <message_id> "<reply>")
 Acked      → read: true, pendingAckAt: null, acknowledgedAt: <timestamp>
 ```
 


### PR DESCRIPTION
## Summary
- Bucketed `atm read` output: unread / pending-ack / history with newest-first ordering
- History collapsed by default; `--history` flag to expand
- Summary header + JSON bucket counts (`--json`)
- New flags: `--unread-only`, `--pending-ack-only`
- `atm ack <message-id> "<reply>"` — atomic message-bound acknowledgement with compensated transaction (local ack state + visible reply send); cross-team routing via `source_team`

Closes #927, #928, #929, #930, #931

## Test plan
- [ ] `cargo test --workspace` passes
- [ ] CI green on integrate/phase-BA base
- [ ] QA: arch-qa-agent + atm-qa-agent via quality-mgr

🤖 Generated with [Claude Code](https://claude.com/claude-code)