### PR TITLE
fix: BB smoke-pass stabilization (version display, ATM_HOME hint, monitor implicit start)

### DIFF
--- a/crates/atm-core/src/daemon_client.rs
+++ b/crates/atm-core/src/daemon_client.rs
@@ -708,6 +708,34 @@ fn shared_runtime_test_bypass_enabled(input: &RuntimePolicyInput) -> bool {
         == Some("1")
 }
 
+fn shared_runtime_env_mismatch_hint() -> Option<String> {
+    let raw_atm_home = std::env::var("ATM_HOME").ok()?;
+    let trimmed = raw_atm_home.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let expected_home = canonical_shared_runtime_root().ok()?;
+    let actual_home = canonicalize_lossy(std::path::Path::new(trimmed));
+    let canonical_temp_root = canonicalize_lossy(&std::env::temp_dir());
+    if actual_home == expected_home || actual_home.starts_with(&canonical_temp_root) {
+        return None;
+    }
+
+    Some(format!(
+        "shared runtime requires ATM_HOME unset (canonical root: {}); current ATM_HOME resolves to {}",
+        expected_home.display(),
+        actual_home.display()
+    ))
+}
+
+fn append_shared_runtime_env_mismatch_hint(detail: String) -> String {
+    match shared_runtime_env_mismatch_hint() {
+        Some(hint) => format!("{detail}; {hint}"),
+        None => detail,
+    }
+}
+
 // Enforces BB.2 single-daemon invariant: one canonical runtime root, one
 // binary selection policy. See docs/daemon-spawn-auth/requirements.md.
 fn enforce_shared_runtime_invariant(
@@ -1344,13 +1372,17 @@ pub fn query_team_member_states(
         Ok(None) => {
             return Ok(DaemonAvailability::unavailable(
                 "daemon_client::query_team_member_states",
-                format!("daemon team-scoped state query unavailable for team '{team}'"),
+                append_shared_runtime_env_mismatch_hint(format!(
+                    "daemon team-scoped state query unavailable for team '{team}'"
+                )),
             ));
         }
         Err(err) => {
             return Ok(DaemonAvailability::unavailable(
                 "daemon_client::query_team_member_states",
-                format!("daemon team-scoped state query failed for team '{team}': {err}"),
+                append_shared_runtime_env_mismatch_hint(format!(
+                    "daemon team-scoped state query failed for team '{team}': {err}"
+                )),
             ));
         }
     };
@@ -1358,7 +1390,9 @@ pub fn query_team_member_states(
     if !response.is_ok() {
         return Ok(DaemonAvailability::unavailable(
             "daemon_client::query_team_member_states",
-            format!("daemon rejected team-scoped state query for team '{team}'"),
+            append_shared_runtime_env_mismatch_hint(format!(
+                "daemon rejected team-scoped state query for team '{team}'"
+            )),
         ));
     }
 
@@ -1367,7 +1401,9 @@ pub fn query_team_member_states(
         None => {
             return Ok(DaemonAvailability::unavailable(
                 "daemon_client::query_team_member_states",
-                format!("daemon returned no payload for team-scoped state query '{team}'"),
+                append_shared_runtime_env_mismatch_hint(format!(
+                    "daemon returned no payload for team-scoped state query '{team}'"
+                )),
             ));
         }
     };
@@ -4227,6 +4263,30 @@ sleep 8
             assert!(
                 matches!(result, Ok(DaemonAvailability::Unavailable(_))),
                 "offline daemon must map to explicit unavailable, got: {result:?}"
+            );
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_query_team_member_states_noncanonical_shared_home_surfaces_atm_home_hint() {
+        with_autostart_disabled(|| {
+            let os_home = crate::home::get_os_home_dir().expect("os home");
+            let tmp = tempfile::tempdir_in(&os_home).expect("tempdir");
+            let _home_guard = EnvGuard::set("ATM_HOME", tmp.path().to_str().unwrap());
+
+            let result = query_team_member_states("atm-dev").expect("query result");
+            let details = match result {
+                DaemonAvailability::Unavailable(details) => details,
+                other => panic!("expected unavailable, got {other:?}"),
+            };
+
+            assert!(
+                details
+                    .detail
+                    .contains("shared runtime requires ATM_HOME unset"),
+                "expected shared-runtime ATM_HOME hint, got: {}",
+                details.detail
             );
         });
     }

--- a/crates/atm-core/src/install.rs
+++ b/crates/atm-core/src/install.rs
@@ -1,0 +1,76 @@
+use std::fs;
+use std::path::Path;
+
+/// Read the dev-install milestone from the install manifest adjacent to a bin/
+/// directory. Returns `None` for source builds or installs without a manifest.
+pub fn read_install_milestone_from_exe(exe: &Path) -> Option<String> {
+    let bin_dir = exe.parent()?;
+    if bin_dir.file_name()?.to_str()? != "bin" {
+        return None;
+    }
+
+    let manifest_path = bin_dir.parent()?.join("manifest.json");
+    let raw = fs::read_to_string(manifest_path).ok()?;
+    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
+    value
+        .get("milestone_version")
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+pub fn read_active_install_milestone() -> Option<String> {
+    let exe = std::env::current_exe().ok()?;
+    read_install_milestone_from_exe(&exe)
+}
+
+/// Prefer the installed milestone label when available so dev installs can
+/// report their promoted build identity instead of only the workspace version.
+pub fn effective_display_version(default_version: &str) -> String {
+    read_active_install_milestone().unwrap_or_else(|| default_version.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_milestone_from_bin_adjacent_manifest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let install_root = temp.path().join("installs/0.46.1-dev.6");
+        let bin_dir = install_root.join("bin");
+        std::fs::create_dir_all(&bin_dir).expect("create bin");
+        std::fs::write(
+            install_root.join("manifest.json"),
+            r#"{"milestone_version":"0.46.1-dev.6"}"#,
+        )
+        .expect("write manifest");
+        let exe = bin_dir.join("atm");
+        std::fs::write(&exe, "").expect("write exe");
+
+        let milestone = read_install_milestone_from_exe(&exe);
+        assert_eq!(milestone.as_deref(), Some("0.46.1-dev.6"));
+    }
+
+    #[test]
+    fn returns_none_when_not_running_from_bin_dir() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let exe = temp.path().join("target/release/atm");
+        std::fs::create_dir_all(exe.parent().expect("parent")).expect("create parent");
+        std::fs::write(&exe, "").expect("write exe");
+
+        assert_eq!(read_install_milestone_from_exe(&exe), None);
+    }
+
+    #[test]
+    fn returns_none_for_missing_manifest() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let bin_dir = temp.path().join("install/bin");
+        std::fs::create_dir_all(&bin_dir).expect("create bin");
+        let exe = bin_dir.join("atm");
+        std::fs::write(&exe, "").expect("write exe");
+
+        assert_eq!(read_install_milestone_from_exe(&exe), None);
+    }
+}

--- a/crates/atm-core/src/lib.rs
+++ b/crates/atm-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod daemon_stream;
 pub mod event_log;
 pub mod gh_command;
 pub mod home;
+pub mod install;
 pub mod io;
 pub mod log_reader;
 pub mod logging;

--- a/crates/atm-daemon/src/main.rs
+++ b/crates/atm-daemon/src/main.rs
@@ -11,7 +11,7 @@ use agent_team_mail_daemon::daemon::{
 use agent_team_mail_daemon::plugin::{MailService, PluginContext, PluginRegistry};
 use agent_team_mail_daemon::roster::RosterService;
 use anyhow::{Context, Result};
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use sc_observability_types::{MetricRecord, OtelConfig, TraceRecord};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -144,7 +144,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
+    let version =
+        agent_team_mail_core::install::effective_display_version(env!("CARGO_PKG_VERSION"));
+    let version: &'static str = Box::leak(version.into_boxed_str());
+    let matches = Args::command().version(version).get_matches();
+    let args = Args::from_arg_matches(&matches).unwrap_or_else(|err| err.exit());
 
     // Initialize shared logging. --verbose maps to ATM_LOG=debug.
     if args.verbose {

--- a/crates/atm-daemon/src/plugins/ci_monitor/gh_command_routing.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/gh_command_routing.rs
@@ -266,6 +266,7 @@ fn run_repo_scoped_gh_command(
 }
 
 pub fn validate_gh_cli_prerequisites() -> Result<()> {
+    // NOT_MONITORED_PATH: bootstrap prerequisite probe before gh firewall/routing is active.
     let version = Command::new("gh")
         .arg("--version")
         .output()
@@ -276,6 +277,7 @@ pub fn validate_gh_cli_prerequisites() -> Result<()> {
         );
     }
 
+    // NOT_MONITORED_PATH: bootstrap auth check before gh firewall/routing is active.
     let auth = Command::new("gh")
         .args(["auth", "status"])
         .output()

--- a/crates/atm-daemon/src/plugins/ci_monitor/github_provider.rs
+++ b/crates/atm-daemon/src/plugins/ci_monitor/github_provider.rs
@@ -220,6 +220,7 @@ fn run_gh_subprocess(args: &[String]) -> Result<String, CiProviderError> {
     #[cfg(test)]
     GH_SUBPROCESS_COUNT.fetch_add(1, Ordering::SeqCst);
 
+    // NOT_MONITORED_PATH: provider subprocess execution is the gh firewall boundary being wrapped.
     let output = Command::new("gh").args(args).output().map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             CiProviderError::provider("gh CLI not found. Install from https://cli.github.com/")

--- a/crates/atm/src/commands/doctor.rs
+++ b/crates/atm/src/commands/doctor.rs
@@ -1119,19 +1119,7 @@ fn read_daemon_status_uptime_secs(home_dir: &Path) -> Option<u64> {
 }
 
 fn read_active_install_milestone() -> Option<String> {
-    let exe = std::env::current_exe().ok()?;
-    let bin_dir = exe.parent()?;
-    if bin_dir.file_name()?.to_str()? != "bin" {
-        return None;
-    }
-
-    let manifest_path = bin_dir.parent()?.join("manifest.json");
-    let raw = fs::read_to_string(manifest_path).ok()?;
-    let value: serde_json::Value = serde_json::from_str(&raw).ok()?;
-    value
-        .get("milestone_version")
-        .and_then(serde_json::Value::as_str)
-        .map(ToString::to_string)
+    agent_team_mail_core::install::read_active_install_milestone()
 }
 
 fn check_pid_session_reconciliation(

--- a/crates/atm/src/commands/gh.rs
+++ b/crates/atm/src/commands/gh.rs
@@ -445,6 +445,7 @@ pub fn execute(args: GhArgs) -> Result<()> {
 
             let output = match monitor.target {
                 MonitorTarget::Pr(pr) => {
+                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Pr,
@@ -464,6 +465,7 @@ pub fn execute(args: GhArgs) -> Result<()> {
                     })?)
                 }
                 MonitorTarget::Workflow(workflow) => {
+                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Workflow,
@@ -483,6 +485,7 @@ pub fn execute(args: GhArgs) -> Result<()> {
                     })?)
                 }
                 MonitorTarget::Run(run) => {
+                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Run,
@@ -1464,6 +1467,31 @@ fn namespace_actions(
 
 fn yes_no(v: bool) -> &'static str {
     if v { "yes" } else { "no" }
+}
+
+fn ensure_monitor_lifecycle_started(
+    team: &str,
+    current_dir: &Path,
+    args: &GhArgs,
+    config: &Config,
+) -> Result<()> {
+    let request = GhMonitorControlRequest {
+        team: team.to_string(),
+        action: GhMonitorLifecycleAction::Start,
+        repo: Some(resolve_daemon_repo_scope(
+            args.repo.as_deref(),
+            current_dir,
+        )?),
+        drain_timeout_secs: None,
+        config_cwd: Some(current_dir.to_string_lossy().to_string()),
+        actor: Some(resolve_monitor_caller_identity(config)),
+        actor_team: Some(config.core.default_team.clone()),
+        user_authorized: false,
+        operator_reason: None,
+    };
+    gh_monitor_control(&request)?
+        .ok_or_else(|| anyhow::anyhow!("daemon is not reachable for atm gh monitor command"))?;
+    Ok(())
 }
 
 fn execute_init(

--- a/crates/atm/src/commands/gh.rs
+++ b/crates/atm/src/commands/gh.rs
@@ -445,7 +445,12 @@ pub fn execute(args: GhArgs) -> Result<()> {
 
             let output = match monitor.target {
                 MonitorTarget::Pr(pr) => {
-                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
+                    ensure_monitor_lifecycle_started(
+                        team,
+                        &current_dir,
+                        args.repo.as_deref(),
+                        &config,
+                    )?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Pr,
@@ -465,7 +470,12 @@ pub fn execute(args: GhArgs) -> Result<()> {
                     })?)
                 }
                 MonitorTarget::Workflow(workflow) => {
-                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
+                    ensure_monitor_lifecycle_started(
+                        team,
+                        &current_dir,
+                        args.repo.as_deref(),
+                        &config,
+                    )?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Workflow,
@@ -485,7 +495,12 @@ pub fn execute(args: GhArgs) -> Result<()> {
                     })?)
                 }
                 MonitorTarget::Run(run) => {
-                    ensure_monitor_lifecycle_started(team, &current_dir, &args, &config)?;
+                    ensure_monitor_lifecycle_started(
+                        team,
+                        &current_dir,
+                        args.repo.as_deref(),
+                        &config,
+                    )?;
                     let request = GhMonitorRequest {
                         team: team.to_string(),
                         target_kind: GhMonitorTargetKind::Run,
@@ -1472,16 +1487,13 @@ fn yes_no(v: bool) -> &'static str {
 fn ensure_monitor_lifecycle_started(
     team: &str,
     current_dir: &Path,
-    args: &GhArgs,
+    repo_override: Option<&str>,
     config: &Config,
 ) -> Result<()> {
     let request = GhMonitorControlRequest {
         team: team.to_string(),
         action: GhMonitorLifecycleAction::Start,
-        repo: Some(resolve_daemon_repo_scope(
-            args.repo.as_deref(),
-            current_dir,
-        )?),
+        repo: Some(resolve_daemon_repo_scope(repo_override, current_dir)?),
         drain_timeout_secs: None,
         config_cwd: Some(current_dir.to_string_lossy().to_string()),
         actor: Some(resolve_monitor_caller_identity(config)),

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -10,7 +10,7 @@ use agent_team_mail_core::gh_command::{
     flush_local_gh_observability_records, install_cli_teardown_hook, run_cli_teardown_hook,
 };
 use agent_team_mail_core::logging;
-use clap::{CommandFactory, FromArgMatches, Parser};
+use clap::{CommandFactory, FromArgMatches};
 use sc_observability::LogConfig;
 use sc_observability_types::{MetricKind, MetricRecord, OtelConfig, TraceRecord, TraceStatus};
 use std::sync::Arc;

--- a/crates/atm/src/main.rs
+++ b/crates/atm/src/main.rs
@@ -10,7 +10,7 @@ use agent_team_mail_core::gh_command::{
     flush_local_gh_observability_records, install_cli_teardown_hook, run_cli_teardown_hook,
 };
 use agent_team_mail_core::logging;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser};
 use sc_observability::LogConfig;
 use sc_observability_types::{MetricKind, MetricRecord, OtelConfig, TraceRecord, TraceStatus};
 use std::sync::Arc;
@@ -22,6 +22,14 @@ mod consts;
 mod util;
 
 use commands::Cli;
+
+fn parse_cli() -> Cli {
+    let version =
+        agent_team_mail_core::install::effective_display_version(env!("CARGO_PKG_VERSION"));
+    let version: &'static str = Box::leak(version.into_boxed_str());
+    let matches = Cli::command().version(version).get_matches();
+    Cli::from_arg_matches(&matches).unwrap_or_else(|err| err.exit())
+}
 
 fn env_nonempty(key: &str) -> Option<String> {
     std::env::var(key).ok().and_then(|value| {
@@ -245,7 +253,7 @@ fn main() {
         }));
     }
 
-    let cli = Cli::parse();
+    let cli = parse_cli();
     let command_name = cli.command_name().to_string();
     let request_id = Uuid::new_v4().to_string();
     let trace_id = agent_team_mail_core::event_log::trace_id_for_request("atm", &request_id);

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -1493,6 +1493,8 @@ fn test_gh_monitor_pr_implicitly_starts_lifecycle() {
         .arg("gh")
         .arg("--team")
         .arg("test-team")
+        .arg("--repo")
+        .arg("acme/agent-team-mail")
         .arg("--json")
         .arg("monitor")
         .arg("pr")

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -634,6 +634,16 @@ fn read_last_request_matching(request_log: &std::path::Path, command: &str) -> s
         .unwrap_or_else(|| panic!("missing {command} request in {}", request_log.display()))
 }
 
+#[cfg(unix)]
+fn read_request_log(request_log: &std::path::Path) -> Vec<serde_json::Value> {
+    std::fs::read_to_string(request_log)
+        .unwrap()
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+        .collect()
+}
+
 /// Start the fake daemon with an explicit request log path.
 ///
 /// Use instead of `start_fake_gh_daemon` when the test needs to inspect the
@@ -1461,6 +1471,54 @@ fn test_gh_monitor_repo_override_accepts_github_url_and_cc() {
         request["payload"]["cc"],
         serde_json::json!(["qa-bot", "obs@ops"])
     );
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+}
+
+#[test]
+#[cfg(unix)]
+#[serial]
+fn test_gh_monitor_pr_implicitly_starts_lifecycle() {
+    let temp_dir = TempDir::new().unwrap();
+    setup_test_team(&temp_dir, "test-team");
+    let request_log = temp_dir.path().join("request-log.json");
+    let mut daemon = start_fake_gh_daemon_with_request_log(temp_dir.path(), &request_log);
+    let workdir = temp_dir.path().join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+    write_repo_gh_monitor_config_with_owner(&workdir, "test-team", "acme", "agent-team-mail");
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir, "test-team", false);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("gh")
+        .arg("--team")
+        .arg("test-team")
+        .arg("--json")
+        .arg("monitor")
+        .arg("pr")
+        .arg("101")
+        .arg("--start-timeout")
+        .arg("0")
+        .assert()
+        .success();
+
+    let requests = read_request_log(&request_log);
+    let start_idx = requests
+        .iter()
+        .position(|request| {
+            request["command"].as_str() == Some("gh-monitor-control")
+                && request["payload"]["action"].as_str() == Some("start")
+        })
+        .expect("start request should be sent");
+    let monitor_idx = requests
+        .iter()
+        .position(|request| request["command"].as_str() == Some("gh-monitor"))
+        .expect("monitor request should be sent");
+    assert!(
+        start_idx < monitor_idx,
+        "monitor lifecycle start must precede monitor request"
+    );
+
     let _ = daemon.kill();
     let _ = daemon.wait();
 }

--- a/crates/atm/tests/integration_gh.rs
+++ b/crates/atm/tests/integration_gh.rs
@@ -644,6 +644,53 @@ fn read_request_log(request_log: &std::path::Path) -> Vec<serde_json::Value> {
         .collect()
 }
 
+#[cfg(unix)]
+fn assert_monitor_target_implicitly_starts_lifecycle(
+    monitor_args: &[&str],
+    workdir_setup: impl FnOnce(&Path),
+) {
+    let temp_dir = TempDir::new().unwrap();
+    setup_test_team(&temp_dir, "test-team");
+    let request_log = temp_dir.path().join("request-log.json");
+    let mut daemon = start_fake_gh_daemon_with_request_log(temp_dir.path(), &request_log);
+    let workdir = temp_dir.path().join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+    workdir_setup(&workdir);
+
+    let mut cmd = cargo::cargo_bin_cmd!("atm");
+    set_home_env(&mut cmd, &temp_dir, "test-team", false);
+    cmd.env("ATM_TEAM", "test-team")
+        .arg("gh")
+        .arg("--team")
+        .arg("test-team")
+        .arg("--repo")
+        .arg("acme/agent-team-mail")
+        .arg("--json")
+        .args(monitor_args)
+        .assert()
+        .success();
+
+    let requests = read_request_log(&request_log);
+    let start_idx = requests
+        .iter()
+        .position(|request| {
+            request["command"].as_str() == Some("gh-monitor-control")
+                && request["payload"]["action"].as_str() == Some("start")
+        })
+        .expect("start request should be sent");
+    let monitor_idx = requests
+        .iter()
+        .position(|request| request["command"].as_str() == Some("gh-monitor"))
+        .expect("monitor request should be sent");
+    assert!(
+        start_idx < monitor_idx,
+        "monitor lifecycle start must precede monitor request"
+    );
+
+    let _ = daemon.kill();
+    let _ = daemon.wait();
+}
+
 /// Start the fake daemon with an explicit request log path.
 ///
 /// Use instead of `start_fake_gh_daemon` when the test needs to inspect the
@@ -1479,50 +1526,51 @@ fn test_gh_monitor_repo_override_accepts_github_url_and_cc() {
 #[cfg(unix)]
 #[serial]
 fn test_gh_monitor_pr_implicitly_starts_lifecycle() {
-    let temp_dir = TempDir::new().unwrap();
-    setup_test_team(&temp_dir, "test-team");
-    let request_log = temp_dir.path().join("request-log.json");
-    let mut daemon = start_fake_gh_daemon_with_request_log(temp_dir.path(), &request_log);
-    let workdir = temp_dir.path().join("workdir");
-    std::fs::create_dir_all(&workdir).unwrap();
-    write_repo_gh_monitor_config_with_owner(&workdir, "test-team", "acme", "agent-team-mail");
-
-    let mut cmd = cargo::cargo_bin_cmd!("atm");
-    set_home_env(&mut cmd, &temp_dir, "test-team", false);
-    cmd.env("ATM_TEAM", "test-team")
-        .arg("gh")
-        .arg("--team")
-        .arg("test-team")
-        .arg("--repo")
-        .arg("acme/agent-team-mail")
-        .arg("--json")
-        .arg("monitor")
-        .arg("pr")
-        .arg("101")
-        .arg("--start-timeout")
-        .arg("0")
-        .assert()
-        .success();
-
-    let requests = read_request_log(&request_log);
-    let start_idx = requests
-        .iter()
-        .position(|request| {
-            request["command"].as_str() == Some("gh-monitor-control")
-                && request["payload"]["action"].as_str() == Some("start")
-        })
-        .expect("start request should be sent");
-    let monitor_idx = requests
-        .iter()
-        .position(|request| request["command"].as_str() == Some("gh-monitor"))
-        .expect("monitor request should be sent");
-    assert!(
-        start_idx < monitor_idx,
-        "monitor lifecycle start must precede monitor request"
+    assert_monitor_target_implicitly_starts_lifecycle(
+        &["monitor", "pr", "101", "--start-timeout", "0"],
+        |workdir| {
+            write_repo_gh_monitor_config_with_owner(
+                workdir,
+                "test-team",
+                "acme",
+                "agent-team-mail",
+            );
+        },
     );
+}
 
-    let _ = daemon.kill();
-    let _ = daemon.wait();
+#[test]
+#[cfg(unix)]
+#[serial]
+fn test_gh_monitor_workflow_implicitly_starts_lifecycle() {
+    assert_monitor_target_implicitly_starts_lifecycle(
+        &[
+            "monitor",
+            "workflow",
+            "ci",
+            "--ref",
+            "develop",
+            "--start-timeout",
+            "0",
+        ],
+        |workdir| {
+            write_repo_gh_monitor_config_with_owner(
+                workdir,
+                "test-team",
+                "acme",
+                "agent-team-mail",
+            );
+        },
+    );
+}
+
+#[test]
+#[cfg(unix)]
+#[serial]
+fn test_gh_monitor_run_implicitly_starts_lifecycle() {
+    assert_monitor_target_implicitly_starts_lifecycle(&["monitor", "run", "987654"], |workdir| {
+        write_repo_gh_monitor_config_with_owner(workdir, "test-team", "acme", "agent-team-mail");
+    });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes the three items that caused BB smoke FAIL in REVIEW-2:

- **Version display**: `atm --version` / `atm-daemon --version` now prefer the dev install manifest milestone (e.g. `0.46.1-dev.6`) rather than the static Cargo.toml stable version
- **ATM_HOME hint**: shared-runtime daemon availability error now surfaces an explicit user-facing hint to unset `ATM_HOME` when a non-canonical shared runtime root is exported (CLEAN-1 enforcement made legible)
- **Monitor implicit start**: `atm gh monitor pr/workflow/run` now implicitly starts the GH monitor lifecycle before submitting the monitor request, restoring the prior product contract

Adds regression coverage for the shared-runtime hint and implicit monitor start path.

## Test plan
- [ ] QA: rust-qa-agent + atm-qa-agent
- [ ] Smoke REVIEW-3 after QA PASS + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)