### PR TITLE
docs: Phase BB daemon reset plan

### DIFF
--- a/docs/daemon/architecture.md
+++ b/docs/daemon/architecture.md
@@ -1,0 +1,73 @@
+# ATM Daemon Reset Architecture
+
+**Version**: 0.1
+**Date**: 2026-03-20
+**Status**: PLANNED
+
+## 1. Target Architecture
+
+The reset architecture is intentionally smaller than the current daemon model.
+
+### 1.1 Roots
+
+- **Config root**: stable team/config location, independent of `ATM_HOME`
+- **Runtime root**: daemon socket, lock, status, logs, and other runtime files
+
+`ATM_HOME` controls the runtime root only.
+
+### 1.2 Ownership Model
+
+- One system daemon per user account
+- One lock-metadata file as the ownership source of truth
+- One status snapshot as the health source of truth
+
+No per-home shared-daemon arbitration. No runtime-kind-specific daemon
+ownership model.
+
+### 1.3 Startup Contract
+
+The daemon startup sequence must be:
+
+1. resolve config root and runtime root,
+2. validate admission,
+3. acquire canonical lock,
+4. initialize the minimal required runtime endpoints,
+5. publish lock/status only after readiness is established.
+
+If startup fails before readiness, the daemon must leave no state that implies a
+live daemon is available.
+
+### 1.4 Shutdown Contract
+
+Shutdown and restart must clean up the same runtime artifacts that startup owns.
+The design must not require callers to infer daemon health from partial,
+leftover files.
+
+## 2. Explicit Deletion Targets
+
+The reset architecture assumes removal or collapse of these current concepts:
+
+- multi-daemon runtime kinds (`release`, `dev`, `isolated`) as daemon ownership
+  modes
+- config lookup under `ATM_HOME/.claude`
+- `daemon-touch.json` as a competing ownership sidecar
+- separate PID-file ownership as a required source of truth
+- multi-home daemon identity replacement heuristics
+
+## 3. Transitional Strategy
+
+The reset should be implemented by introducing a smaller canonical path and then
+deleting legacy behavior quickly:
+
+1. add explicit config-root/runtime-root APIs,
+2. move callers to the new APIs,
+3. collapse runtime artifact set,
+4. remove legacy multi-daemon logic,
+5. rewrite tests to the single-daemon model,
+6. delete the obsolete code and documentation.
+
+## 4. Architectural Rule
+
+Any daemon change during the reset must make the subsystem smaller, simpler, or
+more deterministic. Changes that add branches, modes, runtime artifacts, or
+compatibility layers are out of scope for the reset.

--- a/docs/daemon/architecture.md
+++ b/docs/daemon/architecture.md
@@ -3,6 +3,8 @@
 **Version**: 0.1
 **Date**: 2026-03-20
 **Status**: PLANNED
+**Supersedes**: pre-BB daemon/runtime architecture assumptions in
+`docs/requirements.md` and `docs/project-plan.md`
 
 ## 1. Target Architecture
 
@@ -10,7 +12,8 @@ The reset architecture is intentionally smaller than the current daemon model.
 
 ### 1.1 Roots
 
-- **Config root**: stable team/config location, independent of `ATM_HOME`
+- **Config root**: `~/.claude`
+- **Team state root**: `~/.claude/teams`
 - **Runtime root**: daemon socket, lock, status, logs, and other runtime files
 
 `ATM_HOME` controls the runtime root only.
@@ -65,6 +68,22 @@ deleting legacy behavior quickly:
 4. remove legacy multi-daemon logic,
 5. rewrite tests to the single-daemon model,
 6. delete the obsolete code and documentation.
+
+BB sequencing is serial:
+
+- `BB.1 -> BB.2 -> BB.3 -> BB.4`
+
+Additional implementation constraints discovered during planning:
+
+- `BB.1` must inventory and migrate the existing path-root call sites in
+  `atm-core`, `atm-daemon`, and daemon plugin initialization before `BB.2`
+  begins.
+- `BB.2` changes span `atm-core`, `atm-daemon`, and `atm-daemon-launch`
+  together; there is no safe partial rollout.
+- `BB.3` must include the schema migration note for `RuntimeOwnerMetadata` in
+  `status.json`.
+- `BB.3` may not land on the integration branch without the BB.4 compatibility
+  work required by PID-file removal and daemon test rewrites.
 
 ## 4. Architectural Rule
 

--- a/docs/daemon/requirements.md
+++ b/docs/daemon/requirements.md
@@ -3,6 +3,8 @@
 **Version**: 0.1
 **Date**: 2026-03-20
 **Status**: PLANNED
+**Supersedes**: pre-BB multi-daemon/runtime-splitting assumptions in
+`docs/requirements.md` and `docs/project-plan.md`
 
 This document defines the simplified daemon requirements that supersede the
 current multi-daemon/runtime-splitting model.
@@ -29,6 +31,8 @@ not directly serve the remaining requirements.
 - `ATM_HOME` is a runtime-state root only.
 - Team configuration must resolve from one stable config root independent of
   daemon runtime state.
+- The canonical config root is `~/.claude`.
+- The canonical team-state root is `~/.claude/teams`.
 
 ### 2.3 Minimal Daemon Responsibilities
 

--- a/docs/daemon/requirements.md
+++ b/docs/daemon/requirements.md
@@ -1,0 +1,109 @@
+# ATM Daemon Reset Requirements
+
+**Version**: 0.1
+**Date**: 2026-03-20
+**Status**: PLANNED
+
+This document defines the simplified daemon requirements that supersede the
+current multi-daemon/runtime-splitting model.
+
+## 1. Design Goal
+
+The daemon must be reduced to a manageable, reliable subsystem. The reset goal
+is to eliminate multi-daemon support and remove any daemon behavior that does
+not directly serve the remaining requirements.
+
+## 2. Core Requirements
+
+### 2.1 Single Daemon Only
+
+- ATM supports at most one system daemon per user account.
+- ATM must not support separate `release`, `dev`, and per-home shared daemons.
+- ATM may still support serialized or shared-fixture daemon testing, but test
+  support must not require multiple concurrent daemon instances.
+
+### 2.2 Config Root and Runtime Root Are Separate
+
+- Team configuration, inboxes, and team metadata must not be resolved from
+  `ATM_HOME`.
+- `ATM_HOME` is a runtime-state root only.
+- Team configuration must resolve from one stable config root independent of
+  daemon runtime state.
+
+### 2.3 Minimal Daemon Responsibilities
+
+The daemon may exist only for responsibilities that still require a background
+process after the reset. At minimum, every daemon responsibility must answer:
+
+1. why it cannot be synchronous,
+2. why it cannot live in the CLI/process invoking it, and
+3. why it justifies daemon complexity.
+
+Any daemon behavior that cannot meet that bar is a deletion candidate.
+
+### 2.4 Startup Must Be Transactional
+
+- The daemon must not publish partial live-daemon state before it is ready to
+  accept work.
+- Startup either succeeds and publishes canonical runtime state, or fails and
+  leaves no misleading live-daemon artifacts behind.
+
+### 2.5 Shutdown and Restart Must Be Symmetric
+
+- Stop/restart cleanup must remove all daemon-owned runtime artifacts together.
+- Cleanup must not leave ambiguous combinations such as lock/status metadata
+  without a live daemon.
+
+### 2.6 Runtime Artifacts Must Be Minimal
+
+The reset target is one ownership source of truth and one health source of
+truth.
+
+- Ownership artifact: lock metadata
+- Health artifact: status snapshot
+
+Any additional daemon runtime artifact must be justified as required. Existing
+artifacts such as `atm-daemon.pid` and `daemon-touch.json` are deletion
+candidates unless explicitly retained by the reset design.
+
+### 2.7 No Multi-Daemon Arbitration
+
+The daemon design must not require:
+
+- runtime-kind arbitration,
+- per-home daemon identity competition,
+- mismatched-daemon replacement heuristics,
+- broad stale-artifact inference to decide which daemon is authoritative.
+
+The system must instead have one canonical daemon ownership model.
+
+## 3. Test Model
+
+- Daemon integration tests must work under a single-daemon design.
+- Tests that require a real daemon must use serialized execution or a shared
+  fixture model.
+- The test strategy must not depend on isolated per-test daemon instances.
+
+## 4. Deletion Requirements
+
+The reset phase must explicitly classify daemon-related code into:
+
+- keep and simplify,
+- transitional,
+- delete.
+
+Refactoring that only redistributes code without reducing behaviors, modes,
+artifacts, or branches does not satisfy the reset.
+
+## 5. Exit Criteria
+
+The daemon reset is complete only when all of the following are true:
+
+1. Multi-daemon support is removed from the requirements and implementation.
+2. Team config is no longer resolved from `ATM_HOME`.
+3. Startup leaves no partial live-daemon state on failure.
+4. Stop/restart cleanup removes all daemon-owned runtime artifacts
+   deterministically.
+5. Dogfood start/restart/stop passes repeatedly on a clean machine/home.
+6. The remaining daemon code and docs are smaller, simpler, and easier to
+   reason about than the current model.

--- a/docs/phase-bb-daemon-reset.md
+++ b/docs/phase-bb-daemon-reset.md
@@ -1,7 +1,15 @@
 # Phase BB: Daemon Reset
 
+**Version**: 0.2
+**Date**: 2026-03-20
 **Status**: PLANNED
-**Target branch**: `integrate/phase-BB`
+**Integration branch**: `integrate/phase-BB`
+**Prerequisites**: `develop` at `103bd127` or later, with Phases through BA
+merged to `develop`
+**Dependency graph**: `BB.0 -> BB.1 -> BB.2 -> BB.3 -> BB.4` (serial)
+**Supersedes**: older multi-daemon planning assumptions in
+`docs/requirements.md`, `docs/project-plan.md`, and the pre-BB daemon/runtime
+model
 
 ## Goal
 
@@ -22,6 +30,17 @@ The current daemon model has accumulated:
 - repeated reliability regressions across many follow-up phases.
 
 Phase BB changes the strategy from patching symptoms to reducing the design.
+
+## Canonical Roots for This Phase
+
+Phase BB resolves the open path decision up front:
+
+- **Config root**: `~/.claude`
+- **Team state root**: `~/.claude/teams`
+- **Runtime root**: `ATM_HOME`
+
+`ATM_HOME` remains available for runtime-state overrides, but it must no longer
+redirect team config, inboxes, or other stable team metadata.
 
 ## Sprint Plan
 
@@ -65,13 +84,26 @@ Deliverables:
 
 - team config/inbox paths stop resolving from `ATM_HOME`
 - `ATM_HOME` becomes runtime-state-only
+- `~/.claude` becomes the canonical config root and `~/.claude/teams` becomes
+  the canonical team-state root
 - daemon and CLI call sites migrate to the split path model
+- BB.1 includes an explicit migration inventory for the currently known path
+  split surface:
+  - `crates/atm-core/src/home.rs`
+  - `crates/atm-daemon/src/main.rs` config/bootstrap lookup
+  - inline `get_home_dir()` / `teams_root_dir_for()` call sites in
+    `crates/atm-daemon/src/daemon/socket.rs`
+  - plugin init call sites in:
+    - `crates/atm-daemon/src/plugins/ci_monitor/plugin.rs`
+    - `crates/atm-daemon/src/plugins/issues/plugin.rs`
+    - `crates/atm-daemon/src/plugins/worker_adapter/plugin.rs`
 
 Acceptance:
 
 - dev/shared runtime homes no longer break team config lookup
-- `~/.claude/teams` (or the chosen stable config root) is independent of
-  runtime-home overrides
+- `~/.claude/teams` is independent of runtime-home overrides
+- the BB.1 migration inventory is complete enough that later sprints are not
+  forced to rediscover path split call sites during implementation
 
 ### BB.2 Single-Daemon Model Collapse
 
@@ -82,12 +114,25 @@ Deliverables:
 - remove multi-daemon runtime ownership support
 - remove daemon runtime-kind arbitration for `release` vs `dev` shared daemons
 - simplify admission/ownership checks around one daemon model
+- update the cross-crate blast radius together in:
+  - `atm-core`
+  - `atm-daemon`
+  - `atm-daemon-launch`
+- replace the current `validate_runtime_admission_input` preconditions with one
+  explicit invariant:
+  - the daemon may only launch against the canonical runtime root for the user,
+    with one approved daemon binary selection policy and no per-home ownership
+    competition
+- document the replacement for any security checks that currently rely on
+  `RuntimeKind` branching or shared-vs-isolated runtime admission heuristics
 
 Acceptance:
 
 - daemon ownership no longer depends on per-home competition
 - runtime-kind branching is reduced to what is still required for tests only, or
   removed entirely
+- BB.2 is treated as dependent on BB.1 completion; it does not begin on an
+  unresolved path model
 
 ### BB.3 Artifact Collapse and Transactional Startup
 
@@ -100,6 +145,12 @@ Deliverables:
 - remove obsolete sidecars and redundant ownership files where possible
 - remove daemon/plugin surfaces that are dead in production and only add
   maintenance load to the daemon reset
+- include a status schema migration note for `RuntimeOwnerMetadata` in
+  `status.json` so `RuntimeKind` removal or collapse cannot become a silent
+  deserialization hazard
+- carry the BB.4 compatibility work needed for PID-file removal before BB.3 is
+  allowed onto `integrate/phase-BB`; BB.3 must not land on the phase branch in
+  a state that knowingly breaks the daemon test suite
 
 Primary deletion candidates:
 
@@ -115,6 +166,9 @@ Acceptance:
 - stop/restart leaves no ambiguous stale-artifact combinations
 - production-dead daemon plugin code is removed rather than carried through the
   reset
+- BB.3 changes are integration-safe with the BB.4 test rewrite path; no phase
+  branch state is allowed where PID-file deletion is merged but the test/model
+  rewrite is absent
 
 ### BB.4 Test Model Rewrite and Final Deletion
 
@@ -125,11 +179,17 @@ Deliverables:
 - serialized/shared-fixture daemon test model
 - obsolete multi-daemon tests removed
 - dead code, env vars, docs, and fallback paths deleted
+- the final daemon dogfood gate cites and reuses the canonical manual
+  dev-daemon smoke protocol introduced in Phase AR (`docs/project-plan.md`
+  section 17.26, plus `scripts/dev-daemon-smoke.py`)
+- obsolete daemon/runtime planning docs are deleted or explicitly archived so
+  the post-reset documentation surface is smaller and authoritative
 
 Acceptance:
 
 - daemon tests no longer depend on isolated per-test daemon instances
-- dogfood start/restart/stop passes repeatedly under the new model
+- dogfood start/restart/stop passes repeatedly on a clean machine/home under
+  the new model
 - deleted code outweighs newly added code for the phase
 
 ## Exit Criteria
@@ -142,5 +202,7 @@ Phase BB is complete only when:
 3. dead-code cleanup identified in `BB.0` is complete,
 4. daemon startup/shutdown behavior is deterministic,
 5. stale-artifact ambiguity is removed,
-6. the daemon code and documentation are materially smaller than before the
+6. dogfood start/restart/stop passes repeatedly on a clean machine/home using
+   the canonical Phase AR smoke protocol,
+7. the daemon code and documentation are materially smaller than before the
    phase began.

--- a/docs/phase-bb-daemon-reset.md
+++ b/docs/phase-bb-daemon-reset.md
@@ -1,0 +1,109 @@
+# Phase BB: Daemon Reset
+
+**Status**: PLANNED
+**Target branch**: `integrate/phase-BB`
+
+## Goal
+
+Remove multi-daemon support and replace the current daemon/runtime model with a
+smaller, deterministic single-daemon design.
+
+This phase is a deletion-heavy reset, not a feature phase.
+
+## Why This Phase Exists
+
+The current daemon model has accumulated:
+
+- multi-daemon/runtime-mode branching,
+- `ATM_HOME` coupling for both runtime and config,
+- partial startup artifacts,
+- asymmetric cleanup,
+- hard-to-reason-about identity replacement logic,
+- repeated reliability regressions across many follow-up phases.
+
+Phase BB changes the strategy from patching symptoms to reducing the design.
+
+## Sprint Plan
+
+### BB.1 Path Separation
+
+Define and adopt separate APIs for:
+
+- config root
+- runtime root
+
+Deliverables:
+
+- team config/inbox paths stop resolving from `ATM_HOME`
+- `ATM_HOME` becomes runtime-state-only
+- daemon and CLI call sites migrate to the split path model
+
+Acceptance:
+
+- dev/shared runtime homes no longer break team config lookup
+- `~/.claude/teams` (or the chosen stable config root) is independent of
+  runtime-home overrides
+
+### BB.2 Single-Daemon Model Collapse
+
+Collapse daemon ownership to one system-daemon model.
+
+Deliverables:
+
+- remove multi-daemon runtime ownership support
+- remove daemon runtime-kind arbitration for `release` vs `dev` shared daemons
+- simplify admission/ownership checks around one daemon model
+
+Acceptance:
+
+- daemon ownership no longer depends on per-home competition
+- runtime-kind branching is reduced to what is still required for tests only, or
+  removed entirely
+
+### BB.3 Artifact Collapse and Transactional Startup
+
+Reduce daemon runtime state to the minimum required artifact set.
+
+Deliverables:
+
+- startup publishes canonical state only after readiness
+- stop/restart cleanup removes all daemon-owned runtime artifacts symmetrically
+- remove obsolete sidecars and redundant ownership files where possible
+
+Primary deletion candidates:
+
+- `atm-daemon.pid`
+- `daemon-touch.json`
+
+Acceptance:
+
+- failed startup leaves no misleading live-daemon state
+- stop/restart leaves no ambiguous stale-artifact combinations
+
+### BB.4 Test Model Rewrite and Final Deletion
+
+Move daemon tests to the single-daemon model and delete the old complexity.
+
+Deliverables:
+
+- serialized/shared-fixture daemon test model
+- obsolete multi-daemon tests removed
+- dead code, env vars, docs, and fallback paths deleted
+
+Acceptance:
+
+- daemon tests no longer depend on isolated per-test daemon instances
+- dogfood start/restart/stop passes repeatedly under the new model
+- deleted code outweighs newly added code for the phase
+
+## Exit Criteria
+
+Phase BB is complete only when:
+
+1. multi-daemon support is removed from the active requirements and
+   implementation,
+2. config root and runtime root are separate,
+3. daemon startup/shutdown behavior is deterministic,
+4. stale-artifact ambiguity is removed,
+5. the daemon code and documentation are materially smaller than before the
+   phase began.

--- a/docs/phase-bb-daemon-reset.md
+++ b/docs/phase-bb-daemon-reset.md
@@ -25,6 +25,35 @@ Phase BB changes the strategy from patching symptoms to reducing the design.
 
 ## Sprint Plan
 
+### BB.0 Dead Code Cleanup (Pre-Reset Trim)
+
+Trim obviously dead code before the structural daemon reset starts.
+
+Deliverables:
+
+- remove unused `atm-core` schema/version scaffolding that never became part of
+  the active runtime model
+- remove dead/deprecated constructors and helpers that are provably uncalled
+- reduce visibility on helpers that should be test-only or crate-private
+
+Concrete candidates already identified:
+
+- `crates/atm-core/src/schema/version.rs`
+- `SystemContext.schema_version` and `with_schema_version()`
+- deprecated `logging::init`
+- `RetentionResult::new` / `CleanReportResult::new` visibility tightening
+
+Acceptance:
+
+- dead-code cleanup lands with no behavior change
+- workspace validation remains green
+- BB.1 and later sprints do not have to preserve these obsolete surfaces
+
+Decision:
+
+- `BB.0` is intentionally a pre-phase cleanup sprint because it removes code
+  that no longer participates in any daemon-reset design choice.
+
 ### BB.1 Path Separation
 
 Define and adopt separate APIs for:
@@ -69,16 +98,23 @@ Deliverables:
 - startup publishes canonical state only after readiness
 - stop/restart cleanup removes all daemon-owned runtime artifacts symmetrically
 - remove obsolete sidecars and redundant ownership files where possible
+- remove daemon/plugin surfaces that are dead in production and only add
+  maintenance load to the daemon reset
 
 Primary deletion candidates:
 
 - `atm-daemon.pid`
 - `daemon-touch.json`
+- unregistered bridge plugin module under `crates/atm-daemon/src/plugins/bridge/`
+- dead plugin capabilities and registry helpers with no production callers
+- superseded issue-provider legacy entrypoints
 
 Acceptance:
 
 - failed startup leaves no misleading live-daemon state
 - stop/restart leaves no ambiguous stale-artifact combinations
+- production-dead daemon plugin code is removed rather than carried through the
+  reset
 
 ### BB.4 Test Model Rewrite and Final Deletion
 
@@ -103,7 +139,8 @@ Phase BB is complete only when:
 1. multi-daemon support is removed from the active requirements and
    implementation,
 2. config root and runtime root are separate,
-3. daemon startup/shutdown behavior is deterministic,
-4. stale-artifact ambiguity is removed,
-5. the daemon code and documentation are materially smaller than before the
+3. dead-code cleanup identified in `BB.0` is complete,
+4. daemon startup/shutdown behavior is deterministic,
+5. stale-artifact ambiguity is removed,
+6. the daemon code and documentation are materially smaller than before the
    phase began.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2695,6 +2695,15 @@ You are the Scrum Master for the agent-team-mail (atm) project.
 collapse daemon runtime artifacts to a minimal authoritative set, and replace
 the current daemon test model with a simpler single-daemon strategy.
 
+**Integration branch**: `integrate/phase-BB`
+
+**Prerequisites**: `develop` at `103bd127` or later, with Phases through BA
+merged to `develop`.
+
+**Dependency graph**: `BB.0 -> BB.1 -> BB.2 -> BB.3 -> BB.4` (serial). `BB.3`
+must not land on the phase branch unless the BB.4 compatibility/test changes
+required by PID-file removal are present on the same integration head.
+
 **Design references**:
 - `docs/daemon/requirements.md`
 - `docs/daemon/architecture.md`
@@ -2714,7 +2723,7 @@ the current daemon test model with a simpler single-daemon strategy.
 3. Dead-code cleanup identified in BB.0 is complete and obsolete surfaces are not carried into later sprints.
 4. Daemon startup failure leaves no misleading live-daemon state behind.
 5. Stop/restart removes all daemon-owned runtime artifacts deterministically.
-6. Dogfood daemon start/restart/stop passes repeatedly under the simplified model.
+6. Dogfood daemon start/restart/stop passes repeatedly on a clean machine/home under the simplified model and follows the canonical Phase AR smoke protocol.
 7. Net phase outcome is deletion-heavy: daemon complexity and documentation are materially smaller than before Phase BB.
 
 ## Communication

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2702,18 +2702,20 @@ the current daemon test model with a simpler single-daemon strategy.
 
 | Sprint | Name | Goal | Branch |
 |--------|------|------|--------|
+| BB.0 | Dead Code Cleanup | Remove obviously dead atm-core / daemon code before the structural reset so later sprints do not preserve obsolete surfaces | `feature/pBB-s0-dead-code-cleanup` |
 | BB.1 | Path Separation | Stop resolving team config from `ATM_HOME`; introduce explicit config-root vs runtime-root APIs and migrate callers | `feature/pBB-s1-path-separation` |
 | BB.2 | Single-Daemon Model Collapse | Remove multi-daemon ownership/runtime-mode support and simplify daemon admission/ownership to one system daemon model | `feature/pBB-s2-single-daemon` |
-| BB.3 | Artifact Collapse + Transactional Startup | Remove redundant daemon artifacts, make startup publish state only after readiness, and make restart/cleanup symmetric | `feature/pBB-s3-artifact-collapse` |
+| BB.3 | Artifact Collapse + Transactional Startup | Remove redundant daemon artifacts, remove production-dead daemon plugin surfaces, make startup publish state only after readiness, and make restart/cleanup symmetric | `feature/pBB-s3-artifact-collapse` |
 | BB.4 | Test Model Rewrite + Final Deletion | Rewrite daemon tests for serialized/shared-fixture execution and delete obsolete multi-daemon code/docs/env paths | `feature/pBB-s4-test-rewrite-cleanup` |
 
 **Acceptance criteria**:
 1. Team config no longer resolves from `ATM_HOME`.
 2. Multi-daemon support is removed from active daemon requirements and implementation.
-3. Daemon startup failure leaves no misleading live-daemon state behind.
-4. Stop/restart removes all daemon-owned runtime artifacts deterministically.
-5. Dogfood daemon start/restart/stop passes repeatedly under the simplified model.
-6. Net phase outcome is deletion-heavy: daemon complexity and documentation are materially smaller than before Phase BB.
+3. Dead-code cleanup identified in BB.0 is complete and obsolete surfaces are not carried into later sprints.
+4. Daemon startup failure leaves no misleading live-daemon state behind.
+5. Stop/restart removes all daemon-owned runtime artifacts deterministically.
+6. Dogfood daemon start/restart/stop passes repeatedly under the simplified model.
+7. Net phase outcome is deletion-heavy: daemon complexity and documentation are materially smaller than before Phase BB.
 
 ## Communication
 

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -187,6 +187,7 @@ All sprint work MUST use dedicated worktrees via `sc-git-worktree` skill. Main r
 | AV | OTel Collector Logs Rollout | Ship OTLP HTTP logs export, dogfood it against a Grafana-compatible receiver, and preserve fail-open local logging | COMPLETE |
 | AW | OTel Traces + Metrics Expansion | Add native traces and metrics, Grafana dashboards/smoke, and external repo rollout on top of AV | PLANNED |
 | BA | CLI Message Management + Plugin Boundary | Fix inbox lifecycle noise, add atomic queue/ack semantics, and remove current `atm -> daemon plugin` command coupling | PLANNED |
+| BB | Daemon Reset | Remove multi-daemon support, separate config root from runtime root, collapse daemon artifacts, and rewrite daemon testing around a single-daemon model | PLANNED |
 
 ---
 
@@ -2685,6 +2686,34 @@ You are the Scrum Master for the agent-team-mail (atm) project.
 - Project Plan: docs/project-plan.md
 - Agent Team API: docs/agent-team-api.md
 - Rust Guidelines: .claude/skills/rust-development/guidelines.txt
+
+---
+
+## Phase BB: Daemon Reset — PLANNED
+
+**Goal**: remove multi-daemon support, separate config root from runtime root,
+collapse daemon runtime artifacts to a minimal authoritative set, and replace
+the current daemon test model with a simpler single-daemon strategy.
+
+**Design references**:
+- `docs/daemon/requirements.md`
+- `docs/daemon/architecture.md`
+- `docs/phase-bb-daemon-reset.md`
+
+| Sprint | Name | Goal | Branch |
+|--------|------|------|--------|
+| BB.1 | Path Separation | Stop resolving team config from `ATM_HOME`; introduce explicit config-root vs runtime-root APIs and migrate callers | `feature/pBB-s1-path-separation` |
+| BB.2 | Single-Daemon Model Collapse | Remove multi-daemon ownership/runtime-mode support and simplify daemon admission/ownership to one system daemon model | `feature/pBB-s2-single-daemon` |
+| BB.3 | Artifact Collapse + Transactional Startup | Remove redundant daemon artifacts, make startup publish state only after readiness, and make restart/cleanup symmetric | `feature/pBB-s3-artifact-collapse` |
+| BB.4 | Test Model Rewrite + Final Deletion | Rewrite daemon tests for serialized/shared-fixture execution and delete obsolete multi-daemon code/docs/env paths | `feature/pBB-s4-test-rewrite-cleanup` |
+
+**Acceptance criteria**:
+1. Team config no longer resolves from `ATM_HOME`.
+2. Multi-daemon support is removed from active daemon requirements and implementation.
+3. Daemon startup failure leaves no misleading live-daemon state behind.
+4. Stop/restart removes all daemon-owned runtime artifacts deterministically.
+5. Dogfood daemon start/restart/stop passes repeatedly under the simplified model.
+6. Net phase outcome is deletion-heavy: daemon complexity and documentation are materially smaller than before Phase BB.
 
 ## Communication
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -20,10 +20,17 @@ This primary requirements document registers secondary source-of-truth documents
 - CI monitoring architecture: `docs/ci-monitoring/architecture.md`
 - CI monitoring ADR index: `docs/ci-monitoring/adr.md`
 - Daemon spawn authorization requirements: `docs/daemon-spawn-auth/requirements.md`
+- Daemon reset requirements: `docs/daemon/requirements.md`
+- Daemon reset architecture: `docs/daemon/architecture.md`
 
 All logging/OpenTelemetry requirements for ATM and companion tools are defined
 in the observability documents above. This file references that contract and
 must not duplicate or drift from it.
+
+Active daemon simplification and multi-daemon removal requirements are defined
+in `docs/daemon/requirements.md` and `docs/daemon/architecture.md`. Those
+documents supersede older multi-daemon assumptions in this primary document
+until the daemon sections here are fully consolidated.
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -36,7 +36,7 @@ until the daemon sections here are fully consolidated.
 
 ## 1. Project Summary
 
-`atm` is a Rust workspace that provides mail-like messaging for Claude agent teams. It consists of a CLI for interactive use, a shared library for safe file I/O against the `~/.claude/teams/` file structure, and (post-MVP) an always-on daemon that hosts plugins for CI monitoring, cross-machine bridging, issue tracking, and human chat interfaces.
+`atm` is a Rust workspace that provides mail-like messaging for Claude agent teams. It consists of a CLI for interactive use, a shared library for safe file I/O against the `~/.claude/teams/` file structure, and a daemon/runtime subsystem whose active simplification requirements are defined in `docs/daemon/requirements.md` and `docs/daemon/architecture.md`.
 
 ### Goals
 
@@ -47,7 +47,6 @@ until the daemon sections here are fully consolidated.
 
 ### Non-Goals (MVP)
 
-- Daemon / background process mode (post-MVP)
 - Team or agent lifecycle management (create/delete teams, spawn agents)
 - Cross-machine networking in core (plugin responsibility)
 - GUI or TUI interface
@@ -76,7 +75,7 @@ agent-team-mail/
 │   │   └── src/
 │   │       ├── main.rs
 │   │       └── commands/       # send, read, broadcast, inbox, teams, etc.
-│   └── atm-daemon/             # daemon binary (post-MVP)
+│   └── atm-daemon/             # daemon binary
 │       ├── Cargo.toml
 │       └── src/
 │           ├── main.rs


### PR DESCRIPTION
## Summary

- Daemon reset planning docs for Phase BB
- Path separation (BB.1): decouple team config root from ATM_HOME runtime root
- Single-daemon model collapse (BB.2): remove multi-daemon runtime ownership support
- Updated: docs/daemon/requirements.md, docs/daemon/architecture.md, docs/phase-bb-daemon-reset.md, docs/requirements.md, docs/project-plan.md

## Motivation

Current daemon model has accumulated: multi-daemon/runtime-mode branching, ATM_HOME coupling for both runtime and config, partial startup artifacts, asymmetric cleanup, and repeated reliability regressions across multiple phases (AX–BA). Phase BB changes strategy from patching symptoms to reducing the design.

## Review Checklist
- [ ] Plan QA (atm-qa-agent) — requirements coverage
- [ ] Architecture review (arch-qa-agent) — structural soundness
- [ ] User approval before sprint execution begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)