### PR TITLE
feat(BA.4): boundary enforcement + plugin availability UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,16 @@ jobs:
       - name: Enforce ARCH-BOUNDARY-002
         run: bash scripts/ci/observability_boundary_check.sh
 
+  cli-boundary:
+    name: cli-boundary (ubuntu)
+    needs: [fmt]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enforce CLI boundary
+        run: bash scripts/ci/cli_boundary_check.sh
+
   core-isolation:
     name: core-isolation (${{ matrix.os }})
     needs: [clippy]

--- a/crates/atm/Cargo.toml
+++ b/crates/atm/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 
 [dependencies]
 agent-team-mail-core.workspace = true
+# BA.4 classification: permitted CLI dependency for canonical launcher lifecycle ownership.
 agent-team-mail-daemon-launch.workspace = true
 sc-composer.workspace = true
 sc-observability.workspace = true

--- a/crates/atm/src/commands/gh.rs
+++ b/crates/atm/src/commands/gh.rs
@@ -267,6 +267,7 @@ struct GhNamespaceStatus {
     config_source: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     config_path: Option<String>,
+    namespace_state: &'static str,
     lifecycle_state: String,
     availability_state: String,
     in_flight: u64,
@@ -298,6 +299,23 @@ struct GhNamespaceStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
     owner_poll_interval_secs: Option<u64>,
     actions: Vec<&'static str>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GhNamespaceState {
+    Absent,
+    PresentDisabled,
+    PresentEnabled,
+}
+
+impl GhNamespaceState {
+    fn as_str(self) -> &'static str {
+        match self {
+            GhNamespaceState::Absent => "absent",
+            GhNamespaceState::PresentDisabled => "present_disabled",
+            GhNamespaceState::PresentEnabled => "present_enabled",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1277,6 +1295,7 @@ fn print_namespace_status(health: &GhMonitorHealth, json: bool) -> Result<()> {
     println!("Team:              {}", status.team);
     println!("Configured:        {}", yes_no(status.configured));
     println!("Enabled:           {}", yes_no(status.enabled));
+    println!("Namespace State:   {}", status.namespace_state);
     if let Some(source) = status.config_source.as_deref() {
         println!("Config Source:     {source}");
     }
@@ -1331,12 +1350,14 @@ fn print_namespace_status(health: &GhMonitorHealth, json: bool) -> Result<()> {
 }
 
 fn namespace_status_view(health: &GhMonitorHealth) -> GhNamespaceStatus {
+    let namespace_state = namespace_state_for_health(health);
     GhNamespaceStatus {
         team: health.team.clone(),
         configured: health.configured,
         enabled: health.enabled,
         config_source: health.config_source.clone(),
         config_path: health.config_path.clone(),
+        namespace_state: namespace_state.as_str(),
         lifecycle_state: health.lifecycle_state.clone(),
         availability_state: health.availability_state.clone(),
         in_flight: health.in_flight,
@@ -1354,13 +1375,30 @@ fn namespace_status_view(health: &GhMonitorHealth) -> GhNamespaceStatus {
         owner_atm_home: health.owner_atm_home.clone(),
         owner_repo: health.owner_repo.clone(),
         owner_poll_interval_secs: health.owner_poll_interval_secs,
-        actions: namespace_actions(health.enabled && health.configured),
+        actions: namespace_actions(namespace_state),
     }
 }
 
-fn namespace_actions(enabled: bool) -> Vec<&'static str> {
-    if enabled {
-        vec![
+fn namespace_state_for_health(health: &GhMonitorHealth) -> GhNamespaceState {
+    if !health.configured {
+        GhNamespaceState::Absent
+    } else if health.enabled && health.availability_state != "disabled_config_error" {
+        GhNamespaceState::PresentEnabled
+    } else {
+        GhNamespaceState::PresentDisabled
+    }
+}
+
+fn namespace_actions(state: GhNamespaceState) -> Vec<&'static str> {
+    match state {
+        GhNamespaceState::Absent => vec!["atm gh init"],
+        GhNamespaceState::PresentDisabled => vec![
+            "atm gh",
+            "atm gh init",
+            "atm gh status",
+            "atm gh monitor status",
+        ],
+        GhNamespaceState::PresentEnabled => vec![
             "atm gh",
             "atm gh status",
             "atm gh status <pr|workflow|run> <target>",
@@ -1372,9 +1410,7 @@ fn namespace_actions(enabled: bool) -> Vec<&'static str> {
             "atm gh pr init-report [--output <path>]",
             "atm gh monitor start|stop|restart|status",
             "atm gh init",
-        ]
-    } else {
-        vec!["atm gh", "atm gh init"]
+        ],
     }
 }
 

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -1306,9 +1306,21 @@ fn test_gh_namespace_status_missing_repo_is_actionable() {
         status["availability_state"].as_str(),
         Some("disabled_config_error")
     );
+    assert_eq!(status["namespace_state"].as_str(), Some("present_disabled"));
     let message = status["message"].as_str().unwrap_or_default();
     assert!(message.contains("missing required field: repo"));
     assert!(message.contains("atm gh init"));
+    let actions = status["actions"].as_array().unwrap();
+    assert!(
+        actions
+            .iter()
+            .any(|value| value.as_str() == Some("atm gh init"))
+    );
+    assert!(
+        actions
+            .iter()
+            .all(|value| value.as_str() != Some("atm gh monitor pr <number>"))
+    );
 
     let _ = daemon.kill();
     let _ = daemon.wait();
@@ -1411,6 +1423,7 @@ fn test_gh_monitor_status_json_has_stable_schema() {
         "team",
         "configured",
         "enabled",
+        "namespace_state",
         "lifecycle_state",
         "availability_state",
         "in_flight",
@@ -1420,6 +1433,69 @@ fn test_gh_monitor_status_json_has_stable_schema() {
         assert!(json.get(key).is_some(), "missing key: {key}");
     }
     assert!(json["actions"].is_array());
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+}
+
+#[test]
+#[cfg(unix)]
+fn test_gh_namespace_absent_only_advertises_init() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_test_team(&temp_dir, "test-team");
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir, "test-team", false);
+    let output = cmd
+        .env("ATM_TEAM", "test-team")
+        .arg("gh")
+        .arg("--team")
+        .arg("test-team")
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["namespace_state"].as_str(), Some("absent"));
+    assert_eq!(json["actions"], serde_json::json!(["atm gh init"]));
+}
+
+#[test]
+#[cfg(unix)]
+#[serial]
+fn test_gh_namespace_enabled_advertises_full_command_surface() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_test_team(&temp_dir, "test-team");
+    let mut daemon = start_fake_gh_daemon(temp_dir.path());
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir, "test-team", true);
+    let output = cmd
+        .env("ATM_TEAM", "test-team")
+        .arg("gh")
+        .arg("--team")
+        .arg("test-team")
+        .arg("--json")
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value = serde_json::from_slice(&output).unwrap();
+    assert_eq!(json["namespace_state"].as_str(), Some("present_enabled"));
+    let actions = json["actions"].as_array().unwrap();
+    assert!(
+        actions
+            .iter()
+            .any(|value| value.as_str() == Some("atm gh pr list"))
+    );
+    assert!(
+        actions
+            .iter()
+            .any(|value| value.as_str() == Some("atm gh monitor pr <number>"))
+    );
 
     let _ = daemon.kill();
     let _ = daemon.wait();

--- a/crates/atm/tests/integration_read_timeout.rs
+++ b/crates/atm/tests/integration_read_timeout.rs
@@ -382,5 +382,7 @@ fn test_read_timeout_with_explicit_agent_overrides_default_identity() {
         .success()
         .stdout(predicate::str::contains("message for explicit target"))
         .stdout(predicate::str::contains("Queue for arch-ctm@test-team"))
-        .stdout(predicate::str::contains("Unread: 1 | Pending Ack: 0 | History: 0"));
+        .stdout(predicate::str::contains(
+            "Unread: 1 | Pending Ack: 0 | History: 0",
+        ));
 }

--- a/docs/cli/architecture.md
+++ b/docs/cli/architecture.md
@@ -105,6 +105,8 @@ For `atm gh` specifically:
   appear
 - if it is enabled, the CLI may present the full namespace while still routing
   execution through neutral plugin contracts
+- the CLI root/status surface should expose the effective namespace state
+  explicitly as `absent`, `present_disabled`, or `present_enabled`
 
 ## 5. Inbox and Task-Queue Architecture
 
@@ -143,35 +145,42 @@ Target flow:
 2. CLI performs one atomic `ack + reply`
 3. shared inbox state and visible conversation remain in sync
 
-## 6. Current Violations
+## 6. Current Boundary Status
 
-The current codebase does not yet meet the target architecture:
+BA.3 removed the direct CLI coupling that originally motivated Phase BA:
 
-### 6.1 CLI -> Plugin Coupling
+- `crates/atm/src/commands/gh.rs` no longer imports daemon plugin
+  implementation helpers directly
+- `crates/atm/src/commands/doctor.rs` no longer imports direct
+  `agent_team_mail_ci_monitor` GH helper blocks
+- `crates/atm/src/main.rs` now uses the neutral `atm-core` teardown hook
+- `crates/atm/Cargo.toml` no longer carries non-dev dependencies on
+  `agent-team-mail-daemon` or `agent-team-mail-ci-monitor`
 
-- `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
-  directly from `agent_team_mail_daemon::plugins::ci_monitor`
-- `crates/atm/src/commands/doctor.rs` imports a direct
-  `agent_team_mail_ci_monitor` helper block for GH observer/ledger state
-- `crates/atm/src/commands/doctor.rs` imports a daemon-plugin-owned helper for
-  GitHub execution
-- `crates/atm/src/main.rs` directly calls
-  `agent_team_mail_ci_monitor::flush_gh_observability_records()` on shutdown
+BA.4 is therefore an enforcement/UX sprint rather than another extraction
+sprint.
 
-### 6.2 Crate Dependency Coupling
+### 6.1 Remaining Explicit Exception
 
-`crates/atm/Cargo.toml` currently carries non-dev dependencies on:
+`crates/atm/Cargo.toml` still carries:
 
-- `agent-team-mail-ci-monitor`
-- `agent-team-mail-daemon`
 - `agent-team-mail-daemon-launch`
 
-That means the CLI crate is compiled against plugin-host and plugin-specific
-implementation crates rather than purely neutral contracts.
+This is the one permitted CLI/product dependency for canonical launcher
+lifecycle ownership. BA.4 must keep that classification explicit in both docs
+and manifest comments.
+
+### 6.2 Enforcement Gap
+
+Without a dedicated CLI boundary gate, the CLI could still regress by:
+
+- reintroducing `agent_team_mail_daemon::plugins::*` imports
+- reintroducing `agent_team_mail_ci_monitor::*` imports
+- re-adding forbidden runtime dependencies to `crates/atm/Cargo.toml`
 
 ## 7. Recommended Boundary Repair
 
-Phase BA should repair the CLI boundary in two sprints:
+Phase BA repairs the boundary in two sprints:
 
 ### BA.3 — Command Boundary Extraction
 
@@ -189,15 +198,13 @@ Phase BA should repair the CLI boundary in two sprints:
 
 ### BA.4 — Boundary Enforcement and UX
 
-- demote `agent-team-mail-daemon` and `agent-team-mail-ci-monitor` from
-  non-dev `crates/atm/Cargo.toml` dependencies after BA.3 so the compiler
-  enforces the boundary
+- keep `agent-team-mail-daemon` and `agent-team-mail-ci-monitor` absent from
+  non-dev `crates/atm/Cargo.toml`
 - wire plugin namespace availability from capability descriptors
 - add CI checks that forbid new CLI imports from daemon plugin modules
 - keep a secondary grep/lint gate as belt-and-suspenders after dep demotion
-- explicitly classify `agent-team-mail-daemon-launch` as either:
-  - a permitted CLI dependency for canonical launcher lifecycle wiring
-  - or a follow-on boundary violation to remove
+- explicitly classify `agent-team-mail-daemon-launch` as a permitted CLI
+  dependency for canonical launcher lifecycle wiring
 - document the absent/present/enabled plugin command states
 
 ## 8. Architectural Direction for Cross-Team Commands

--- a/docs/cli/requirements.md
+++ b/docs/cli/requirements.md
@@ -40,12 +40,17 @@ daemon-spawn, and plugin-specific subsystem contracts.
 - If the plugin is present but not enabled, only bootstrap/management commands
   may appear.
 - If the plugin is present and enabled, the full namespace may appear.
+- Plugin root/status UX must surface the effective namespace state explicitly.
 
 For the GitHub monitor stack specifically:
 
 - the gh plugin/provider layer owns GitHub command semantics
 - the CLI may route `atm gh ...` but must not directly depend on daemon plugin
   implementation modules to do so
+- the CLI-advertised namespace states are:
+  - `absent`
+  - `present_disabled`
+  - `present_enabled`
 
 ### 2.3 CLI Boundary Rules
 
@@ -136,32 +141,21 @@ For the GitHub monitor stack specifically:
 
 ## 5. Current Boundary Findings Driving Phase BA
 
-The current codebase still contains CLI/plugin coupling that Phase BA must
-remove:
+Phase AT closed the GitHub-behavior boundary (raw `gh` execution ownership).
+Phase BA addresses the remaining CLI boundary gap.
 
-- `crates/atm/Cargo.toml` has non-dev dependencies on
-  `agent-team-mail-ci-monitor`, `agent-team-mail-daemon`, and
-  `agent-team-mail-daemon-launch`
-- `crates/atm/src/commands/gh.rs` imports
-  `agent_team_mail_daemon::plugins::ci_monitor::*`
-- `crates/atm/src/commands/doctor.rs` imports a direct
-  `agent_team_mail_ci_monitor` helper block for GH observer/ledger functions:
-  `GhCliObserverContext`, `RateLimitUpdate`, `emit_gh_info_denied`,
-  `emit_gh_info_live_refresh`, `emit_gh_info_requested`,
-  `emit_gh_info_served_from_cache`, `gh_repo_state_cache_age_secs`,
-  `new_gh_execution_call_id`, `new_gh_info_request_id`, `read_gh_repo_state`,
-  `update_gh_repo_state_rate_limit`
-- `crates/atm/src/commands/doctor.rs` imports the daemon-plugin-owned helper
-  `run_attributed_gh_command_with_ids`
-- `crates/atm/src/main.rs` directly calls
-  `agent_team_mail_ci_monitor::flush_gh_observability_records()` during CLI
-  teardown
-- Phase AT closed the GitHub-behavior boundary (raw `gh` execution ownership)
-  but did not remove these CLI-to-plugin implementation couplings. BA therefore
-  addresses a post-AT boundary gap, not a reopening of AT’s completed raw-`gh`
-  elimination scope.
+- BA.3 removed direct non-dev CLI dependencies on
+  `agent-team-mail-daemon` and `agent-team-mail-ci-monitor`.
+- BA.3 removed direct CLI imports of daemon plugin implementation helpers and
+  moved the GH contract plus teardown hook behind `atm-core::gh_command`.
+- BA.4 must keep that cleanup enforced so the CLI cannot regress back to daemon
+  plugin implementation imports or forbidden manifest dependencies.
+- `agent-team-mail-daemon-launch` remains a permitted CLI dependency for
+  canonical launcher lifecycle ownership. Its allowed status must stay explicit
+  in docs and manifest comments rather than becoming an implicit exception.
 
-These are boundary violations against the target command-ownership model above.
+These are enforcement requirements against the target command-ownership model
+above.
 
 ## 6. Phase BA Implementation Targets
 
@@ -174,11 +168,10 @@ These are boundary violations against the target command-ownership model above.
   - `gh` namespace command request/response contracts
   - any permitted CLI teardown lifecycle hook such as ledger flush
 - BA.4: CLI boundary enforcement + plugin availability UX, with:
-  - primary enforcement by demoting `agent-team-mail-daemon` and
-    `agent-team-mail-ci-monitor` from non-dev `crates/atm/Cargo.toml`
-    dependencies once BA.3 lands
+  - primary enforcement by keeping `agent-team-mail-daemon` and
+    `agent-team-mail-ci-monitor` absent from non-dev `crates/atm/Cargo.toml`
   - secondary CI grep/lint forbidding new CLI imports from daemon plugin
     implementation modules
-  - explicit treatment of `agent-team-mail-daemon-launch` as either a permitted
-    CLI lifecycle dependency or a follow-on removal target; BA may not leave its
+  - explicit treatment of `agent-team-mail-daemon-launch` as a permitted CLI
+    lifecycle dependency for canonical launcher ownership; BA may not leave its
     status implicit

--- a/docs/phase-ba-cli-message-boundary-planning.md
+++ b/docs/phase-ba-cli-message-boundary-planning.md
@@ -32,21 +32,21 @@ Current dogfood issues fall into two linked groups:
 
 ### CLI boundary problems
 
-- `crates/atm/Cargo.toml` depends directly on `agent-team-mail-daemon` and
-  `agent-team-mail-ci-monitor`
-- `crates/atm/src/commands/gh.rs` imports daemon plugin implementation helpers
-- `crates/atm/src/commands/doctor.rs` imports both:
+- before BA.3, `crates/atm/Cargo.toml` depended directly on
+  `agent-team-mail-daemon` and `agent-team-mail-ci-monitor`
+- before BA.3, `crates/atm/src/commands/gh.rs` imported daemon plugin
+  implementation helpers
+- before BA.3, `crates/atm/src/commands/doctor.rs` imported both:
   - a direct `agent_team_mail_ci_monitor` helper block for GH observer/ledger
     state
   - a plugin-owned GitHub execution helper from
     `agent_team_mail_daemon::plugins::ci_monitor`
-- `crates/atm/src/main.rs` directly calls
+- before BA.3, `crates/atm/src/main.rs` directly called
   `agent_team_mail_ci_monitor::flush_gh_observability_records()`
 - plugin command ownership is blurred: the CLI effectively implements plugin
   behavior instead of routing through plugin capability contracts
-- `agent-team-mail-daemon-launch` is also a current CLI dependency and must be
-  classified explicitly during BA.3/BA.4 rather than left as an implicit
-  exception
+- `agent-team-mail-daemon-launch` remains a current CLI dependency and must be
+  classified explicitly during BA.4 rather than left as an implicit exception
 
 ### Scope clarification vs Phase AT
 
@@ -168,6 +168,8 @@ BA.4.
 - direct CLI dependency on plugin implementation crates is removed or reduced to
   neutral contract crates only
 - `atm gh` no longer depends on daemon plugin implementation helpers
+- `crates/atm/Cargo.toml` no longer depends on `agent-team-mail-daemon` or
+  `agent-team-mail-ci-monitor`
 
 ## BA.4 — Boundary Enforcement + Plugin Availability UX
 
@@ -177,12 +179,11 @@ BA.4.
 - absent / present-disabled / present-enabled UX rules for plugin commands
 - primary boundary gate: demote `agent-team-mail-daemon` and
   `agent-team-mail-ci-monitor` from non-dev dependencies in `crates/atm/Cargo.toml`
-  after BA.3 lands
+  must remain in force after BA.3 lands
 - secondary CI/lint gate that forbids new CLI imports from daemon plugin modules
 - docs/tests for plugin command availability and boundary enforcement
-- explicit classification of `agent-team-mail-daemon-launch` as either:
-  - permitted CLI dependency for canonical launcher lifecycle ownership
-  - or follow-on removal target
+- explicit classification of `agent-team-mail-daemon-launch` as a permitted CLI
+  dependency for canonical launcher lifecycle ownership
 
 **Acceptance**:
 

--- a/scripts/ci/cli_boundary_check.sh
+++ b/scripts/ci/cli_boundary_check.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ATM_MANIFEST="$ROOT/crates/atm/Cargo.toml"
+
+declare -a matches=()
+
+while IFS= read -r match; do
+  [[ -z "$match" ]] && continue
+  matches+=("$match")
+done < <(grep -nH -E '^[[:space:]]*agent-team-mail-(daemon|ci-monitor)(\.workspace|[[:space:]]*=)' "$ATM_MANIFEST" || true)
+
+while IFS= read -r match; do
+  [[ -z "$match" ]] && continue
+  matches+=("$match")
+done < <(grep -RInE 'agent_team_mail_daemon::plugins::|agent_team_mail_ci_monitor::' "$ROOT/crates/atm/src" --include='*.rs' || true)
+
+fail=0
+for match in "${matches[@]-}"; do
+  [[ -z "$match" ]] && continue
+  rel="${match#"$ROOT"/}"
+  file="${rel%%:*}"
+  rest="${rel#*:}"
+  line="${rest%%:*}"
+  echo "::error file=$file,line=$line::CLI-BOUNDARY violation: $rel"
+  fail=1
+done
+
+if [[ "$fail" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "CLI-BOUNDARY check passed."


### PR DESCRIPTION
## Summary
- Capability-advertised plugin namespace model: `absent` / `present_disabled` / `present_enabled` states for all plugin commands
- New CLI boundary gate: `scripts/ci/cli_boundary_check.sh` — fails if CLI reintroduces daemon-plugin implementation imports
- `agent-team-mail-daemon-launch` explicitly classified as permitted CLI dependency for canonical launcher lifecycle ownership
- Plugin command availability documented and tested

## Acceptance
- Plugin namespaces shown according to capability state, not hard-coded implementation ownership ✓
- CI fails if CLI reintroduces daemon-plugin implementation imports ✓
- Dependency gate explicit, not implied ✓
- `agent-team-mail-daemon-launch` classified ✓
- CLI availability model documented and tested ✓

## Test plan
- [ ] `bash scripts/ci/cli_boundary_check.sh` passes
- [ ] `cargo test --workspace` passes
- [ ] CI green on integrate/phase-BA base
- [ ] QA: arch-qa-agent + atm-qa-agent via quality-mgr

🤖 Generated with [Claude Code](https://claude.com/claude-code)