### PR TITLE
docs: add Rust Guidance section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,10 @@ Always follow this sequence for every ATM message:
 4. Immediate completion acknowledgement by receiver
 
 No silent processing.
+
+## Rust Guidance
+
+For Rust design and review work, also read:
+- `$HOME/.claude/skills/rust-best-practices/SKILL.md`
+
+Use it as the baseline for state machines, newtypes, sealed traits, structured error design, and crate-boundary review.


### PR DESCRIPTION
## Summary

- Adds `## Rust Guidance` section to `AGENTS.md` pointing to `$HOME/.claude/skills/rust-best-practices/SKILL.md`
- Establishes rust-best-practices as baseline for state machines, newtypes, sealed traits, structured error design, and crate-boundary review
- Consistent with schook `AGENTS.md` at `cb596e1`

## Test plan

- [ ] Verify `AGENTS.md` renders correctly on GitHub
- [ ] Confirm wording matches schook AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)