### PR TITLE
docs: add sc-compose Jinja2 template rendering to team-lead skill

### DIFF
--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -89,10 +89,43 @@ When assigning work to any teammate:
    - The task and its scope (link to worktree, relevant issues, design docs)
    - Applicable development guidelines (`docs/cross-platform-guidelines.md`, Rust guidelines, etc.)
    - Expected deliverables and acceptance criteria
-3. **Use Jinja2 templates** (see `/codex-orchestration` skill) that require:
-   - **Immediate ACK** when the agent starts the skill
-   - **Intermediate status** notifications at meaningful milestones
-   - **Completion notification** with commit/PR reference when done
+3. **Render all task messages via `sc-compose`** from a Jinja2 template (see `/codex-orchestration` skill). Never hand-write prose for task assignments.
+
+### Template Rendering with sc-compose
+
+All dev and QA assignments MUST be rendered via `sc-compose` before sending:
+
+```bash
+# Dev assignment
+sc-compose render .claude/skills/codex-orchestration/dev-template.xml.j2 \
+  --var-file vars.json
+
+# QA assignment
+sc-compose render .claude/skills/codex-orchestration/qa-template.xml.j2 \
+  --var-file vars.json
+```
+
+Example `vars.json` for a dev assignment:
+
+```json
+{
+  "task_id": "SC-EXAMPLE-1",
+  "sprint": "S10-EXAMPLE",
+  "assignee": "arch-ctm",
+  "description": "Short description of the task.",
+  "worktree_path": "/Users/randlee/Documents/github/schook-worktrees/feature-example",
+  "branch": "feature/example",
+  "pr_target": "integrate/phase-x",
+  "deliverables": "- Deliverable one\n- Deliverable two",
+  "acceptance_criteria": "- cargo test --workspace PASS\n- cargo clippy -- -D warnings PASS",
+  "references": "- docs/requirements.md\n- docs/architecture.md"
+}
+```
+
+Rendered output is sent directly as the task message body. Required fields are
+defined in the frontmatter of each template. Scalar strings (not JSON arrays)
+must be used for list fields — see the `/codex-orchestration` skill for the
+full render contract and tested examples.
 
 ### Communication Rules
 


### PR DESCRIPTION
## Summary

- Replaces the generic "Use Jinja2 templates" bullet in Task Assignment Protocol with an explicit `sc-compose render` requirement
- Adds a **Template Rendering with sc-compose** subsection with bash commands for dev and QA assignments
- Includes a fenced JSON example showing all required `vars.json` fields for a dev assignment
- Documents the scalar-string render contract for list fields, pointing to `/codex-orchestration` for full tested examples

## Motivation

The existing skill mentioned Jinja2 templates but did not specify `sc-compose` as the render tool. This led to hand-written prose assignments on the schook repo. This change makes the tooling explicit and provides a concrete example to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)